### PR TITLE
Camera nodes have sizing dimension input, Perspective camera has FOV

### DIFF
--- a/Fabric/Graph/GraphRenderer.swift
+++ b/Fabric/Graph/GraphRenderer.swift
@@ -26,7 +26,7 @@ public class GraphRenderer : MetalViewRenderer
 
     // This is fucking horrible:
     public private(set) var currentCamera:Camera? = nil
-    private let defaultCamera = PerspectiveCamera()
+    private let defaultCamera = PerspectiveCameraNode.makeDefaultCamera()
     private let sceneProxy = Object() // ?  IBLScene()
     
     private var graphRequiresResize:Bool = false
@@ -49,9 +49,7 @@ public class GraphRenderer : MetalViewRenderer
         self.renderer = Renderer(context: context, stencilStoreAction: .store, frameBufferOnly:false)
 
         self.renderer.sortObjects = true
-        
-        self.defaultCamera.position = simd_float3(0, 0, 2)
-        self.defaultCamera.lookAt(target: .zero)
+
         self.privateTextureCache = GraphRendererTextureCache(device: self.context.device)
         
         var sharedConfig = GraphRendererTextureCache.Configuration()
@@ -454,13 +452,11 @@ public class GraphRenderer : MetalViewRenderer
     
     /// Handle output drawable resize.
     ///
-    /// Updates the internal renderer size, flags the graph for resize (so every node
-    /// receives the new dimensions), and sets the default camera's aspect ratio.
-    /// Individual camera nodes are responsible for their own projection setup —
-    /// see `PerspectiveCameraNode` and `OrthographicCameraNode`, which have
-    /// sizing-dimension and FOV inputs that control how viewport changes map to
-    /// the visible scene. The default expectation is width = 2 world units, as
-    /// per Quartz Composer convention.
+    /// Updates the internal renderer size, flags the graph for resize (so every
+    /// node receives the new dimensions), and updates the default camera via
+    /// ``PerspectiveCameraNode/resizeDefaultCamera(_:size:)``.
+    /// The default expectation is width = 2 world units, as per Quartz
+    /// Composer convention.
     override public func resize(size: (width: Float, height: Float), scaleFactor: Float)
     {
         self.renderer.resize(size)
@@ -468,7 +464,7 @@ public class GraphRenderer : MetalViewRenderer
         self.graphRequiresResize = true
         self.resizeScaleFactor = scaleFactor
 
-        self.defaultCamera.aspect = size.width / size.height
+        PerspectiveCameraNode.resizeDefaultCamera(self.defaultCamera, size: size)
     }
     
     private func feedbackCache(for graphID: UUID) -> GraphRendererFeedbackCache

--- a/Fabric/Graph/GraphRenderer.swift
+++ b/Fabric/Graph/GraphRenderer.swift
@@ -454,15 +454,13 @@ public class GraphRenderer : MetalViewRenderer
     
     /// Handle output drawable resize.
     ///
-    /// Resize policy:
-    /// - **FOV is fixed.** Changing the window size or scale factor only changes the pixel
-    ///   resolution of the render — it must not alter what is visible in the scene.
-    /// - **Aspect ratio tracks the drawable.** When the aspect ratio changes, the horizontal
-    ///   extent in world coordinates stays constant and vertical extent adjusts, revealing
-    ///   more or less content at the top/bottom edges. `perspectiveMatrixf(fov, aspect, …)`
-    ///   handles this via the aspect parameter alone.
-    /// - **Coordinates remain square.** A 1:1 aspect object must appear 1:1 on screen
-    ///   regardless of window shape.
+    /// Updates the internal renderer size, flags the graph for resize (so every node
+    /// receives the new dimensions), and sets the default camera's aspect ratio.
+    /// Individual camera nodes are responsible for their own projection setup —
+    /// see `PerspectiveCameraNode` and `OrthographicCameraNode`, which have
+    /// sizing-dimension and FOV inputs that control how viewport changes map to
+    /// the visible scene. The default expectation is width = 2 world units, as
+    /// per Quartz Composer convention.
     override public func resize(size: (width: Float, height: Float), scaleFactor: Float)
     {
         self.renderer.resize(size)

--- a/Fabric/Graph/GraphRenderer.swift
+++ b/Fabric/Graph/GraphRenderer.swift
@@ -452,16 +452,25 @@ public class GraphRenderer : MetalViewRenderer
         fatalError("use execute(graph:renderPassDescriptor:commandBuffer:) instead.")
     }
     
+    /// Handle output drawable resize.
+    ///
+    /// Resize policy:
+    /// - **FOV is fixed.** Changing the window size or scale factor only changes the pixel
+    ///   resolution of the render — it must not alter what is visible in the scene.
+    /// - **Aspect ratio tracks the drawable.** When the aspect ratio changes, the horizontal
+    ///   extent in world coordinates stays constant and vertical extent adjusts, revealing
+    ///   more or less content at the top/bottom edges. `perspectiveMatrixf(fov, aspect, …)`
+    ///   handles this via the aspect parameter alone.
+    /// - **Coordinates remain square.** A 1:1 aspect object must appear 1:1 on screen
+    ///   regardless of window shape.
     override public func resize(size: (width: Float, height: Float), scaleFactor: Float)
     {
         self.renderer.resize(size)
-        
+
         self.graphRequiresResize = true
         self.resizeScaleFactor = scaleFactor
-        
+
         self.defaultCamera.aspect = size.width / size.height
-        
-        self.defaultCamera.fov = radToDeg( 2.0 * atan(  (size.height / size.width) / 2.0 ) )
     }
     
     private func feedbackCache(for graphID: UUID) -> GraphRendererFeedbackCache

--- a/Fabric/Nodes/Object/Camera/OrthographicCameraNode.swift
+++ b/Fabric/Nodes/Object/Camera/OrthographicCameraNode.swift
@@ -21,14 +21,16 @@ public class OrthographicCameraNode : ObjectNode<OrthographicCamera>
     // Ports
     override public class func registerPorts(context: Context) -> [(name: String, port: Port)] {
         let ports = super.registerPorts(context: context)
-        
+
         return  [
                     ("inputLookAt", ParameterPort(parameter:Float3Parameter("Look At", simd_float3(repeating:0), .inputfield, "Target position the camera points toward")) ),
+                    ("inputSizingDimension", ParameterPort(parameter:StringParameter("Sizing Dimension", "Height", ["Width", "Height"], .dropdown, "Which dimension maps to -1,+1")) ),
                 ] + ports
     }
-    
-    // Proxy Port
+
+    // Proxy Ports
     public var inputLookAt:ParameterPort<simd_float3> { port(named: "inputLookAt") }
+    public var inputSizingDimension:ParameterPort<String> { port(named: "inputSizingDimension") }
     
     override public var object: OrthographicCamera?
     {
@@ -36,6 +38,7 @@ public class OrthographicCameraNode : ObjectNode<OrthographicCamera>
     }
     
     private let camera = OrthographicCamera(left: -1, right: 1, bottom: -1, top: 1, near: 0.01, far: 500.0)
+    private var viewportSize: (width: Float, height: Float) = (1, 1)
 
     override public func startExecution(context:GraphExecutionContext)
     {
@@ -57,7 +60,11 @@ public class OrthographicCameraNode : ObjectNode<OrthographicCamera>
 
         // This needs to fire every frame
         self.camera.lookAt(target: self.inputLookAt.value ?? .zero)
-        
+
+        if self.inputSizingDimension.valueDidChange {
+            self.updateBounds()
+        }
+
         return shouldUpdate
     }
     
@@ -70,10 +77,26 @@ public class OrthographicCameraNode : ObjectNode<OrthographicCamera>
     
     public override func resize(size: (width: Float, height: Float), scaleFactor: Float)
     {
-        let aspect = size.width / size.height
+        self.viewportSize = size
+        self.updateBounds()
+    }
 
-        self.camera.left = -aspect / 2.0
-        self.camera.right = aspect / 2.0
+    private func updateBounds()
+    {
+        let aspect = viewportSize.width / viewportSize.height
+        let sizing = self.inputSizingDimension.value ?? "Height"
+
+        if sizing == "Width" {
+            self.camera.left = -1
+            self.camera.right = 1
+            self.camera.bottom = -1 / aspect
+            self.camera.top = 1 / aspect
+        } else {
+            self.camera.bottom = -1
+            self.camera.top = 1
+            self.camera.left = -aspect / 2.0
+            self.camera.right = aspect / 2.0
+        }
     }
 }
 

--- a/Fabric/Nodes/Object/Camera/OrthographicCameraNode.swift
+++ b/Fabric/Nodes/Object/Camera/OrthographicCameraNode.swift
@@ -1,5 +1,5 @@
 //
-//  PerspectiveCameraNode.swift
+//  OrthographicCameraNode.swift
 //  Fabric
 //
 //  Created by Anton Marini on 4/26/25.
@@ -12,6 +12,10 @@ import Metal
 
 public class OrthographicCameraNode : ObjectNode<OrthographicCamera>
 {
+    public static let defaultSize: Float = 2.0
+    public static let defaultSizingDimension: String = "Width"
+    public static let defaultPosition: simd_float3 = .init(0, 0, 2)
+
     public override class var name:String { "Orthographic Camera" }
     public override class var nodeType:Node.NodeType { Node.NodeType.Object(objectType: .Camera) }
     override public class var nodeExecutionMode: Node.ExecutionMode { .Consumer }
@@ -24,14 +28,16 @@ public class OrthographicCameraNode : ObjectNode<OrthographicCamera>
 
         return  [
                     ("inputLookAt", ParameterPort(parameter:Float3Parameter("Look At", simd_float3(repeating:0), .inputfield, "Target position the camera points toward")) ),
-                    ("inputSizingDimension", ParameterPort(parameter:StringParameter("Sizing Dimension", "Height", ["Width", "Height"], .dropdown, "Which dimension maps to -1,+1")) ),
+                    ("inputSize", ParameterPort(parameter:FloatParameter("Size", 2.0, 0.001, 10000.0, .inputfield, "Visible world units along the sizing dimension")) ),
+                    ("inputSizingDimension", ParameterPort(parameter:StringParameter("Sizing Dimension", "Width", ["Width", "Height"], .dropdown, "Which dimension the size applies to")) ),
                 ] + ports
     }
 
     // Proxy Ports
     public var inputLookAt:ParameterPort<simd_float3> { port(named: "inputLookAt") }
+    public var inputSize:ParameterPort<Float> { port(named: "inputSize") }
     public var inputSizingDimension:ParameterPort<String> { port(named: "inputSizingDimension") }
-    
+
     override public var object: OrthographicCamera?
     {
         camera
@@ -44,10 +50,10 @@ public class OrthographicCameraNode : ObjectNode<OrthographicCamera>
     {
         super.startExecution(context: context)
 
-        self.inputPosition.value = .init(repeating: 5.0)
+        self.inputPosition.value = Self.defaultPosition
 
         self.camera.lookAt(target: self.inputLookAt.value ?? .zero)
-        self.camera.position = self.inputPosition.value ?? .zero
+        self.camera.position = self.inputPosition.value ?? Self.defaultPosition
         self.camera.scale = self.inputScale.value ?? .one
 
         let orientation = self.inputOrientation.value ?? .zero
@@ -61,20 +67,20 @@ public class OrthographicCameraNode : ObjectNode<OrthographicCamera>
         // This needs to fire every frame
         self.camera.lookAt(target: self.inputLookAt.value ?? .zero)
 
-        if self.inputSizingDimension.valueDidChange {
+        if self.inputSize.valueDidChange || self.inputSizingDimension.valueDidChange {
             self.updateBounds()
         }
 
         return shouldUpdate
     }
-    
+
     public override func execute(context:GraphExecutionContext,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
     {
         let _ = self.evaluate(object: self.object, atTime: context.timing.time)
     }
-    
+
     public override func resize(size: (width: Float, height: Float), scaleFactor: Float)
     {
         self.viewportSize = size
@@ -83,20 +89,21 @@ public class OrthographicCameraNode : ObjectNode<OrthographicCamera>
 
     private func updateBounds()
     {
+        let size = self.inputSize.value ?? Self.defaultSize
+        let halfSize = size / 2.0
         let aspect = viewportSize.width / viewportSize.height
-        let sizing = self.inputSizingDimension.value ?? "Height"
+        let sizing = self.inputSizingDimension.value ?? Self.defaultSizingDimension
 
         if sizing == "Width" {
-            self.camera.left = -1
-            self.camera.right = 1
-            self.camera.bottom = -1 / aspect
-            self.camera.top = 1 / aspect
+            self.camera.left = -halfSize
+            self.camera.right = halfSize
+            self.camera.bottom = -halfSize / aspect
+            self.camera.top = halfSize / aspect
         } else {
-            self.camera.bottom = -1
-            self.camera.top = 1
-            self.camera.left = -aspect / 2.0
-            self.camera.right = aspect / 2.0
+            self.camera.bottom = -halfSize
+            self.camera.top = halfSize
+            self.camera.left = -halfSize * aspect
+            self.camera.right = halfSize * aspect
         }
     }
 }
-

--- a/Fabric/Nodes/Object/Camera/OrthographicCameraNode.swift
+++ b/Fabric/Nodes/Object/Camera/OrthographicCameraNode.swift
@@ -24,12 +24,13 @@ public class OrthographicCameraNode : ObjectNode<OrthographicCamera>
 
     // Ports
     override public class func registerPorts(context: Context) -> [(name: String, port: Port)] {
-        let ports = super.registerPorts(context: context)
+        let ports = super.registerPorts(context: context).filter { $0.name != "inputPosition" }
 
         return  [
                     ("inputLookAt", ParameterPort(parameter:Float3Parameter("Look At", simd_float3(repeating:0), .inputfield, "Target position the camera points toward")) ),
                     ("inputSize", ParameterPort(parameter:FloatParameter("Size", 2.0, 0.001, 10000.0, .inputfield, "Visible world units along the sizing dimension")) ),
                     ("inputSizingDimension", ParameterPort(parameter:StringParameter("Sizing Dimension", "Width", ["Width", "Height"], .dropdown, "Which dimension the size applies to")) ),
+                    ("inputPosition", ParameterPort(parameter:Float3Parameter("Position", defaultPosition, .inputfield, "Position in 3D space (X, Y, Z) in world units")) ),
                 ] + ports
     }
 
@@ -49,8 +50,6 @@ public class OrthographicCameraNode : ObjectNode<OrthographicCamera>
     override public func startExecution(context:GraphExecutionContext)
     {
         super.startExecution(context: context)
-
-        self.inputPosition.value = Self.defaultPosition
 
         self.camera.lookAt(target: self.inputLookAt.value ?? .zero)
         self.camera.position = self.inputPosition.value ?? Self.defaultPosition

--- a/Fabric/Nodes/Object/Camera/OrthographicCameraNode.swift
+++ b/Fabric/Nodes/Object/Camera/OrthographicCameraNode.swift
@@ -36,20 +36,20 @@ public class OrthographicCameraNode : ObjectNode<OrthographicCamera>
     {
         camera
     }
-    
+
     private let camera = OrthographicCamera(left: -1, right: 1, bottom: -1, top: 1, near: 0.01, far: 500.0)
     private var viewportSize: (width: Float, height: Float) = (1, 1)
 
     override public func startExecution(context:GraphExecutionContext)
     {
         super.startExecution(context: context)
-        
+
         self.inputPosition.value = .init(repeating: 5.0)
-        
+
         self.camera.lookAt(target: self.inputLookAt.value ?? .zero)
         self.camera.position = self.inputPosition.value ?? .zero
         self.camera.scale = self.inputScale.value ?? .one
-        
+
         let orientation = self.inputOrientation.value ?? .zero
         self.camera.orientation = simd_quatf(vector:orientation)
     }

--- a/Fabric/Nodes/Object/Camera/PerspectiveCamera+SetFOV.swift
+++ b/Fabric/Nodes/Object/Camera/PerspectiveCamera+SetFOV.swift
@@ -1,0 +1,27 @@
+//
+//  PerspectiveCamera+SetFOV.swift
+//  Fabric
+//
+
+import Satin
+
+extension PerspectiveCamera {
+
+    /// Set the field of view for a given sizing dimension.
+    ///
+    /// - Parameters:
+    ///   - fovDegrees: Field of view in degrees, measured along `sizingDimension`.
+    ///   - sizingDimension: `"Width"` or `"Height"`. When `"Width"`, the
+    ///     horizontal FOV is held constant and vertical FOV is derived from
+    ///     the current ``aspect`` ratio — matching the Quartz Composer
+    ///     convention where width = 2 world units.
+    public func setFOV(_ fovDegrees: Float, sizing sizingDimension: String) {
+        if sizingDimension == "Width" {
+            let hfovRad = degToRad(fovDegrees)
+            let vfovRad = 2.0 * atan(tan(hfovRad / 2.0) / aspect)
+            self.fov = radToDeg(vfovRad)
+        } else {
+            self.fov = fovDegrees
+        }
+    }
+}

--- a/Fabric/Nodes/Object/Camera/PerspectiveCameraNode.swift
+++ b/Fabric/Nodes/Object/Camera/PerspectiveCameraNode.swift
@@ -42,12 +42,13 @@ public class PerspectiveCameraNode : ObjectNode<PerspectiveCamera>
 
     // Ports
     override public class func registerPorts(context: Context) -> [(name: String, port: Port)] {
-        let ports = super.registerPorts(context: context)
+        let ports = super.registerPorts(context: context).filter { $0.name != "inputPosition" }
 
         return  [
                     ("inputLookAt", ParameterPort(parameter:Float3Parameter("Look At", simd_float3(repeating:0), .inputfield, "Target position the camera points toward")) ),
                     ("inputFOV", ParameterPort(parameter:FloatParameter("FOV", 30.0, 1.0, 179.0, .inputfield, "Field of view in degrees")) ),
                     ("inputSizingDimension", ParameterPort(parameter:StringParameter("Sizing Dimension", "Width", ["Width", "Height"], .dropdown, "Which dimension the FOV applies to")) ),
+                    ("inputPosition", ParameterPort(parameter:Float3Parameter("Position", defaultPosition, .inputfield, "Position in 3D space (X, Y, Z) in world units")) ),
                 ] + ports
     }
 
@@ -67,8 +68,6 @@ public class PerspectiveCameraNode : ObjectNode<PerspectiveCamera>
     override public func startExecution(context:GraphExecutionContext)
     {
         super.startExecution(context: context)
-
-        self.inputPosition.value = Self.defaultPosition
 
         self.camera.lookAt(target: self.inputLookAt.value ?? .zero)
         self.camera.position = self.inputPosition.value ?? Self.defaultPosition

--- a/Fabric/Nodes/Object/Camera/PerspectiveCameraNode.swift
+++ b/Fabric/Nodes/Object/Camera/PerspectiveCameraNode.swift
@@ -12,6 +12,28 @@ import Metal
 
 public class PerspectiveCameraNode : ObjectNode<PerspectiveCamera>
 {
+    public static let defaultFOV: Float = 30.0
+    /// Z distance derived so that width = 2 world units at the origin: Z = 1 / tan(hfov/2)
+    public static let defaultPosition: simd_float3 = .init(0, 0, 1.0 / tan(degToRad(defaultFOV) / 2.0))
+    public static let defaultSizingDimension: String = "Width"
+
+    /// Create a `PerspectiveCamera` configured with the node's default values.
+    /// Used by `GraphRenderer` as the fallback when no camera node is in the graph.
+    public static func makeDefaultCamera() -> PerspectiveCamera {
+        let cam = PerspectiveCamera(position: defaultPosition,
+                                    near: 0.01,
+                                    far: 500.0,
+                                    fov: defaultFOV)
+        cam.lookAt(target: .zero)
+        return cam
+    }
+
+    /// Resize a `PerspectiveCamera` using the node's default FOV and sizing dimension.
+    public static func resizeDefaultCamera(_ camera: PerspectiveCamera, size: (width: Float, height: Float)) {
+        camera.aspect = size.width / size.height
+        camera.setFOV(defaultFOV, sizing: defaultSizingDimension)
+    }
+
     override public class var name:String { "Perspective Camera" }
     override public class var nodeType:Node.NodeType { Node.NodeType.Object(objectType: .Camera) }
     override public class var nodeExecutionMode: Node.ExecutionMode { .Consumer }
@@ -38,22 +60,24 @@ public class PerspectiveCameraNode : ObjectNode<PerspectiveCamera>
     {
         camera
     }
-    
-    private let camera = PerspectiveCamera(position: .init(repeating: 5.0), near: 0.01, far: 500.0, fov: 30)
+
+    private let camera = PerspectiveCamera(position: defaultPosition, near: 0.01, far: 500.0, fov: defaultFOV)
     private var viewportSize: (width: Float, height: Float) = (1, 1)
 
     override public func startExecution(context:GraphExecutionContext)
     {
         super.startExecution(context: context)
-                
+
+        self.inputPosition.value = Self.defaultPosition
+
         self.camera.lookAt(target: self.inputLookAt.value ?? .zero)
-        self.camera.position = self.inputPosition.value ?? .zero
+        self.camera.position = self.inputPosition.value ?? Self.defaultPosition
         self.camera.scale = self.inputScale.value ?? .one
-        
+
         let orientation = self.inputOrientation.value ?? .zero
         self.camera.orientation = simd_quatf(vector:orientation)
     }
-    
+
     override public func evaluate(object: Object?, atTime: TimeInterval) -> Bool
     {
         let shouldUpdate = super.evaluate(object: object, atTime: atTime)
@@ -62,39 +86,26 @@ public class PerspectiveCameraNode : ObjectNode<PerspectiveCamera>
         self.camera.lookAt(target: self.inputLookAt.value ?? .zero)
 
         if self.inputFOV.valueDidChange || self.inputSizingDimension.valueDidChange {
-            self.updateFOV()
+            self.camera.setFOV(self.inputFOV.value ?? Self.defaultFOV,
+                                          sizing: self.inputSizingDimension.value ?? Self.defaultSizingDimension)
         }
 
         return shouldUpdate
     }
-    
+
     public override func execute(context:GraphExecutionContext,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
     {
         let _ = self.evaluate(object: self.camera, atTime: context.timing.time)
     }
-    
+
     public override func resize(size: (width: Float, height: Float), scaleFactor: Float)
     {
         self.viewportSize = size
         self.camera.aspect = size.width / size.height
-        self.updateFOV()
-    }
-
-    private func updateFOV()
-    {
-        let fov = self.inputFOV.value ?? 30.0
-        let aspect = viewportSize.width / viewportSize.height
-        let sizing = self.inputSizingDimension.value ?? "Width"
-
-        if sizing == "Width" {
-            let hfovRad = degToRad(fov)
-            let vfovRad = 2.0 * atan(tan(hfovRad / 2.0) / aspect)
-            self.camera.fov = radToDeg(vfovRad)
-        } else {
-            self.camera.fov = fov
-        }
+        self.camera.setFOV(self.inputFOV.value ?? Self.defaultFOV,
+                           sizing: self.inputSizingDimension.value ?? Self.defaultSizingDimension)
     }
 }
 


### PR DESCRIPTION
I like QC’s unit system of -1,+1 with square units. But which dimension? QC used width. FOV is typically calculated on height. It looks like in Fabric the perspective camera uses horizontal and orthographic camera uses vertical?

This PR adds `Sizing Dimension` to both cameras, so this can be adopted on a case-by-case basis. On a practical note, fixing height and extending width per aspect is really handy in performance contexts where you can [design for a single 16:9 output, and output your 3D world in wider-and-wider-wide-screen by adding screens to the side](https://tobyz.net/diary/2024/04/immersive-view/). Oh, you’ll want to increase the field of view then too... so that’s now a perspective camera input too.

Note - I’ve run out of time so this is currently untested! Will get back to this... at some unknown point soon.