### PR TITLE
Fix modulo by zero crash

### DIFF
--- a/Fabric/Nodes/Parameters/Number/MathOperator.swift
+++ b/Fabric/Nodes/Parameters/Number/MathOperator.swift
@@ -60,7 +60,7 @@ enum BinaryMathOperator: String, CaseIterable
         case .Power: return pow(lhs, rhs)
         case .Minimum: return min(lhs, rhs)
         case .Maximum: return max(lhs, rhs)
-        case .Modulo: return fmod(lhs, rhs)
+        case .Modulo: return rhs != 0 ? fmod(lhs, rhs) : 0
         }
     }
 }


### PR DESCRIPTION
Adds zero check to modulo operator to prevent crash when divisor is 0.

Returns 0 for modulo by zero, matching existing division operator behavior.