### PR TITLE
Add bidirectional node connection dragging

### DIFF
--- a/Fabric Editor/Info.plist
+++ b/Fabric Editor/Info.plist
@@ -35,6 +35,18 @@
 			<key>UTTypeTagSpecification</key>
 			<dict/>
 		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeIcons</key>
+			<dict/>
+			<key>UTTypeIdentifier</key>
+			<string>info.vade.v.inletData</string>
+			<key>UTTypeTagSpecification</key>
+			<dict/>
+		</dict>
 	</array>
 	<key>UTImportedTypeDeclarations</key>
 	<array>

--- a/Fabric/Graph/Port/Port.swift
+++ b/Fabric/Graph/Port/Port.swift
@@ -56,9 +56,27 @@ extension OutletData :Transferable
     }
 }
 
+struct InletData : Codable
+{
+    let portID: UUID
+    init(portID: UUID)
+    {
+        self.portID = portID
+    }
+}
+
+extension InletData :Transferable
+{
+    static var transferRepresentation: some TransferRepresentation
+    {
+        CodableRepresentation(contentType: .inletData)
+    }
+}
+
 extension UTType
 {
     static var outletData: UTType { UTType(exportedAs: "info.vade.v.outletData") }
+    static var inletData: UTType { UTType(exportedAs: "info.vade.v.inletData") }
 }
 
 

--- a/Fabric/Views/Nodes/NodeInletView.swift
+++ b/Fabric/Views/Nodes/NodeInletView.swift
@@ -28,6 +28,7 @@ struct NodeInletView: View
                 .brightness( port.published ? 0.2 : 0.0)
             //            .padding(.leading, 20)
             //            .position(node.localInletPositions[index])
+                .draggable(InletData(portID: self.port.id))
                 .dropDestination(for: OutletData.self) { outletData, location in
                     //                return animateDrop(at: location)
                     print("drop destination \(self.port.name), \(outletData)")

--- a/Fabric/Views/Nodes/NodeOutletView.swift
+++ b/Fabric/Views/Nodes/NodeOutletView.swift
@@ -9,9 +9,13 @@ import SwiftUI
 
 struct NodeOutletView: View
 {
+    @Environment(Graph.self) var graph:Graph
+
     let port: Port
 
-    var body: some View 
+    @State private var isDropTargeted = false
+
+    var body: some View
     {
         HStack
         {
@@ -19,7 +23,7 @@ struct NodeOutletView: View
                 .foregroundStyle(Color.secondary)
                 .font(.system(size: 9))
                 .lineLimit(1)
-            
+
             Circle()
                 .fill(port.color)
                 .frame(width: 15)
@@ -28,14 +32,28 @@ struct NodeOutletView: View
                     key: PortAnchorKey.self,
                     value: .center,
                     transform: {  anchor in
-                        
+
                         [  port.id : anchor ]
                     })
                 .draggable(
-                    
+
                     OutletData(portID: self.port.id)
-                    
+
                 )
+                .dropDestination(for: InletData.self) { inletData, location in
+                    print("drop destination \(self.port.name), \(inletData)")
+
+                    if let firstInlet = inletData.first,
+                       let inletPort = self.graph.nodePort(forID: firstInlet.portID)
+                    {
+                        self.port.connect(to: inletPort)
+                        self.graph.shouldUpdateConnections.toggle()
+                        return true
+                    }
+                    return false
+                } isTargeted: {
+                    isDropTargeted = $0
+                }
         }
         .frame(height: 15)
 


### PR DESCRIPTION
Enables dragging node connections in both directions (outlet→inlet and inlet→outlet).

Previously only outlet→inlet dragging was supported. This adds inlet→outlet capability by mirroring the drag/drop pattern for inlets.