### PR TITLE
Fix – Renamed published ports showing original name in parent graph

### DIFF
--- a/Fabric/Graph/Port/ProxyPort.swift
+++ b/Fabric/Graph/Port/ProxyPort.swift
@@ -36,6 +36,11 @@ public class ProxyPort<Value: PortValueRepresentable>: NodePort<Value>, ProxyPor
 
     public var innerPortID: UUID { innerPort.id }
 
+    /// Prefers the proxy's own publishedName (set when renamed in the
+    /// parent graph), falling back to the inner port's displayName (which
+    /// reflects sub-graph level renames).
+    override public var displayName: String { publishedName ?? innerPort.displayName }
+
     public init(wrapping innerPort: NodePort<Value>)
     {
         self.innerPort = innerPort


### PR DESCRIPTION
ProxyPort captured innerPort.name at creation time, so displayName returned the stale original name even after the inner port was renamed via publishedName. Override displayName to delegate to the inner port so renames propagate dynamically.