### PR TITLE
Fix - `deltaTime` is computed correctly at source, workarounds removed

### DIFF
--- a/Fabric Editor/Views/CAMetalDisplayLinkRenderer.swift
+++ b/Fabric Editor/Views/CAMetalDisplayLinkRenderer.swift
@@ -15,7 +15,6 @@ class CAMetalDisplayLinkRenderer: GameView
 {
     let graphRenderer:GraphRenderer
     let graph:Graph
-    private var lastRenderTime: CFTimeInterval = 0
 
 //    private let commandQueue: (any MTLCommandQueue)
     private let renderPassDescriptor = MTLRenderPassDescriptor()
@@ -122,15 +121,8 @@ class CAMetalDisplayLinkRenderer: GameView
         self.renderPassDescriptor.renderTargetWidth = update.drawable.texture.width
         self.renderPassDescriptor.renderTargetHeight = update.drawable.texture.height
         
-        // CAMetalDisplayLink passes a negative deltaTime (time until target
-        // presentation). We need a positive elapsed-since-last-frame value, so
-        // compute our own from consecutive CACurrentMediaTime() calls.
-        let now = CACurrentMediaTime()
-        let frameDelta = self.lastRenderTime > 0 ? now - self.lastRenderTime : 1.0 / 60.0
-        self.lastRenderTime = now
-
-        let timing = GraphExecutionTiming(time: now,
-                                          deltaTime: frameDelta,
+        let timing = GraphExecutionTiming(time: CACurrentMediaTime(),
+                                          deltaTime: deltaTime,
                                           displayTime: update.targetPresentationTimestamp,
                                           systemTime: Date.timeIntervalSinceReferenceDate,
                                           frameNumber: self.graphRenderer.frameIndex)

--- a/Fabric Editor/Views/GameView.m
+++ b/Fabric Editor/Views/GameView.m
@@ -189,7 +189,7 @@ The implementation of the cross-platform game view.
 - (void)metalDisplayLink:(CAMetalDisplayLink *)link
              needsUpdate:(CAMetalDisplayLinkUpdate *_Nonnull)update
 {
-    CFTimeInterval deltaTime = _previousTargetPresentationTimestamp - update.targetPresentationTimestamp;
+    CFTimeInterval deltaTime = update.targetPresentationTimestamp - _previousTargetPresentationTimestamp;
     _previousTargetPresentationTimestamp = update.targetPresentationTimestamp;
     
     [self renderUpdate:update with:deltaTime];

--- a/Fabric/Nodes/Parameters/Number/NumberIntegralNode.swift
+++ b/Fabric/Nodes/Parameters/Number/NumberIntegralNode.swift
@@ -42,7 +42,7 @@ public class NumberIntegralNode : Node
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
     {
-        self.state += (self.inputNumber.value ?? 0.0) * -Float(context.timing.deltaTime)
+        self.state += (self.inputNumber.value ?? 0.0) * Float(context.timing.deltaTime)
         
         self.outputNumber.send(self.state)
     }


### PR DESCRIPTION
The CAMetalDisplayLink callback computed deltaTime as previous - current, producing a negative value. Fixed to current - previous. Reverted the workaround in CAMetalDisplayLinkRenderer (commit e9c3be7) that computed its own delta, and removed the compensating negation in NumberIntegralNode.

Fixes #228 