### PR TITLE
Fix typo in README.md for pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Author
 * Interacive 3D graphics
 * Image processing and effects
 * Audio reactive scenes
-* images and video analysis pipeines
+* images and video analysis pipelines
 * embed your scenes into your own apps
 
 Check out the [Samples](https://github.com/Fabric-Project/Fabric/tree/main/Samples) 


### PR DESCRIPTION
Changed 'pipeines' to 'pipelines' on line 37 in the 'What can I do with Fabric?' section.