### PR TITLE
Add scroll-to-node and zoom features

### DIFF
--- a/Fabric Editor/Views/ContentView.swift
+++ b/Fabric Editor/Views/ContentView.swift
@@ -8,7 +8,10 @@
 import SwiftUI
 import Fabric
 
-
+struct ScrollGeometry: Equatable {
+    let offset: CGPoint
+    let containerSize: CGSize
+}
 
 struct ContentView: View {
     
@@ -21,7 +24,11 @@ struct ContentView: View {
     @State private var hitTestEnable:Bool = true
     @State private var columnVisibility = NavigationSplitViewVisibility.doubleColumn
     @State private var inspectorVisibility:Bool = false
+    @State private var contentOffset: CGPoint = .zero
     @State private var scrollOffset: CGPoint = .zero
+    @State private var zoomAnchor: UnitPoint = .center
+    @State private var hoverLocation: CGPoint = .zero
+    @State private var isMagnifying = false
     
     var body: some View {
         
@@ -64,29 +71,64 @@ struct ContentView: View {
                 {
                     // Render behind nodes ?
                     // SatinMetalView(renderer: document.graphRenderer)
-                    
+
                     GeometryReader { geom in
                         RadialGradient(colors: [.clear, .black.opacity(0.75)], center: .center, startRadius: 0, endRadius: geom.size.width * 1.5)
                             .allowsHitTesting(false)
                     }
-                    
-                    ScrollView([.horizontal, .vertical])
-                    {
-                        NodeCanvas()
-                            .frame(width: 10000 , height: 10000)
-                            .environment(self.document.graph)
-                            .allowsHitTesting(self.hitTestEnable)
-                        
+
+                    ScrollViewReader { proxy in
+                        ScrollView([.horizontal, .vertical])
+                        {
+                            NodeCanvas()
+                                .frame(width: 10000, height: 10000)
+                                .scaleEffect(finalMagnification * magnifyBy, anchor: zoomAnchor)
+                                .gesture(
+                                    MagnificationGesture()
+                                        .onChanged { value in
+                                            if !isMagnifying {
+                                                isMagnifying = true
+                                                let canvasX = 1.0 - ((contentOffset.x + hoverLocation.x) / 10000)
+                                                let canvasY = (contentOffset.y + hoverLocation.y) / 10000
+                                                zoomAnchor = UnitPoint(x: canvasX.clamped(to: 0...1), y: canvasY.clamped(to: 0...1))
+                                            }
+                                        }
+                                        .updating($magnifyBy) { value, gestureState, _ in
+                                            gestureState = value
+                                        }
+                                        .onEnded { value in
+                                            finalMagnification *= value
+                                            finalMagnification = min(max(finalMagnification, 0.25), 4.0)
+                                            isMagnifying = false
+                                        }
+                                )
+                                .environment(self.document.graph)
+                                .allowsHitTesting(self.hitTestEnable)
+                                .id("canvas")
+                                .task {
+                                    try? await Task.sleep(for: .milliseconds(100))
+                                    if let firstNode = self.document.graph.nodes.first {
+                                        let targetPoint = UnitPoint(
+                                            x: (5000 + firstNode.offset.width) / 10000,
+                                            y: (5000 + firstNode.offset.height) / 10000
+                                        )
+                                        proxy.scrollTo("canvas", anchor: targetPoint)
+                                    }
+                                }
+                        }
+                        .defaultScrollAnchor(.center)
+                        .onContinuousHover { phase in
+                            if case .active(let location) = phase {
+                                hoverLocation = location
+                            }
+                        }
                     }
-                    .defaultScrollAnchor(UnitPoint(x: 0.5, y: 0.5))
-                    .onScrollGeometryChange(for: CGPoint.self) { geometry in
-                        let center = CGPoint(x: geometry.contentSize.width / 2,
-                                             y: geometry.contentSize.height / 2)
-                        let offset = (geometry.contentOffset - center) + (geometry.containerSize / 2)
-                        return offset
-                        
-                    } action: { oldScrollOffset, newScrollOffset in
-                        self.scrollOffset =  newScrollOffset
+                    .onScrollGeometryChange(for: ScrollGeometry.self) { geometry in
+                        return ScrollGeometry(offset: geometry.contentOffset, containerSize: geometry.containerSize)
+                    } action: { _, new in
+                        contentOffset = new.offset
+                        let center = CGPoint(x: 5000, y: 5000)
+                        scrollOffset = (new.offset - center) + (new.containerSize / 2)
                     }
                     .onScrollPhaseChange { oldPhase, newPhase in
                         self.hitTestEnable = !newPhase.isScrolling
@@ -118,4 +160,10 @@ struct ContentView: View {
 
 #Preview {
     ContentView(document: .constant(FabricDocument()))
+}
+
+extension Comparable {
+    func clamped(to range: ClosedRange<Self>) -> Self {
+        return min(max(self, range.lowerBound), range.upperBound)
+    }
 }

--- a/Fabric/Graph/Graph.swift
+++ b/Fabric/Graph/Graph.swift
@@ -28,9 +28,9 @@ internal import AnyCodable
     public let id:UUID
     public let version: Graph.Version
     @ObservationIgnored public let context:Context
-    
-    private(set) var nodes: [Node]
-    
+
+    public private(set) var nodes: [Node]
+
     var needsExecution:Bool {
         self.nodes.reduce(true) { (result, node) -> Bool in
             result || node.isDirty
@@ -47,7 +47,7 @@ internal import AnyCodable
         return renderableNodes.compactMap { $0.getObject() as? Satin.Renderable }
     }
     
-    var shouldUpdateConnections = false // New property to trigger view update
+    public var shouldUpdateConnections = false // New property to trigger view update
     {
         didSet
         {


### PR DESCRIPTION
1: Adds pinch-to-zoom (two-finger magnify gesture)

https://github.com/user-attachments/assets/10089b82-c398-4c45-9d7f-8389b42b1a64

The SwiftUI Canvas + ScrollView is notorious to get the pinch magnification right but this is a first-step and adds value where it's at. 

2: Scrolls to first node when opening a project.

Problem: When opening a project, it doesn't scroll to the first node. Test it with this example:
[Test Sphere.zip](https://github.com/user-attachments/files/23565597/Test.Sphere.zip)
Before: Project opens in top left corner, lost in the canvas, have to scroll all the way to center to find nodes.
After: The ScrollView automatically scrolls to the nodes