### PR TITLE
Fix Unary Typo

### DIFF
--- a/Fabric/Nodes/NodeRegistry.swift
+++ b/Fabric/Nodes/NodeRegistry.swift
@@ -202,7 +202,7 @@ public class NodeRegistry {
         CurrentTimeNode.self,
         SystemTimeNode.self,
         NumberNode.self,
-        NumberUnnaryOperator.self,
+        NumberUnaryOperator.self,
         NumberBinaryOperator.self,
         NumberRoundNode.self,
         NumberClampNode.self,

--- a/Fabric/Nodes/Parameters/Number/NumberUnaryOperator.swift
+++ b/Fabric/Nodes/Parameters/Number/NumberUnaryOperator.swift
@@ -13,9 +13,9 @@ import Satin
 import simd
 import Metal
 
-public class NumberUnnaryOperator : Node
+public class NumberUnaryOperator : Node
 {
-    override public class var name:String { "Number Unnary Operator" }
+    override public class var name:String { "Number Unary Operator" }
     override public class var nodeType:Node.NodeType { .Parameter(parameterType: .Number) }
     override public class var nodeExecutionMode: Node.ExecutionMode { .Processor }
     override public class var nodeTimeMode: Node.TimeMode { .None }


### PR DESCRIPTION
Simple PR – got confused when I searched 'Unary' and had no results in the sidebar. Fixed the typo Unnary -> Unary. 