### PR TITLE
Feature/app intents support

### DIFF
--- a/Fabric Editor/AppIntents/FabricAppIntents.swift
+++ b/Fabric Editor/AppIntents/FabricAppIntents.swift
@@ -8,119 +8,240 @@
 import AppIntents
 import Foundation
 
-struct OpenGraphIntent: AppIntent {
-    static let title: LocalizedStringResource = "Open Graph"
-    static let description = IntentDescription("Open a Fabric graph from a file URL or path.")
+struct GetGraphFileIntent: AppIntent {
+    static let title: LocalizedStringResource = "Get Graph File"
+    static let description = IntentDescription("Select a Fabric graph file and return it as a graph entity.")
 
-    @Parameter(title: "Graph URL")
-    var graphURL: String
+    @Parameter(title: "Graph File")
+    var graphFile: IntentFile
 
     func perform() async throws -> some IntentResult & ReturnsValue<FabricGraphEntity> & ProvidesDialog {
-        let graph = try await FabricDocumentAutomationService.shared.openGraph(at: self.graphURL)
-        return .result(value: graph, dialog: "Opened \(graph.displayName).")
+        let graph = try await FabricDocumentAutomationService.shared.openGraph(file: self.graphFile)
+        return .result(value: graph, dialog: "Loaded \(graph.displayName).")
     }
 }
 
-struct CreateGraphIntent: AppIntent {
-    static let title: LocalizedStringResource = "Create Graph"
-    static let description = IntentDescription("Create a new Fabric graph file, optionally seeded with the default template.")
-
-    @Parameter(title: "Graph URL")
-    var graphURL: String
+struct CreateNewGraphIntent: AppIntent {
+    static let title: LocalizedStringResource = "Create New Graph"
+    static let description = IntentDescription("Create a new untitled Fabric graph and return it as a graph entity.")
 
     @Parameter(title: "Use Template", default: true)
     var useTemplate: Bool
 
     func perform() async throws -> some IntentResult & ReturnsValue<FabricGraphEntity> & ProvidesDialog {
-        let graph = try await FabricDocumentAutomationService.shared.createGraph(at: self.graphURL, useTemplate: self.useTemplate)
+        let graph = await FabricDocumentAutomationService.shared.createGraph(useTemplate: self.useTemplate)
         return .result(value: graph, dialog: "Created \(graph.displayName).")
     }
 }
 
-struct GetGraphSummaryIntent: AppIntent {
-    static let title: LocalizedStringResource = "Get Graph Summary"
-    static let description = IntentDescription("Summarize a Fabric graph file.")
+struct GetGraphDetailsIntent: AppIntent {
+    static let title: LocalizedStringResource = "Get Graph Details"
+    static let description = IntentDescription("Refresh and return summary information about a Fabric graph.")
 
-    @Parameter(title: "Graph URL")
-    var graphURL: String
+    @Parameter(title: "Graph")
+    var graph: FabricGraphEntity
 
-    func perform() async throws -> some IntentResult & ReturnsValue<String> & ProvidesDialog {
-        let summary = try await FabricDocumentAutomationService.shared.graphSummary(for: self.graphURL)
-        return .result(value: summary, dialog: IntentDialog(stringLiteral: summary))
+    func perform() async throws -> some IntentResult & ReturnsValue<FabricGraphEntity> & ProvidesDialog {
+        let refreshedGraph = try await FabricDocumentAutomationService.shared.graphDetails(for: self.graph)
+        return .result(
+            value: refreshedGraph,
+            dialog: "\(refreshedGraph.displayName) has \(refreshedGraph.nodeCount) nodes and \(refreshedGraph.publishedParameterCount) published parameters."
+        )
     }
 }
 
-struct ListPublishedParametersIntent: AppIntent {
-    static let title: LocalizedStringResource = "List Published Parameters"
-    static let description = IntentDescription("Return the published parameter surface for a graph.")
+struct SaveGraphIntent: AppIntent {
+    static let title: LocalizedStringResource = "Save Graph"
+    static let description = IntentDescription("Save graph changes back to disk.")
 
-    @Parameter(title: "Graph URL")
-    var graphURL: String
+    @Parameter(title: "Graph")
+    var graph: FabricGraphEntity
 
-    func perform() async throws -> some IntentResult & ReturnsValue<[FabricPublishedParameterEntity]> & ProvidesDialog {
-        let parameters = try await FabricDocumentAutomationService.shared.listPublishedParameters(in: self.graphURL)
-        return .result(value: parameters, dialog: "Found \(parameters.count) published parameters.")
+    func perform() async throws -> some IntentResult & ReturnsValue<FabricGraphEntity> & ProvidesDialog {
+        let savedGraph = try await FabricDocumentAutomationService.shared.saveGraph(self.graph)
+        return .result(value: savedGraph, dialog: "Saved \(savedGraph.displayName).")
     }
 }
 
-struct SetPublishedParametersIntent: AppIntent {
-    static let title: LocalizedStringResource = "Set Published Parameters"
-    static let description = IntentDescription("Apply one or more published parameter assignments using Label=Value entries.")
+struct RevealGraphFileIntent: AppIntent {
+    static let title: LocalizedStringResource = "Reveal Graph File"
+    static let description = IntentDescription("Reveal a graph file in Finder.")
 
-    @Parameter(title: "Graph URL")
-    var graphURL: String
+    @Parameter(title: "Graph")
+    var graph: FabricGraphEntity
 
-    @Parameter(title: "Assignments")
-    var assignments: [String]
-
-    func perform() async throws -> some IntentResult & ReturnsValue<[FabricPublishedParameterEntity]> & ProvidesDialog {
-        let parameters = try await FabricDocumentAutomationService.shared.setPublishedParameters(self.assignments, in: self.graphURL)
-        return .result(value: parameters, dialog: "Updated \(self.assignments.count) parameter assignments.")
+    func perform() async throws -> some IntentResult & ReturnsValue<IntentFile> & ProvidesDialog {
+        let file = try await FabricDocumentAutomationService.shared.revealGraphFile(for: self.graph)
+        return .result(value: file, dialog: "Revealed \(self.graph.displayName).")
     }
 }
 
-struct ListNodesIntent: AppIntent {
-    static let title: LocalizedStringResource = "List Nodes"
-    static let description = IntentDescription("List nodes in a Fabric graph.")
-
-    @Parameter(title: "Graph URL")
-    var graphURL: String
-
-    func perform() async throws -> some IntentResult & ReturnsValue<[FabricNodeEntity]> & ProvidesDialog {
-        let nodes = try await FabricDocumentAutomationService.shared.listNodes(in: self.graphURL)
-        return .result(value: nodes, dialog: "Found \(nodes.count) nodes.")
-    }
-}
-
-struct ListNodeRegistryIntent: AppIntent {
-    static let title: LocalizedStringResource = "List Node Registry"
-    static let description = IntentDescription("List all available node registry entries.")
+struct ListAvailableNodesIntent: AppIntent {
+    static let title: LocalizedStringResource = "List Available Nodes"
+    static let description = IntentDescription("Return all node types available in Fabric’s node registry.")
 
     func perform() async throws -> some IntentResult & ReturnsValue<[FabricRegistryNodeEntity]> & ProvidesDialog {
-        let nodes = await FabricDocumentAutomationService.shared.listRegistryNodes(matching: nil)
-        return .result(value: nodes, dialog: "Found \(nodes.count) registry nodes.")
+        let nodes = await FabricDocumentAutomationService.shared.listRegistryNodes()
+        return .result(value: nodes, dialog: "Found \(nodes.count) available nodes.")
     }
 }
 
-struct SearchNodeRegistryIntent: AppIntent {
-    static let title: LocalizedStringResource = "Search Node Registry"
-    static let description = IntentDescription("Search available Fabric node registry entries.")
+struct FindAvailableNodesIntent: AppIntent {
+    static let title: LocalizedStringResource = "Find Available Nodes"
+    static let description = IntentDescription("Search the Fabric node registry by name, type, or description.")
 
     @Parameter(title: "Search Text")
     var searchText: String
 
     func perform() async throws -> some IntentResult & ReturnsValue<[FabricRegistryNodeEntity]> & ProvidesDialog {
         let nodes = await FabricDocumentAutomationService.shared.listRegistryNodes(matching: self.searchText)
-        return .result(value: nodes, dialog: "Found \(nodes.count) matching registry nodes.")
+        return .result(value: nodes, dialog: "Found \(nodes.count) matching node types.")
+    }
+}
+
+struct GetAvailableNodeDetailsIntent: AppIntent {
+    static let title: LocalizedStringResource = "Get Available Node Details"
+    static let description = IntentDescription("Return the canonical details for a registry node type.")
+
+    @Parameter(title: "Registry Node")
+    var registryNode: FabricRegistryNodeEntity
+
+    func perform() async throws -> some IntentResult & ReturnsValue<FabricRegistryNodeEntity> & ProvidesDialog {
+        let registryNode = try await FabricDocumentAutomationService.shared.registryNodeDetails(for: self.registryNode)
+        return .result(value: registryNode, dialog: "Loaded \(registryNode.nodeName).")
+    }
+}
+
+struct GetGraphNodesIntent: AppIntent {
+    static let title: LocalizedStringResource = "Get Graph Nodes"
+    static let description = IntentDescription("Return all nodes currently in a graph.")
+
+    @Parameter(title: "Graph")
+    var graph: FabricGraphEntity
+
+    func perform() async throws -> some IntentResult & ReturnsValue<[FabricNodeEntity]> & ProvidesDialog {
+        let nodes = try await FabricDocumentAutomationService.shared.listNodes(in: self.graph)
+        return .result(value: nodes, dialog: "Found \(nodes.count) nodes.")
+    }
+}
+
+struct FindGraphNodesIntent: AppIntent {
+    static let title: LocalizedStringResource = "Find Graph Nodes"
+    static let description = IntentDescription("Search nodes inside a graph by name, class, or type.")
+
+    @Parameter(title: "Graph")
+    var graph: FabricGraphEntity
+
+    @Parameter(title: "Search Text")
+    var searchText: String
+
+    func perform() async throws -> some IntentResult & ReturnsValue<[FabricNodeEntity]> & ProvidesDialog {
+        let nodes = try await FabricDocumentAutomationService.shared.findNodes(in: self.graph, matching: self.searchText)
+        return .result(value: nodes, dialog: "Found \(nodes.count) matching nodes.")
+    }
+}
+
+struct GetNodeDetailsIntent: AppIntent {
+    static let title: LocalizedStringResource = "Get Node Details"
+    static let description = IntentDescription("Return detailed information about a graph node.")
+
+    @Parameter(title: "Node")
+    var node: FabricNodeEntity
+
+    func perform() async throws -> some IntentResult & ReturnsValue<FabricNodeEntity> & ProvidesDialog {
+        let node = try await FabricDocumentAutomationService.shared.nodeDetails(for: self.node)
+        return .result(value: node, dialog: "Loaded \(node.displayName).")
+    }
+}
+
+struct GetNodePortsIntent: AppIntent {
+    static let title: LocalizedStringResource = "Get Node Ports"
+    static let description = IntentDescription("Return all ports on a graph node.")
+
+    @Parameter(title: "Node")
+    var node: FabricNodeEntity
+
+    func perform() async throws -> some IntentResult & ReturnsValue<[FabricPortEntity]> & ProvidesDialog {
+        let ports = try await FabricDocumentAutomationService.shared.listPorts(for: self.node)
+        return .result(value: ports, dialog: "Found \(ports.count) ports.")
+    }
+}
+
+struct FindNodePortsIntent: AppIntent {
+    static let title: LocalizedStringResource = "Find Node Ports"
+    static let description = IntentDescription("Search a node’s ports by name, type, or publication state.")
+
+    @Parameter(title: "Node")
+    var node: FabricNodeEntity
+
+    @Parameter(title: "Search Text", default: "")
+    var searchText: String
+
+    @Parameter(title: "Kind")
+    var kind: FabricPortKindAppEnum?
+
+    @Parameter(title: "Published Only", default: false)
+    var publishedOnly: Bool
+
+    func perform() async throws -> some IntentResult & ReturnsValue<[FabricPortEntity]> & ProvidesDialog {
+        let ports = try await FabricDocumentAutomationService.shared.findPorts(
+            for: self.node,
+            matching: self.searchText,
+            kind: self.kind,
+            publishedOnly: self.publishedOnly
+        )
+        return .result(value: ports, dialog: "Found \(ports.count) matching ports.")
+    }
+}
+
+struct GetGraphPublishedParametersIntent: AppIntent {
+    static let title: LocalizedStringResource = "Get Graph Published Parameters"
+    static let description = IntentDescription("Return the graph’s published parameter surface.")
+
+    @Parameter(title: "Graph")
+    var graph: FabricGraphEntity
+
+    func perform() async throws -> some IntentResult & ReturnsValue<[FabricPublishedParameterEntity]> & ProvidesDialog {
+        let parameters = try await FabricDocumentAutomationService.shared.listPublishedParameters(in: self.graph)
+        return .result(value: parameters, dialog: "Found \(parameters.count) published parameters.")
+    }
+}
+
+struct FindPublishedParametersIntent: AppIntent {
+    static let title: LocalizedStringResource = "Find Published Parameters"
+    static let description = IntentDescription("Search published graph parameters by label, type, or value summary.")
+
+    @Parameter(title: "Graph")
+    var graph: FabricGraphEntity
+
+    @Parameter(title: "Search Text")
+    var searchText: String
+
+    func perform() async throws -> some IntentResult & ReturnsValue<[FabricPublishedParameterEntity]> & ProvidesDialog {
+        let parameters = try await FabricDocumentAutomationService.shared.findPublishedParameters(in: self.graph, matching: self.searchText)
+        return .result(value: parameters, dialog: "Found \(parameters.count) matching published parameters.")
+    }
+}
+
+struct GetPublishedParameterDetailsIntent: AppIntent {
+    static let title: LocalizedStringResource = "Get Published Parameter Details"
+    static let description = IntentDescription("Return the canonical details for a published parameter.")
+
+    @Parameter(title: "Published Parameter")
+    var parameter: FabricPublishedParameterEntity
+
+    func perform() async throws -> some IntentResult & ReturnsValue<FabricPublishedParameterEntity> & ProvidesDialog {
+        let parameter = try await FabricDocumentAutomationService.shared.publishedParameterDetails(for: self.parameter)
+        return .result(value: parameter, dialog: "Loaded \(parameter.label).")
     }
 }
 
 struct AddNodeToGraphIntent: AppIntent {
     static let title: LocalizedStringResource = "Add Node To Graph"
-    static let description = IntentDescription("Add a registry node to a graph file.")
+    static let description = IntentDescription("Add a registry node type to a graph and return the created node.")
 
-    @Parameter(title: "Graph URL")
-    var graphURL: String
+    @Parameter(title: "Graph")
+    var graph: FabricGraphEntity
 
     @Parameter(title: "Registry Node")
     var registryNode: FabricRegistryNodeEntity
@@ -134,7 +255,7 @@ struct AddNodeToGraphIntent: AppIntent {
     func perform() async throws -> some IntentResult & ReturnsValue<FabricNodeEntity> & ProvidesDialog {
         let node = try await FabricDocumentAutomationService.shared.addNode(
             registryNode: self.registryNode,
-            to: self.graphURL,
+            to: self.graph,
             x: self.xPosition,
             y: self.yPosition
         )
@@ -142,29 +263,16 @@ struct AddNodeToGraphIntent: AppIntent {
     }
 }
 
-struct GetNodeDetailsIntent: AppIntent {
-    static let title: LocalizedStringResource = "Get Node Details"
-    static let description = IntentDescription("Return the canonical node details for a node reference.")
+struct RemoveNodeFromGraphIntent: AppIntent {
+    static let title: LocalizedStringResource = "Remove Node From Graph"
+    static let description = IntentDescription("Remove a node from a graph.")
 
     @Parameter(title: "Node")
     var node: FabricNodeEntity
 
-    func perform() async throws -> some IntentResult & ReturnsValue<FabricNodeEntity> & ProvidesDialog {
-        let node = try await FabricDocumentAutomationService.shared.nodeDetails(for: self.node)
-        return .result(value: node, dialog: "Loaded \(node.displayName).")
-    }
-}
-
-struct GetNodePortsIntent: AppIntent {
-    static let title: LocalizedStringResource = "Get Node Ports"
-    static let description = IntentDescription("List ports for a node in a graph.")
-
-    @Parameter(title: "Node")
-    var node: FabricNodeEntity
-
-    func perform() async throws -> some IntentResult & ReturnsValue<[FabricPortEntity]> & ProvidesDialog {
-        let ports = try await FabricDocumentAutomationService.shared.ports(for: self.node)
-        return .result(value: ports, dialog: "Found \(ports.count) ports.")
+    func perform() async throws -> some IntentResult & ReturnsValue<FabricGraphEntity> & ProvidesDialog {
+        let graph = try await FabricDocumentAutomationService.shared.removeNode(self.node)
+        return .result(value: graph, dialog: "Removed \(self.node.displayName).")
     }
 }
 
@@ -178,15 +286,15 @@ struct ConnectPortsIntent: AppIntent {
     @Parameter(title: "Destination Port")
     var destinationPort: FabricPortEntity
 
-    func perform() async throws -> some IntentResult & ReturnsValue<String> & ProvidesDialog {
-        let message = try await FabricDocumentAutomationService.shared.connectPorts(from: self.sourcePort, to: self.destinationPort)
-        return .result(value: message, dialog: IntentDialog(stringLiteral: message))
+    func perform() async throws -> some IntentResult & ReturnsValue<FabricGraphEntity> & ProvidesDialog {
+        let graph = try await FabricDocumentAutomationService.shared.connectPorts(from: self.sourcePort, to: self.destinationPort)
+        return .result(value: graph, dialog: "Connected \(self.sourcePort.portDisplayName) to \(self.destinationPort.portDisplayName).")
     }
 }
 
 struct DisconnectPortsIntent: AppIntent {
     static let title: LocalizedStringResource = "Disconnect Ports"
-    static let description = IntentDescription("Disconnect a specific port pair or all connections on a source port.")
+    static let description = IntentDescription("Disconnect a specific connection or all connections from a source port.")
 
     @Parameter(title: "Source Port")
     var sourcePort: FabricPortEntity
@@ -194,9 +302,131 @@ struct DisconnectPortsIntent: AppIntent {
     @Parameter(title: "Destination Port")
     var destinationPort: FabricPortEntity?
 
-    func perform() async throws -> some IntentResult & ReturnsValue<String> & ProvidesDialog {
-        let message = try await  FabricDocumentAutomationService.shared.disconnectPorts(from: self.sourcePort, to: self.destinationPort)
-        return .result(value: message, dialog: IntentDialog(stringLiteral: message))
+    func perform() async throws -> some IntentResult & ReturnsValue<FabricGraphEntity> & ProvidesDialog {
+        let graph = try await FabricDocumentAutomationService.shared.disconnectPorts(from: self.sourcePort, to: self.destinationPort)
+        return .result(value: graph, dialog: "Updated connections for \(self.sourcePort.portDisplayName).")
+    }
+}
+
+struct PublishPortIntent: AppIntent {
+    static let title: LocalizedStringResource = "Publish Port"
+    static let description = IntentDescription("Expose a node port on the graph’s published control surface.")
+
+    @Parameter(title: "Port")
+    var port: FabricPortEntity
+
+    @Parameter(title: "Published Label")
+    var publishedLabel: String?
+
+    func perform() async throws -> some IntentResult & ReturnsValue<FabricPublishedParameterEntity> & ProvidesDialog {
+        let parameter = try await FabricDocumentAutomationService.shared.publishPort(self.port, label: self.publishedLabel)
+        return .result(value: parameter, dialog: "Published \(parameter.label).")
+    }
+}
+
+struct UnpublishPortIntent: AppIntent {
+    static let title: LocalizedStringResource = "Unpublish Port"
+    static let description = IntentDescription("Remove a node port from the graph’s published control surface.")
+
+    @Parameter(title: "Port")
+    var port: FabricPortEntity
+
+    func perform() async throws -> some IntentResult & ReturnsValue<FabricGraphEntity> & ProvidesDialog {
+        let graph = try await FabricDocumentAutomationService.shared.unpublishPort(self.port)
+        return .result(value: graph, dialog: "Unpublished \(self.port.portDisplayName).")
+    }
+}
+
+struct UnpublishPublishedParameterIntent: AppIntent {
+    static let title: LocalizedStringResource = "Unpublish Published Parameter"
+    static let description = IntentDescription("Remove a published parameter from the graph’s control surface.")
+
+    @Parameter(title: "Published Parameter")
+    var parameter: FabricPublishedParameterEntity
+
+    func perform() async throws -> some IntentResult & ReturnsValue<FabricGraphEntity> & ProvidesDialog {
+        let graph = try await FabricDocumentAutomationService.shared.unpublishParameter(self.parameter)
+        return .result(value: graph, dialog: "Unpublished \(self.parameter.label).")
+    }
+}
+
+struct SetPublishedBooleanIntent: AppIntent {
+    static let title: LocalizedStringResource = "Set Published Boolean"
+    static let description = IntentDescription("Set a published Boolean parameter.")
+
+    @Parameter(title: "Published Parameter")
+    var parameter: FabricPublishedParameterEntity
+
+    @Parameter(title: "Value")
+    var value: Bool
+
+    func perform() async throws -> some IntentResult & ReturnsValue<FabricPublishedParameterEntity> & ProvidesDialog {
+        let parameter = try await FabricDocumentAutomationService.shared.setPublishedBoolean(self.parameter, value: self.value)
+        return .result(value: parameter, dialog: "Set \(parameter.label) to \(self.value ? "on" : "off").")
+    }
+}
+
+struct SetPublishedNumberIntent: AppIntent {
+    static let title: LocalizedStringResource = "Set Published Number"
+    static let description = IntentDescription("Set a published numeric parameter.")
+
+    @Parameter(title: "Published Parameter")
+    var parameter: FabricPublishedParameterEntity
+
+    @Parameter(title: "Value")
+    var value: Double
+
+    func perform() async throws -> some IntentResult & ReturnsValue<FabricPublishedParameterEntity> & ProvidesDialog {
+        let parameter = try await FabricDocumentAutomationService.shared.setPublishedNumber(self.parameter, value: self.value)
+        return .result(value: parameter, dialog: "Set \(parameter.label) to \(self.value.formatted()).")
+    }
+}
+
+struct SetPublishedIntegerIntent: AppIntent {
+    static let title: LocalizedStringResource = "Set Published Integer"
+    static let description = IntentDescription("Set a published integer parameter.")
+
+    @Parameter(title: "Published Parameter")
+    var parameter: FabricPublishedParameterEntity
+
+    @Parameter(title: "Value")
+    var value: Int
+
+    func perform() async throws -> some IntentResult & ReturnsValue<FabricPublishedParameterEntity> & ProvidesDialog {
+        let parameter = try await FabricDocumentAutomationService.shared.setPublishedInteger(self.parameter, value: self.value)
+        return .result(value: parameter, dialog: "Set \(parameter.label) to \(self.value).")
+    }
+}
+
+struct SetPublishedTextIntent: AppIntent {
+    static let title: LocalizedStringResource = "Set Published Text"
+    static let description = IntentDescription("Set a published text parameter.")
+
+    @Parameter(title: "Published Parameter")
+    var parameter: FabricPublishedParameterEntity
+
+    @Parameter(title: "Value")
+    var value: String
+
+    func perform() async throws -> some IntentResult & ReturnsValue<FabricPublishedParameterEntity> & ProvidesDialog {
+        let parameter = try await FabricDocumentAutomationService.shared.setPublishedText(self.parameter, value: self.value)
+        return .result(value: parameter, dialog: "Updated \(parameter.label).")
+    }
+}
+
+struct SetPublishedVectorIntent: AppIntent {
+    static let title: LocalizedStringResource = "Set Published Vector"
+    static let description = IntentDescription("Set a published vector or color parameter using numeric components.")
+
+    @Parameter(title: "Published Parameter")
+    var parameter: FabricPublishedParameterEntity
+
+    @Parameter(title: "Components")
+    var components: [Double]
+
+    func perform() async throws -> some IntentResult & ReturnsValue<FabricPublishedParameterEntity> & ProvidesDialog {
+        let parameter = try await FabricDocumentAutomationService.shared.setPublishedVector(self.parameter, components: self.components)
+        return .result(value: parameter, dialog: "Updated \(parameter.label).")
     }
 }
 
@@ -205,39 +435,39 @@ struct FabricEditorShortcuts: AppShortcutsProvider {
 
     static var appShortcuts: [AppShortcut] {
         AppShortcut(
-            intent: OpenGraphIntent(),
+            intent: GetGraphFileIntent(),
             phrases: [
-                "Open a graph in \(.applicationName)",
-                "Open a Fabric graph with \(.applicationName)",
+                "Get a Fabric graph in \(.applicationName)",
+                "Open a graph with \(.applicationName)",
             ],
-            shortTitle: "Open Graph",
+            shortTitle: "Get Graph",
             systemImageName: "folder"
         )
 
         AppShortcut(
-            intent: ListPublishedParametersIntent(),
+            intent: ListAvailableNodesIntent(),
             phrases: [
+                "List Fabric nodes in \(.applicationName)",
+                "Show available nodes in \(.applicationName)",
+            ],
+            shortTitle: "Available Nodes",
+            systemImageName: "square.grid.2x2"
+        )
+
+        AppShortcut(
+            intent: GetGraphPublishedParametersIntent(),
+            phrases: [
+                "Get graph controls in \(.applicationName)",
                 "List published parameters in \(.applicationName)",
-                "Get graph controls from \(.applicationName)",
             ],
             shortTitle: "Published Parameters",
             systemImageName: "slider.horizontal.3"
         )
 
         AppShortcut(
-            intent: SetPublishedParametersIntent(),
-            phrases: [
-                "Set published parameters in \(.applicationName)",
-                "Update graph controls with \(.applicationName)",
-            ],
-            shortTitle: "Set Parameters",
-            systemImageName: "slider.horizontal.below.rectangle"
-        )
-
-        AppShortcut(
             intent: AddNodeToGraphIntent(),
             phrases: [
-                "Add a Fabric node with \(.applicationName)",
+                "Add a node to a graph with \(.applicationName)",
             ],
             shortTitle: "Add Node",
             systemImageName: "plus.square.on.square"

--- a/Fabric Editor/AppIntents/FabricAppIntents.swift
+++ b/Fabric Editor/AppIntents/FabricAppIntents.swift
@@ -1,0 +1,246 @@
+//
+//  FabricAppIntents.swift
+//  Fabric Editor
+//
+//  Created by Codex on 4/7/26.
+//
+
+import AppIntents
+import Foundation
+
+struct OpenGraphIntent: AppIntent {
+    static let title: LocalizedStringResource = "Open Graph"
+    static let description = IntentDescription("Open a Fabric graph from a file URL or path.")
+
+    @Parameter(title: "Graph URL")
+    var graphURL: String
+
+    func perform() async throws -> some IntentResult & ReturnsValue<FabricGraphEntity> & ProvidesDialog {
+        let graph = try await FabricDocumentAutomationService.shared.openGraph(at: self.graphURL)
+        return .result(value: graph, dialog: "Opened \(graph.displayName).")
+    }
+}
+
+struct CreateGraphIntent: AppIntent {
+    static let title: LocalizedStringResource = "Create Graph"
+    static let description = IntentDescription("Create a new Fabric graph file, optionally seeded with the default template.")
+
+    @Parameter(title: "Graph URL")
+    var graphURL: String
+
+    @Parameter(title: "Use Template", default: true)
+    var useTemplate: Bool
+
+    func perform() async throws -> some IntentResult & ReturnsValue<FabricGraphEntity> & ProvidesDialog {
+        let graph = try await FabricDocumentAutomationService.shared.createGraph(at: self.graphURL, useTemplate: self.useTemplate)
+        return .result(value: graph, dialog: "Created \(graph.displayName).")
+    }
+}
+
+struct GetGraphSummaryIntent: AppIntent {
+    static let title: LocalizedStringResource = "Get Graph Summary"
+    static let description = IntentDescription("Summarize a Fabric graph file.")
+
+    @Parameter(title: "Graph URL")
+    var graphURL: String
+
+    func perform() async throws -> some IntentResult & ReturnsValue<String> & ProvidesDialog {
+        let summary = try await FabricDocumentAutomationService.shared.graphSummary(for: self.graphURL)
+        return .result(value: summary, dialog: IntentDialog(stringLiteral: summary))
+    }
+}
+
+struct ListPublishedParametersIntent: AppIntent {
+    static let title: LocalizedStringResource = "List Published Parameters"
+    static let description = IntentDescription("Return the published parameter surface for a graph.")
+
+    @Parameter(title: "Graph URL")
+    var graphURL: String
+
+    func perform() async throws -> some IntentResult & ReturnsValue<[FabricPublishedParameterEntity]> & ProvidesDialog {
+        let parameters = try await FabricDocumentAutomationService.shared.listPublishedParameters(in: self.graphURL)
+        return .result(value: parameters, dialog: "Found \(parameters.count) published parameters.")
+    }
+}
+
+struct SetPublishedParametersIntent: AppIntent {
+    static let title: LocalizedStringResource = "Set Published Parameters"
+    static let description = IntentDescription("Apply one or more published parameter assignments using Label=Value entries.")
+
+    @Parameter(title: "Graph URL")
+    var graphURL: String
+
+    @Parameter(title: "Assignments")
+    var assignments: [String]
+
+    func perform() async throws -> some IntentResult & ReturnsValue<[FabricPublishedParameterEntity]> & ProvidesDialog {
+        let parameters = try await FabricDocumentAutomationService.shared.setPublishedParameters(self.assignments, in: self.graphURL)
+        return .result(value: parameters, dialog: "Updated \(self.assignments.count) parameter assignments.")
+    }
+}
+
+struct ListNodesIntent: AppIntent {
+    static let title: LocalizedStringResource = "List Nodes"
+    static let description = IntentDescription("List nodes in a Fabric graph.")
+
+    @Parameter(title: "Graph URL")
+    var graphURL: String
+
+    func perform() async throws -> some IntentResult & ReturnsValue<[FabricNodeEntity]> & ProvidesDialog {
+        let nodes = try await FabricDocumentAutomationService.shared.listNodes(in: self.graphURL)
+        return .result(value: nodes, dialog: "Found \(nodes.count) nodes.")
+    }
+}
+
+struct ListNodeRegistryIntent: AppIntent {
+    static let title: LocalizedStringResource = "List Node Registry"
+    static let description = IntentDescription("List all available node registry entries.")
+
+    func perform() async throws -> some IntentResult & ReturnsValue<[FabricRegistryNodeEntity]> & ProvidesDialog {
+        let nodes = await FabricDocumentAutomationService.shared.listRegistryNodes(matching: nil)
+        return .result(value: nodes, dialog: "Found \(nodes.count) registry nodes.")
+    }
+}
+
+struct SearchNodeRegistryIntent: AppIntent {
+    static let title: LocalizedStringResource = "Search Node Registry"
+    static let description = IntentDescription("Search available Fabric node registry entries.")
+
+    @Parameter(title: "Search Text")
+    var searchText: String
+
+    func perform() async throws -> some IntentResult & ReturnsValue<[FabricRegistryNodeEntity]> & ProvidesDialog {
+        let nodes = await FabricDocumentAutomationService.shared.listRegistryNodes(matching: self.searchText)
+        return .result(value: nodes, dialog: "Found \(nodes.count) matching registry nodes.")
+    }
+}
+
+struct AddNodeToGraphIntent: AppIntent {
+    static let title: LocalizedStringResource = "Add Node To Graph"
+    static let description = IntentDescription("Add a registry node to a graph file.")
+
+    @Parameter(title: "Graph URL")
+    var graphURL: String
+
+    @Parameter(title: "Registry Node")
+    var registryNode: FabricRegistryNodeEntity
+
+    @Parameter(title: "X Position")
+    var xPosition: Double?
+
+    @Parameter(title: "Y Position")
+    var yPosition: Double?
+
+    func perform() async throws -> some IntentResult & ReturnsValue<FabricNodeEntity> & ProvidesDialog {
+        let node = try await FabricDocumentAutomationService.shared.addNode(
+            registryNode: self.registryNode,
+            to: self.graphURL,
+            x: self.xPosition,
+            y: self.yPosition
+        )
+        return .result(value: node, dialog: "Added \(node.displayName).")
+    }
+}
+
+struct GetNodeDetailsIntent: AppIntent {
+    static let title: LocalizedStringResource = "Get Node Details"
+    static let description = IntentDescription("Return the canonical node details for a node reference.")
+
+    @Parameter(title: "Node")
+    var node: FabricNodeEntity
+
+    func perform() async throws -> some IntentResult & ReturnsValue<FabricNodeEntity> & ProvidesDialog {
+        let node = try await FabricDocumentAutomationService.shared.nodeDetails(for: self.node)
+        return .result(value: node, dialog: "Loaded \(node.displayName).")
+    }
+}
+
+struct GetNodePortsIntent: AppIntent {
+    static let title: LocalizedStringResource = "Get Node Ports"
+    static let description = IntentDescription("List ports for a node in a graph.")
+
+    @Parameter(title: "Node")
+    var node: FabricNodeEntity
+
+    func perform() async throws -> some IntentResult & ReturnsValue<[FabricPortEntity]> & ProvidesDialog {
+        let ports = try await FabricDocumentAutomationService.shared.ports(for: self.node)
+        return .result(value: ports, dialog: "Found \(ports.count) ports.")
+    }
+}
+
+struct ConnectPortsIntent: AppIntent {
+    static let title: LocalizedStringResource = "Connect Ports"
+    static let description = IntentDescription("Connect one outlet port to one inlet port.")
+
+    @Parameter(title: "Source Port")
+    var sourcePort: FabricPortEntity
+
+    @Parameter(title: "Destination Port")
+    var destinationPort: FabricPortEntity
+
+    func perform() async throws -> some IntentResult & ReturnsValue<String> & ProvidesDialog {
+        let message = try await FabricDocumentAutomationService.shared.connectPorts(from: self.sourcePort, to: self.destinationPort)
+        return .result(value: message, dialog: IntentDialog(stringLiteral: message))
+    }
+}
+
+struct DisconnectPortsIntent: AppIntent {
+    static let title: LocalizedStringResource = "Disconnect Ports"
+    static let description = IntentDescription("Disconnect a specific port pair or all connections on a source port.")
+
+    @Parameter(title: "Source Port")
+    var sourcePort: FabricPortEntity
+
+    @Parameter(title: "Destination Port")
+    var destinationPort: FabricPortEntity?
+
+    func perform() async throws -> some IntentResult & ReturnsValue<String> & ProvidesDialog {
+        let message = try await  FabricDocumentAutomationService.shared.disconnectPorts(from: self.sourcePort, to: self.destinationPort)
+        return .result(value: message, dialog: IntentDialog(stringLiteral: message))
+    }
+}
+
+struct FabricEditorShortcuts: AppShortcutsProvider {
+    static let shortcutTileColor: ShortcutTileColor = .blue
+
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: OpenGraphIntent(),
+            phrases: [
+                "Open a graph in \(.applicationName)",
+                "Open a Fabric graph with \(.applicationName)",
+            ],
+            shortTitle: "Open Graph",
+            systemImageName: "folder"
+        )
+
+        AppShortcut(
+            intent: ListPublishedParametersIntent(),
+            phrases: [
+                "List published parameters in \(.applicationName)",
+                "Get graph controls from \(.applicationName)",
+            ],
+            shortTitle: "Published Parameters",
+            systemImageName: "slider.horizontal.3"
+        )
+
+        AppShortcut(
+            intent: SetPublishedParametersIntent(),
+            phrases: [
+                "Set published parameters in \(.applicationName)",
+                "Update graph controls with \(.applicationName)",
+            ],
+            shortTitle: "Set Parameters",
+            systemImageName: "slider.horizontal.below.rectangle"
+        )
+
+        AppShortcut(
+            intent: AddNodeToGraphIntent(),
+            phrases: [
+                "Add a Fabric node with \(.applicationName)",
+            ],
+            shortTitle: "Add Node",
+            systemImageName: "plus.square.on.square"
+        )
+    }
+}

--- a/Fabric Editor/AppIntents/FabricDocumentAutomationService.swift
+++ b/Fabric Editor/AppIntents/FabricDocumentAutomationService.swift
@@ -1,0 +1,583 @@
+//
+//  FabricDocumentAutomationService.swift
+//  Fabric Editor
+//
+//  Created by Codex on 4/7/26.
+//
+
+import AppKit
+import Foundation
+import Metal
+import Fabric
+import Satin
+import simd
+
+enum FabricIntentError: LocalizedError {
+    case invalidGraphURL(String)
+    case unsupportedGraphFile(URL)
+    case fileAlreadyExists(URL)
+    case nodeNotFound(String)
+    case portNotFound(String)
+    case notAPublishedParameter(String)
+    case ambiguousPublishedParameter(String)
+    case unsupportedParameterType(String)
+    case invalidValue(String)
+    case incompatiblePorts(String)
+    case registryNodeNotFound(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidGraphURL(let value):
+            return "Invalid graph URL: \(value)"
+        case .unsupportedGraphFile(let url):
+            return "Unsupported graph file: \(url.path)"
+        case .fileAlreadyExists(let url):
+            return "A graph already exists at \(url.path)"
+        case .nodeNotFound(let nodeID):
+            return "Node not found: \(nodeID)"
+        case .portNotFound(let portID):
+            return "Port not found: \(portID)"
+        case .notAPublishedParameter(let label):
+            return "Published parameter not found: \(label)"
+        case .ambiguousPublishedParameter(let label):
+            return "Multiple published parameters match '\(label)'"
+        case .unsupportedParameterType(let label):
+            return "Unsupported parameter type for '\(label)'"
+        case .invalidValue(let description):
+            return "Invalid value: \(description)"
+        case .incompatiblePorts(let description):
+            return "Incompatible ports: \(description)"
+        case .registryNodeNotFound(let identifier):
+            return "Registry node not found: \(identifier)"
+        }
+    }
+}
+
+@MainActor
+final class FabricDocumentAutomationService {
+    static let shared = FabricDocumentAutomationService()
+
+    private init() {}
+
+    struct LoadedGraph {
+        let url: URL
+        let graph: Graph
+    }
+
+    func createGraph(at graphURLString: String, useTemplate: Bool) throws -> FabricGraphEntity {
+        let url = try self.graphURL(from: graphURLString)
+        guard url.isFileURL else {
+            throw FabricIntentError.invalidGraphURL(graphURLString)
+        }
+        guard url.pathExtension.localizedCaseInsensitiveCompare("fabric") == .orderedSame else {
+            throw FabricIntentError.unsupportedGraphFile(url)
+        }
+        guard !FileManager.default.fileExists(atPath: url.path) else {
+            throw FabricIntentError.fileAlreadyExists(url)
+        }
+
+        let parentURL = url.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: parentURL, withIntermediateDirectories: true, attributes: nil)
+
+        let document = useTemplate ? FabricDocument(withTemplate: true) : FabricDocument()
+        try self.saveGraph(document.editingContext.rootGraph, to: url)
+        NSWorkspace.shared.open(url)
+        return self.makeGraphEntity(graph: document.editingContext.rootGraph, url: url)
+    }
+
+    func openGraph(at graphURLString: String) throws -> FabricGraphEntity {
+        let loadedGraph = try self.loadGraph(at: graphURLString)
+        NSWorkspace.shared.open(loadedGraph.url)
+        return self.makeGraphEntity(graph: loadedGraph.graph, url: loadedGraph.url)
+    }
+
+    func graphSummary(for graphURLString: String) throws -> String {
+        let loadedGraph = try self.loadGraph(at: graphURLString)
+        let graph = loadedGraph.graph
+        let publishedCount = graph.getPublishedPorts().count
+        return "\(graph.nodes.count) nodes, \(publishedCount) published ports"
+    }
+
+    func graphEntity(for graphURLString: String) throws -> FabricGraphEntity {
+        let loadedGraph = try self.loadGraph(at: graphURLString)
+        return self.makeGraphEntity(graph: loadedGraph.graph, url: loadedGraph.url)
+    }
+
+    func listNodes(in graphURLString: String) throws -> [FabricNodeEntity] {
+        let loadedGraph = try self.loadGraph(at: graphURLString)
+        return loadedGraph.graph.nodes.map { self.makeNodeEntity(node: $0, graphURL: loadedGraph.url.absoluteString) }
+    }
+
+    func listPublishedParameters(in graphURLString: String) throws -> [FabricPublishedParameterEntity] {
+        let loadedGraph = try self.loadGraph(at: graphURLString)
+        return loadedGraph.graph
+            .getPublishedPorts()
+            .compactMap { port in
+                guard let parameter = port.parameter else { return nil }
+                return self.makePublishedParameterEntity(
+                    parameter: parameter,
+                    port: port,
+                    graphURL: loadedGraph.url.absoluteString
+                )
+            }
+    }
+
+    func listRegistryNodes(matching searchText: String?) -> [FabricRegistryNodeEntity] {
+        let normalizedSearchText = searchText?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return NodeRegistry.shared.availableNodes.compactMap { wrapper in
+            if let normalizedSearchText, !normalizedSearchText.isEmpty {
+                let haystack = [
+                    wrapper.nodeName,
+                    String(describing: wrapper.nodeClass),
+                    wrapper.nodeType.description,
+                    wrapper.nodeDescription,
+                ]
+                let matches = haystack.contains { $0.localizedStandardContains(normalizedSearchText) }
+                if !matches {
+                    return nil
+                }
+            }
+
+            return self.makeRegistryNodeEntity(wrapper: wrapper)
+        }
+    }
+
+    func nodeDetails(for nodeEntity: FabricNodeEntity) throws -> FabricNodeEntity {
+        let loadedGraph = try self.loadGraph(at: nodeEntity.graphURL)
+        let node = try self.node(withIdentifier: nodeEntity.nodeIdentifier, in: loadedGraph.graph)
+        return self.makeNodeEntity(node: node, graphURL: loadedGraph.url.absoluteString)
+    }
+
+    func ports(for nodeEntity: FabricNodeEntity) throws -> [FabricPortEntity] {
+        let loadedGraph = try self.loadGraph(at: nodeEntity.graphURL)
+        let node = try self.node(withIdentifier: nodeEntity.nodeIdentifier, in: loadedGraph.graph)
+        return node.ports.map { self.makePortEntity(port: $0, graphURL: loadedGraph.url.absoluteString) }
+    }
+
+    func addNode(
+        registryNode: FabricRegistryNodeEntity,
+        to graphURLString: String,
+        x: Double?,
+        y: Double?
+    ) throws -> FabricNodeEntity {
+        let loadedGraph = try self.loadGraph(at: graphURLString)
+        let wrapper = try self.registryWrapper(for: registryNode)
+        let node = try wrapper.initializeNode(context: loadedGraph.graph.context)
+
+        if let x, let y {
+            node.offset = CGSize(width: x, height: y)
+        }
+
+        loadedGraph.graph.addNode(node)
+        try self.saveGraph(loadedGraph.graph, to: loadedGraph.url)
+        return self.makeNodeEntity(node: node, graphURL: loadedGraph.url.absoluteString)
+    }
+
+    func connectPorts(from sourcePort: FabricPortEntity, to destinationPort: FabricPortEntity) throws -> String {
+        guard sourcePort.graphURL == destinationPort.graphURL else {
+            throw FabricIntentError.incompatiblePorts("Ports must belong to the same graph")
+        }
+
+        let loadedGraph = try self.loadGraph(at: sourcePort.graphURL)
+        let source = try self.port(withIdentifier: sourcePort.portIdentifier, in: loadedGraph.graph)
+        let destination = try self.port(withIdentifier: destinationPort.portIdentifier, in: loadedGraph.graph)
+
+        guard source.kind == .Outlet, destination.kind == .Inlet else {
+            throw FabricIntentError.incompatiblePorts("Connect an outlet source to an inlet destination")
+        }
+
+        if !source.canConnect(to: destination) {
+            throw FabricIntentError.incompatiblePorts("\(source.displayName) cannot connect to \(destination.displayName)")
+        }
+
+        source.connect(to: destination)
+        loadedGraph.graph.rebuildPublishedParameterGroup()
+        try self.saveGraph(loadedGraph.graph, to: loadedGraph.url)
+
+        return "Connected \(source.displayName) to \(destination.displayName)"
+    }
+
+    func disconnectPorts(from sourcePort: FabricPortEntity, to destinationPort: FabricPortEntity?) throws -> String {
+        let loadedGraph = try self.loadGraph(at: sourcePort.graphURL)
+        let source = try self.port(withIdentifier: sourcePort.portIdentifier, in: loadedGraph.graph)
+
+        if let destinationPort {
+            let destination = try self.port(withIdentifier: destinationPort.portIdentifier, in: loadedGraph.graph)
+            source.disconnect(from: destination)
+        } else {
+            source.disconnectAll()
+        }
+
+        loadedGraph.graph.rebuildPublishedParameterGroup()
+        try self.saveGraph(loadedGraph.graph, to: loadedGraph.url)
+
+        return destinationPort == nil
+            ? "Disconnected all connections from \(source.displayName)"
+            : "Disconnected \(source.displayName)"
+    }
+
+    func setPublishedParameters(_ assignments: [String], in graphURLString: String) throws -> [FabricPublishedParameterEntity] {
+        let loadedGraph = try self.loadGraph(at: graphURLString)
+
+        for assignment in assignments {
+            let trimmedAssignment = assignment.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmedAssignment.isEmpty {
+                continue
+            }
+
+            let pair = try self.parseAssignment(trimmedAssignment)
+            let port = try self.publishedPort(label: pair.label, in: loadedGraph.graph)
+            let parameter = try self.parameter(forPublishedPort: port, label: pair.label)
+            try self.apply(rawValue: pair.value, to: parameter, label: pair.label)
+        }
+
+        loadedGraph.graph.rebuildPublishedParameterGroup()
+        try self.saveGraph(loadedGraph.graph, to: loadedGraph.url)
+        return try self.listPublishedParameters(in: loadedGraph.url.absoluteString)
+    }
+
+    private func loadGraph(at graphURLString: String) throws -> LoadedGraph {
+        let url = try self.graphURL(from: graphURLString)
+        let data = try Data(contentsOf: url)
+        let decoder = JSONDecoder()
+        decoder.context = DecoderContext(documentContext: self.makeContext())
+        let graph = try decoder.decode(Graph.self, from: data)
+        return LoadedGraph(url: url, graph: graph)
+    }
+
+    private func saveGraph(_ graph: Graph, to url: URL) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted]
+        let data = try encoder.encode(graph)
+        try data.write(to: url, options: [.atomic])
+    }
+
+    private func makeContext() -> Context {
+        Context(
+            device: MTLCreateSystemDefaultDevice()!,
+            sampleCount: 1,
+            colorPixelFormat: .rgba16Float,
+            depthPixelFormat: .depth32Float,
+            stencilPixelFormat: .stencil8
+        )
+    }
+
+    private func graphURL(from graphURLString: String) throws -> URL {
+        let trimmedValue = graphURLString.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedValue.isEmpty else {
+            throw FabricIntentError.invalidGraphURL(graphURLString)
+        }
+
+        if let url = URL(string: trimmedValue), url.scheme != nil {
+            return url.standardizedFileURL
+        }
+
+        return URL(fileURLWithPath: trimmedValue).standardizedFileURL
+    }
+
+    private func node(withIdentifier nodeIdentifier: String, in graph: Graph) throws -> Node {
+        guard let nodeUUID = UUID(uuidString: nodeIdentifier), let node = graph.node(forID: nodeUUID) else {
+            throw FabricIntentError.nodeNotFound(nodeIdentifier)
+        }
+        return node
+    }
+
+    private func port(withIdentifier portIdentifier: String, in graph: Graph) throws -> Fabric.Port {
+        guard let portUUID = UUID(uuidString: portIdentifier), let port = graph.nodePort(forID: portUUID) else {
+            throw FabricIntentError.portNotFound(portIdentifier)
+        }
+        return port
+    }
+
+    private func publishedPort(label: String, in graph: Graph) throws -> Fabric.Port {
+        let matches = graph
+            .getPublishedPorts()
+            .filter { $0.displayName.localizedStandardContains(label) || $0.displayName == label || $0.name == label }
+
+        if matches.isEmpty {
+            throw FabricIntentError.notAPublishedParameter(label)
+        }
+
+        if matches.count > 1 {
+            let exactMatches = matches.filter { $0.displayName == label || $0.name == label }
+            if exactMatches.count == 1, let exactMatch = exactMatches.first {
+                return exactMatch
+            }
+            throw FabricIntentError.ambiguousPublishedParameter(label)
+        }
+
+        guard let match = matches.first else {
+            throw FabricIntentError.notAPublishedParameter(label)
+        }
+
+        return match
+    }
+
+    private func parameter(forPublishedPort port: Fabric.Port, label: String) throws -> any Parameter {
+        guard let parameter = port.parameter else {
+            throw FabricIntentError.unsupportedParameterType(label)
+        }
+        return parameter
+    }
+
+    private func parseAssignment(_ assignment: String) throws -> (label: String, value: String) {
+        guard let delimiterIndex = assignment.firstIndex(of: "=") else {
+            throw FabricIntentError.invalidValue("Use Label=Value format")
+        }
+
+        let label = String(assignment[..<delimiterIndex]).trimmingCharacters(in: .whitespacesAndNewlines)
+        let valueStartIndex = assignment.index(after: delimiterIndex)
+        let value = String(assignment[valueStartIndex...]).trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !label.isEmpty else {
+            throw FabricIntentError.invalidValue("Missing parameter label")
+        }
+
+        return (label, value)
+    }
+
+    private func parseFloatComponents(_ rawValue: String, expectedCount: Int) throws -> [Float] {
+        let components = rawValue
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
+        guard components.count == expectedCount else {
+            throw FabricIntentError.invalidValue("Expected \(expectedCount) comma-separated values")
+        }
+
+        let numbers = try components.map { component -> Float in
+            guard let value = Float(component) else {
+                throw FabricIntentError.invalidValue("'\(component)' is not a number")
+            }
+            return value
+        }
+
+        return numbers
+    }
+
+    private func apply(rawValue: String, to parameter: any Parameter, label: String) throws {
+        if let parameter = parameter as? BoolParameter {
+            guard let value = Bool(rawValue) else {
+                throw FabricIntentError.invalidValue("'\(rawValue)' is not a Bool")
+            }
+            parameter.value = value
+            return
+        }
+
+        if let parameter = parameter as? GenericParameter<Bool> {
+            guard let value = Bool(rawValue) else {
+                throw FabricIntentError.invalidValue("'\(rawValue)' is not a Bool")
+            }
+            parameter.value = value
+            return
+        }
+
+        if let parameter = parameter as? IntParameter {
+            guard let value = Int(rawValue) else {
+                throw FabricIntentError.invalidValue("'\(rawValue)' is not an Int")
+            }
+            parameter.value = value
+            return
+        }
+
+        if let parameter = parameter as? GenericParameter<Int> {
+            guard let value = Int(rawValue) else {
+                throw FabricIntentError.invalidValue("'\(rawValue)' is not an Int")
+            }
+            parameter.value = value
+            return
+        }
+
+        if let parameter = parameter as? FloatParameter {
+            guard let value = Float(rawValue) else {
+                throw FabricIntentError.invalidValue("'\(rawValue)' is not a Float")
+            }
+            parameter.value = value
+            return
+        }
+
+        if let parameter = parameter as? GenericParameter<Float> {
+            guard let value = Float(rawValue) else {
+                throw FabricIntentError.invalidValue("'\(rawValue)' is not a Float")
+            }
+            parameter.value = value
+            return
+        }
+
+        if let parameter = parameter as? StringParameter {
+            parameter.value = rawValue
+            return
+        }
+
+        if let parameter = parameter as? GenericParameter<String> {
+            parameter.value = rawValue
+            return
+        }
+
+        if let parameter = parameter as? Float2Parameter {
+            let values = try self.parseFloatComponents(rawValue, expectedCount: 2)
+            parameter.value = simd_float2(values[0], values[1])
+            return
+        }
+
+        if let parameter = parameter as? GenericParameter<simd_float2> {
+            let values = try self.parseFloatComponents(rawValue, expectedCount: 2)
+            parameter.value = simd_float2(values[0], values[1])
+            return
+        }
+
+        if let parameter = parameter as? Float3Parameter {
+            let values = try self.parseFloatComponents(rawValue, expectedCount: 3)
+            parameter.value = simd_float3(values[0], values[1], values[2])
+            return
+        }
+
+        if let parameter = parameter as? GenericParameter<simd_float3> {
+            let values = try self.parseFloatComponents(rawValue, expectedCount: 3)
+            parameter.value = simd_float3(values[0], values[1], values[2])
+            return
+        }
+
+        if let parameter = parameter as? Float4Parameter {
+            let values = try self.parseFloatComponents(rawValue, expectedCount: 4)
+            parameter.value = simd_float4(values[0], values[1], values[2], values[3])
+            return
+        }
+
+        if let parameter = parameter as? GenericParameter<simd_float4> {
+            let values = try self.parseFloatComponents(rawValue, expectedCount: 4)
+            parameter.value = simd_float4(values[0], values[1], values[2], values[3])
+            return
+        }
+
+        throw FabricIntentError.unsupportedParameterType(label)
+    }
+
+    private func registryWrapper(for entity: FabricRegistryNodeEntity) throws -> NodeClassWrapper {
+        let matchingWrapper = NodeRegistry.shared.availableNodes.first { wrapper in
+            String(describing: wrapper.nodeClass) == entity.nodeClassName
+                && wrapper.nodeName == entity.nodeName
+                && wrapper.fileURL?.path == entity.sourcePath
+        }
+
+        guard let matchingWrapper else {
+            throw FabricIntentError.registryNodeNotFound(entity.nodeName)
+        }
+
+        return matchingWrapper
+    }
+
+    private func makeGraphEntity(graph: Graph, url: URL) -> FabricGraphEntity {
+        let displayName = url.deletingPathExtension().lastPathComponent
+        return FabricGraphEntity(
+            graphURL: url.absoluteString,
+            displayName: displayName,
+            graphIdentifier: graph.id.uuidString
+        )
+    }
+
+    private func makeNodeEntity(node: Node, graphURL: String) -> FabricNodeEntity {
+        FabricNodeEntity(
+            graphURL: graphURL,
+            nodeIdentifier: node.id.uuidString,
+            displayName: node.name,
+            nodeClassName: String(describing: type(of: node)),
+            nodeTypeDescription: node.nodeType.description
+        )
+    }
+
+    private func makePortEntity(port: Fabric.Port, graphURL: String) -> FabricPortEntity {
+        FabricPortEntity(
+            graphURL: graphURL,
+            nodeIdentifier: port.node?.id.uuidString ?? "",
+            portIdentifier: port.id.uuidString,
+            portName: port.name,
+            portDisplayName: port.displayName,
+            kind: port.kind.rawValue,
+            portType: port.portType.rawValue
+        )
+    }
+
+    private func makePublishedParameterEntity(parameter: any Parameter, port: Fabric.Port, graphURL: String) -> FabricPublishedParameterEntity {
+        FabricPublishedParameterEntity(
+            graphURL: graphURL,
+            parameterIdentifier: parameter.id.uuidString,
+            publishedPortIdentifier: port.id.uuidString,
+            label: port.displayName,
+            valueSummary: self.parameterValueSummary(parameter),
+            controlType: parameter.controlType.rawValue,
+            parameterType: port.portType.rawValue
+        )
+    }
+
+    private func makeRegistryNodeEntity(wrapper: NodeClassWrapper) -> FabricRegistryNodeEntity {
+        FabricRegistryNodeEntity(
+            nodeName: wrapper.nodeName,
+            nodeClassName: String(describing: wrapper.nodeClass),
+            nodeTypeDescription: wrapper.nodeType.description,
+            nodeDescription: wrapper.nodeDescription,
+            sourcePath: wrapper.fileURL?.path
+        )
+    }
+
+    private func parameterValueSummary(_ parameter: any Parameter) -> String {
+        if let parameter = parameter as? BoolParameter {
+            return String(parameter.value)
+        }
+
+        if let parameter = parameter as? GenericParameter<Bool> {
+            return String(parameter.value)
+        }
+
+        if let parameter = parameter as? IntParameter {
+            return String(parameter.value)
+        }
+
+        if let parameter = parameter as? GenericParameter<Int> {
+            return String(parameter.value)
+        }
+
+        if let parameter = parameter as? FloatParameter {
+            return String(parameter.value)
+        }
+
+        if let parameter = parameter as? GenericParameter<Float> {
+            return String(parameter.value)
+        }
+
+        if let parameter = parameter as? StringParameter {
+            return parameter.value
+        }
+
+        if let parameter = parameter as? GenericParameter<String> {
+            return parameter.value
+        }
+
+        if let parameter = parameter as? Float2Parameter {
+            return "\(parameter.value.x), \(parameter.value.y)"
+        }
+
+        if let parameter = parameter as? GenericParameter<simd_float2> {
+            return "\(parameter.value.x), \(parameter.value.y)"
+        }
+
+        if let parameter = parameter as? Float3Parameter {
+            return "\(parameter.value.x), \(parameter.value.y), \(parameter.value.z)"
+        }
+
+        if let parameter = parameter as? GenericParameter<simd_float3> {
+            return "\(parameter.value.x), \(parameter.value.y), \(parameter.value.z)"
+        }
+
+        if let parameter = parameter as? Float4Parameter {
+            return "\(parameter.value.x), \(parameter.value.y), \(parameter.value.z), \(parameter.value.w)"
+        }
+
+        if let parameter = parameter as? GenericParameter<simd_float4> {
+            return "\(parameter.value.x), \(parameter.value.y), \(parameter.value.z), \(parameter.value.w)"
+        }
+
+        return parameter.debugDescription
+    }
+}

--- a/Fabric Editor/AppIntents/FabricDocumentAutomationService.swift
+++ b/Fabric Editor/AppIntents/FabricDocumentAutomationService.swift
@@ -5,21 +5,24 @@
 //  Created by Codex on 4/7/26.
 //
 
+import AppIntents
 import AppKit
+import Fabric
 import Foundation
 import Metal
-import Fabric
 import Satin
 import simd
 
 enum FabricIntentError: LocalizedError {
+    case invalidGraphFile
     case invalidGraphURL(String)
     case unsupportedGraphFile(URL)
     case fileAlreadyExists(URL)
+    case graphHasNoFile(String)
     case nodeNotFound(String)
     case portNotFound(String)
+    case publishedParameterNotFound(String)
     case notAPublishedParameter(String)
-    case ambiguousPublishedParameter(String)
     case unsupportedParameterType(String)
     case invalidValue(String)
     case incompatiblePorts(String)
@@ -27,20 +30,24 @@ enum FabricIntentError: LocalizedError {
 
     var errorDescription: String? {
         switch self {
+        case .invalidGraphFile:
+            return "Select a valid Fabric graph file."
         case .invalidGraphURL(let value):
             return "Invalid graph URL: \(value)"
         case .unsupportedGraphFile(let url):
             return "Unsupported graph file: \(url.path)"
         case .fileAlreadyExists(let url):
             return "A graph already exists at \(url.path)"
+        case .graphHasNoFile(let name):
+            return "\(name) has not been saved to disk yet."
         case .nodeNotFound(let nodeID):
             return "Node not found: \(nodeID)"
         case .portNotFound(let portID):
             return "Port not found: \(portID)"
-        case .notAPublishedParameter(let label):
-            return "Published parameter not found: \(label)"
-        case .ambiguousPublishedParameter(let label):
-            return "Multiple published parameters match '\(label)'"
+        case .publishedParameterNotFound(let parameterID):
+            return "Published parameter not found: \(parameterID)"
+        case .notAPublishedParameter(let portID):
+            return "Port is not published: \(portID)"
         case .unsupportedParameterType(let label):
             return "Unsupported parameter type for '\(label)'"
         case .invalidValue(let description):
@@ -53,78 +60,87 @@ enum FabricIntentError: LocalizedError {
     }
 }
 
+enum FabricPortKindAppEnum: String, AppEnum {
+    case inlet
+    case outlet
+
+    static let typeDisplayRepresentation: TypeDisplayRepresentation = "Fabric Port Kind"
+    static let caseDisplayRepresentations: [Self: DisplayRepresentation] = [
+        .inlet: "Inlet",
+        .outlet: "Outlet",
+    ]
+
+    init?(portKind: PortKind) {
+        switch portKind {
+        case .Inlet:
+            self = .inlet
+        case .Outlet:
+            self = .outlet
+        }
+    }
+}
+
 @MainActor
 final class FabricDocumentAutomationService {
     static let shared = FabricDocumentAutomationService()
 
-    private init() {}
-
     struct LoadedGraph {
-        let url: URL
+        let fileURL: URL?
+        let graphURL: String
         let graph: Graph
     }
 
-    func createGraph(at graphURLString: String, useTemplate: Bool) throws -> FabricGraphEntity {
-        let url = try self.graphURL(from: graphURLString)
-        guard url.isFileURL else {
-            throw FabricIntentError.invalidGraphURL(graphURLString)
-        }
-        guard url.pathExtension.localizedCaseInsensitiveCompare("fabric") == .orderedSame else {
-            throw FabricIntentError.unsupportedGraphFile(url)
-        }
-        guard !FileManager.default.fileExists(atPath: url.path) else {
-            throw FabricIntentError.fileAlreadyExists(url)
-        }
+    private let untitledScheme = "fabric-untitled"
+    private var untitledGraphs: [String: Graph] = [:]
 
-        let parentURL = url.deletingLastPathComponent()
-        try FileManager.default.createDirectory(at: parentURL, withIntermediateDirectories: true, attributes: nil)
+    private init() {}
 
-        let document = useTemplate ? FabricDocument(withTemplate: true) : FabricDocument()
-        try self.saveGraph(document.editingContext.rootGraph, to: url)
+    func openGraph(file: IntentFile) throws -> FabricGraphEntity {
+        let url = try self.graphURL(from: file)
         NSWorkspace.shared.open(url)
-        return self.makeGraphEntity(graph: document.editingContext.rootGraph, url: url)
+        let loadedGraph = try self.loadGraph(at: url)
+        return self.makeGraphEntity(graph: loadedGraph.graph, fileURL: loadedGraph.fileURL)
     }
 
-    func openGraph(at graphURLString: String) throws -> FabricGraphEntity {
-        let loadedGraph = try self.loadGraph(at: graphURLString)
-        NSWorkspace.shared.open(loadedGraph.url)
-        return self.makeGraphEntity(graph: loadedGraph.graph, url: loadedGraph.url)
+    func createGraph(useTemplate: Bool) -> FabricGraphEntity {
+        let document = useTemplate ? FabricDocument(withTemplate: true) : FabricDocument()
+        let graph = document.editingContext.rootGraph
+        self.untitledGraphs[graph.id.uuidString] = graph
+        return self.makeGraphEntity(graph: graph, fileURL: nil)
     }
 
-    func graphSummary(for graphURLString: String) throws -> String {
-        let loadedGraph = try self.loadGraph(at: graphURLString)
-        let graph = loadedGraph.graph
-        let publishedCount = graph.getPublishedPorts().count
-        return "\(graph.nodes.count) nodes, \(publishedCount) published ports"
+    func graphDetails(for graphEntity: FabricGraphEntity) throws -> FabricGraphEntity {
+        let loadedGraph = try self.loadGraph(for: graphEntity)
+        return self.makeGraphEntity(graph: loadedGraph.graph, fileURL: loadedGraph.fileURL)
     }
 
-    func graphEntity(for graphURLString: String) throws -> FabricGraphEntity {
-        let loadedGraph = try self.loadGraph(at: graphURLString)
-        return self.makeGraphEntity(graph: loadedGraph.graph, url: loadedGraph.url)
+    func saveGraph(_ graphEntity: FabricGraphEntity) throws -> FabricGraphEntity {
+        let loadedGraph = try self.loadGraph(for: graphEntity)
+        let saveURL = if let fileURL = loadedGraph.fileURL {
+            fileURL
+        } else {
+            try self.defaultUntitledSaveURL()
+        }
+        try self.saveGraph(loadedGraph.graph, to: saveURL)
+        self.untitledGraphs.removeValue(forKey: loadedGraph.graph.id.uuidString)
+        return self.makeGraphEntity(graph: loadedGraph.graph, fileURL: saveURL)
     }
 
-    func listNodes(in graphURLString: String) throws -> [FabricNodeEntity] {
-        let loadedGraph = try self.loadGraph(at: graphURLString)
-        return loadedGraph.graph.nodes.map { self.makeNodeEntity(node: $0, graphURL: loadedGraph.url.absoluteString) }
+    func revealGraphFile(for graphEntity: FabricGraphEntity) throws -> IntentFile {
+        guard let url = try self.fileURL(for: graphEntity) else {
+            throw FabricIntentError.graphHasNoFile(graphEntity.displayName)
+        }
+        NSWorkspace.shared.activateFileViewerSelecting([url])
+        return IntentFile(fileURL: url)
     }
 
-    func listPublishedParameters(in graphURLString: String) throws -> [FabricPublishedParameterEntity] {
-        let loadedGraph = try self.loadGraph(at: graphURLString)
-        return loadedGraph.graph
-            .getPublishedPorts()
-            .compactMap { port in
-                guard let parameter = port.parameter else { return nil }
-                return self.makePublishedParameterEntity(
-                    parameter: parameter,
-                    port: port,
-                    graphURL: loadedGraph.url.absoluteString
-                )
-            }
+    func listRegistryNodes() -> [FabricRegistryNodeEntity] {
+        self.listRegistryNodes(matching: nil)
     }
 
     func listRegistryNodes(matching searchText: String?) -> [FabricRegistryNodeEntity] {
         let normalizedSearchText = searchText?.trimmingCharacters(in: .whitespacesAndNewlines)
-        return NodeRegistry.shared.availableNodes.compactMap { wrapper in
+        return NodeRegistry.shared.availableNodes.filter { wrapper in
             if let normalizedSearchText, !normalizedSearchText.isEmpty {
                 let haystack = [
                     wrapper.nodeName,
@@ -132,35 +148,124 @@ final class FabricDocumentAutomationService {
                     wrapper.nodeType.description,
                     wrapper.nodeDescription,
                 ]
-                let matches = haystack.contains { $0.localizedStandardContains(normalizedSearchText) }
-                if !matches {
-                    return nil
-                }
+                return haystack.contains { $0.localizedStandardContains(normalizedSearchText) }
             }
 
-            return self.makeRegistryNodeEntity(wrapper: wrapper)
+            return true
+        }
+        .map { self.makeRegistryNodeEntity(wrapper: $0) }
+    }
+
+    func registryNodeDetails(for registryNode: FabricRegistryNodeEntity) throws -> FabricRegistryNodeEntity {
+        let wrapper = try self.registryWrapper(for: registryNode)
+        return self.makeRegistryNodeEntity(wrapper: wrapper)
+    }
+
+    func listNodes(in graphEntity: FabricGraphEntity) throws -> [FabricNodeEntity] {
+        let loadedGraph = try self.loadGraph(for: graphEntity)
+        return loadedGraph.graph.nodes.map { self.makeNodeEntity(node: $0, graphURL: loadedGraph.graphURL) }
+    }
+
+    func findNodes(in graphEntity: FabricGraphEntity, matching searchText: String) throws -> [FabricNodeEntity] {
+        let loadedGraph = try self.loadGraph(for: graphEntity)
+        let normalizedSearchText = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        return loadedGraph.graph.nodes.compactMap { node in
+            guard !normalizedSearchText.isEmpty else {
+                return self.makeNodeEntity(node: node, graphURL: loadedGraph.graphURL)
+            }
+
+            let haystack = [
+                node.name,
+                String(describing: type(of: node)),
+                node.nodeType.description,
+            ]
+            let matches = haystack.contains { $0.localizedStandardContains(normalizedSearchText) }
+            return matches ? self.makeNodeEntity(node: node, graphURL: loadedGraph.graphURL) : nil
         }
     }
 
     func nodeDetails(for nodeEntity: FabricNodeEntity) throws -> FabricNodeEntity {
-        let loadedGraph = try self.loadGraph(at: nodeEntity.graphURL)
+        let loadedGraph = try self.loadGraph(forGraphURL: nodeEntity.graphURL)
         let node = try self.node(withIdentifier: nodeEntity.nodeIdentifier, in: loadedGraph.graph)
-        return self.makeNodeEntity(node: node, graphURL: loadedGraph.url.absoluteString)
+        return self.makeNodeEntity(node: node, graphURL: loadedGraph.graphURL)
     }
 
-    func ports(for nodeEntity: FabricNodeEntity) throws -> [FabricPortEntity] {
-        let loadedGraph = try self.loadGraph(at: nodeEntity.graphURL)
+    func listPorts(for nodeEntity: FabricNodeEntity) throws -> [FabricPortEntity] {
+        let loadedGraph = try self.loadGraph(forGraphURL: nodeEntity.graphURL)
         let node = try self.node(withIdentifier: nodeEntity.nodeIdentifier, in: loadedGraph.graph)
-        return node.ports.map { self.makePortEntity(port: $0, graphURL: loadedGraph.url.absoluteString) }
+        return node.ports.map { self.makePortEntity(port: $0, graphURL: loadedGraph.graphURL) }
+    }
+
+    func findPorts(
+        for nodeEntity: FabricNodeEntity,
+        matching searchText: String,
+        kind: FabricPortKindAppEnum?,
+        publishedOnly: Bool
+    ) throws -> [FabricPortEntity] {
+        let loadedGraph = try self.loadGraph(forGraphURL: nodeEntity.graphURL)
+        let node = try self.node(withIdentifier: nodeEntity.nodeIdentifier, in: loadedGraph.graph)
+        let normalizedSearchText = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        return node.ports.filter { port in
+            if publishedOnly, !port.published {
+                return false
+            }
+
+            if let kind, FabricPortKindAppEnum(portKind: port.kind) != kind {
+                return false
+            }
+
+            if !normalizedSearchText.isEmpty {
+                let haystack = [
+                    port.name,
+                    port.displayName,
+                    port.portType.rawValue,
+                ]
+                return haystack.contains { $0.localizedStandardContains(normalizedSearchText) }
+            }
+
+            return true
+        }
+        .map { self.makePortEntity(port: $0, graphURL: loadedGraph.graphURL) }
+    }
+
+    func listPublishedParameters(in graphEntity: FabricGraphEntity) throws -> [FabricPublishedParameterEntity] {
+        let loadedGraph = try self.loadGraph(for: graphEntity)
+        return self.publishedParameters(in: loadedGraph.graph, graphURL: loadedGraph.graphURL)
+    }
+
+    func findPublishedParameters(in graphEntity: FabricGraphEntity, matching searchText: String) throws -> [FabricPublishedParameterEntity] {
+        let loadedGraph = try self.loadGraph(for: graphEntity)
+        let normalizedSearchText = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        return self.publishedParameters(in: loadedGraph.graph, graphURL: loadedGraph.graphURL).filter { parameter in
+            guard !normalizedSearchText.isEmpty else { return true }
+            let haystack = [
+                parameter.label,
+                parameter.parameterType,
+                parameter.controlType,
+                parameter.valueSummary,
+            ]
+            return haystack.contains { $0.localizedStandardContains(normalizedSearchText) }
+        }
+    }
+
+    func publishedParameterDetails(for parameterEntity: FabricPublishedParameterEntity) throws -> FabricPublishedParameterEntity {
+        let loadedGraph = try self.loadGraph(forGraphURL: parameterEntity.graphURL)
+        let parameterPort = try self.publishedPort(withIdentifier: parameterEntity.publishedPortIdentifier, in: loadedGraph.graph)
+        guard let parameter = parameterPort.parameter else {
+            throw FabricIntentError.unsupportedParameterType(parameterEntity.label)
+        }
+        return self.makePublishedParameterEntity(parameter: parameter, port: parameterPort, graphURL: loadedGraph.graphURL)
     }
 
     func addNode(
         registryNode: FabricRegistryNodeEntity,
-        to graphURLString: String,
+        to graphEntity: FabricGraphEntity,
         x: Double?,
         y: Double?
     ) throws -> FabricNodeEntity {
-        let loadedGraph = try self.loadGraph(at: graphURLString)
+        let loadedGraph = try self.loadGraph(for: graphEntity)
         let wrapper = try self.registryWrapper(for: registryNode)
         let node = try wrapper.initializeNode(context: loadedGraph.graph.context)
 
@@ -169,80 +274,227 @@ final class FabricDocumentAutomationService {
         }
 
         loadedGraph.graph.addNode(node)
-        try self.saveGraph(loadedGraph.graph, to: loadedGraph.url)
-        return self.makeNodeEntity(node: node, graphURL: loadedGraph.url.absoluteString)
+        try self.persistGraph(loadedGraph)
+        return self.makeNodeEntity(node: node, graphURL: loadedGraph.graphURL)
     }
 
-    func connectPorts(from sourcePort: FabricPortEntity, to destinationPort: FabricPortEntity) throws -> String {
-        guard sourcePort.graphURL == destinationPort.graphURL else {
+    func removeNode(_ nodeEntity: FabricNodeEntity) throws -> FabricGraphEntity {
+        let loadedGraph = try self.loadGraph(forGraphURL: nodeEntity.graphURL)
+        let node = try self.node(withIdentifier: nodeEntity.nodeIdentifier, in: loadedGraph.graph)
+        loadedGraph.graph.delete(node: node)
+        try self.persistGraph(loadedGraph)
+        return self.makeGraphEntity(graph: loadedGraph.graph, fileURL: loadedGraph.fileURL)
+    }
+
+    func connectPorts(from sourcePortEntity: FabricPortEntity, to destinationPortEntity: FabricPortEntity) throws -> FabricGraphEntity {
+        guard sourcePortEntity.graphURL == destinationPortEntity.graphURL else {
             throw FabricIntentError.incompatiblePorts("Ports must belong to the same graph")
         }
 
-        let loadedGraph = try self.loadGraph(at: sourcePort.graphURL)
-        let source = try self.port(withIdentifier: sourcePort.portIdentifier, in: loadedGraph.graph)
-        let destination = try self.port(withIdentifier: destinationPort.portIdentifier, in: loadedGraph.graph)
+        let loadedGraph = try self.loadGraph(forGraphURL: sourcePortEntity.graphURL)
+        let source = try self.port(withIdentifier: sourcePortEntity.portIdentifier, in: loadedGraph.graph)
+        let destination = try self.port(withIdentifier: destinationPortEntity.portIdentifier, in: loadedGraph.graph)
 
         guard source.kind == .Outlet, destination.kind == .Inlet else {
             throw FabricIntentError.incompatiblePorts("Connect an outlet source to an inlet destination")
         }
 
-        if !source.canConnect(to: destination) {
+        guard source.canConnect(to: destination) else {
             throw FabricIntentError.incompatiblePorts("\(source.displayName) cannot connect to \(destination.displayName)")
         }
 
         source.connect(to: destination)
         loadedGraph.graph.rebuildPublishedParameterGroup()
-        try self.saveGraph(loadedGraph.graph, to: loadedGraph.url)
-
-        return "Connected \(source.displayName) to \(destination.displayName)"
+        try self.persistGraph(loadedGraph)
+        return self.makeGraphEntity(graph: loadedGraph.graph, fileURL: loadedGraph.fileURL)
     }
 
-    func disconnectPorts(from sourcePort: FabricPortEntity, to destinationPort: FabricPortEntity?) throws -> String {
-        let loadedGraph = try self.loadGraph(at: sourcePort.graphURL)
-        let source = try self.port(withIdentifier: sourcePort.portIdentifier, in: loadedGraph.graph)
+    func disconnectPorts(from sourcePortEntity: FabricPortEntity, to destinationPortEntity: FabricPortEntity?) throws -> FabricGraphEntity {
+        let loadedGraph = try self.loadGraph(forGraphURL: sourcePortEntity.graphURL)
+        let source = try self.port(withIdentifier: sourcePortEntity.portIdentifier, in: loadedGraph.graph)
 
-        if let destinationPort {
-            let destination = try self.port(withIdentifier: destinationPort.portIdentifier, in: loadedGraph.graph)
+        if let destinationPortEntity {
+            let destination = try self.port(withIdentifier: destinationPortEntity.portIdentifier, in: loadedGraph.graph)
             source.disconnect(from: destination)
         } else {
             source.disconnectAll()
         }
 
         loadedGraph.graph.rebuildPublishedParameterGroup()
-        try self.saveGraph(loadedGraph.graph, to: loadedGraph.url)
-
-        return destinationPort == nil
-            ? "Disconnected all connections from \(source.displayName)"
-            : "Disconnected \(source.displayName)"
+        try self.persistGraph(loadedGraph)
+        return self.makeGraphEntity(graph: loadedGraph.graph, fileURL: loadedGraph.fileURL)
     }
 
-    func setPublishedParameters(_ assignments: [String], in graphURLString: String) throws -> [FabricPublishedParameterEntity] {
-        let loadedGraph = try self.loadGraph(at: graphURLString)
+    func publishPort(_ portEntity: FabricPortEntity, label: String?) throws -> FabricPublishedParameterEntity {
+        let loadedGraph = try self.loadGraph(forGraphURL: portEntity.graphURL)
+        let port = try self.port(withIdentifier: portEntity.portIdentifier, in: loadedGraph.graph)
+        port.published = true
 
-        for assignment in assignments {
-            let trimmedAssignment = assignment.trimmingCharacters(in: .whitespacesAndNewlines)
-            if trimmedAssignment.isEmpty {
-                continue
-            }
-
-            let pair = try self.parseAssignment(trimmedAssignment)
-            let port = try self.publishedPort(label: pair.label, in: loadedGraph.graph)
-            let parameter = try self.parameter(forPublishedPort: port, label: pair.label)
-            try self.apply(rawValue: pair.value, to: parameter, label: pair.label)
-        }
+        let trimmedLabel = label?.trimmingCharacters(in: .whitespacesAndNewlines)
+        port.publishedName = trimmedLabel?.isEmpty == false ? trimmedLabel : nil
 
         loadedGraph.graph.rebuildPublishedParameterGroup()
-        try self.saveGraph(loadedGraph.graph, to: loadedGraph.url)
-        return try self.listPublishedParameters(in: loadedGraph.url.absoluteString)
+        try self.persistGraph(loadedGraph)
+
+        guard let parameter = port.parameter else {
+            throw FabricIntentError.unsupportedParameterType(port.displayName)
+        }
+
+        return self.makePublishedParameterEntity(parameter: parameter, port: port, graphURL: loadedGraph.graphURL)
     }
 
-    private func loadGraph(at graphURLString: String) throws -> LoadedGraph {
-        let url = try self.graphURL(from: graphURLString)
+    func unpublishPort(_ portEntity: FabricPortEntity) throws -> FabricGraphEntity {
+        let loadedGraph = try self.loadGraph(forGraphURL: portEntity.graphURL)
+        let port = try self.port(withIdentifier: portEntity.portIdentifier, in: loadedGraph.graph)
+        port.published = false
+        port.publishedName = nil
+        loadedGraph.graph.rebuildPublishedParameterGroup()
+        try self.persistGraph(loadedGraph)
+        return self.makeGraphEntity(graph: loadedGraph.graph, fileURL: loadedGraph.fileURL)
+    }
+
+    func unpublishParameter(_ parameterEntity: FabricPublishedParameterEntity) throws -> FabricGraphEntity {
+        let loadedGraph = try self.loadGraph(forGraphURL: parameterEntity.graphURL)
+        let port = try self.publishedPort(withIdentifier: parameterEntity.publishedPortIdentifier, in: loadedGraph.graph)
+        port.published = false
+        port.publishedName = nil
+        loadedGraph.graph.rebuildPublishedParameterGroup()
+        try self.persistGraph(loadedGraph)
+        return self.makeGraphEntity(graph: loadedGraph.graph, fileURL: loadedGraph.fileURL)
+    }
+
+    func setPublishedBoolean(_ parameterEntity: FabricPublishedParameterEntity, value: Bool) throws -> FabricPublishedParameterEntity {
+        let loadedGraph = try self.loadGraph(forGraphURL: parameterEntity.graphURL)
+        let publishedPort = try self.publishedPort(withIdentifier: parameterEntity.publishedPortIdentifier, in: loadedGraph.graph)
+        let parameter = try self.parameter(forPublishedPort: publishedPort, label: parameterEntity.label)
+        guard let boolParameter = parameter as? BoolParameter else {
+            throw FabricIntentError.unsupportedParameterType(parameterEntity.label)
+        }
+        boolParameter.value = value
+        return try self.persistParameterUpdate(graph: loadedGraph, publishedPort: publishedPort, label: parameterEntity.label)
+    }
+
+    func setPublishedNumber(_ parameterEntity: FabricPublishedParameterEntity, value: Double) throws -> FabricPublishedParameterEntity {
+        let loadedGraph = try self.loadGraph(forGraphURL: parameterEntity.graphURL)
+        let publishedPort = try self.publishedPort(withIdentifier: parameterEntity.publishedPortIdentifier, in: loadedGraph.graph)
+        let parameter = try self.parameter(forPublishedPort: publishedPort, label: parameterEntity.label)
+
+        if let floatParameter = parameter as? FloatParameter {
+            floatParameter.value = Float(value)
+        } else if let doubleParameter = parameter as? DoubleParameter {
+            doubleParameter.value = value
+        } else {
+            throw FabricIntentError.unsupportedParameterType(parameterEntity.label)
+        }
+
+        return try self.persistParameterUpdate(graph: loadedGraph, publishedPort: publishedPort, label: parameterEntity.label)
+    }
+
+    func setPublishedInteger(_ parameterEntity: FabricPublishedParameterEntity, value: Int) throws -> FabricPublishedParameterEntity {
+        let loadedGraph = try self.loadGraph(forGraphURL: parameterEntity.graphURL)
+        let publishedPort = try self.publishedPort(withIdentifier: parameterEntity.publishedPortIdentifier, in: loadedGraph.graph)
+        let parameter = try self.parameter(forPublishedPort: publishedPort, label: parameterEntity.label)
+
+        if let intParameter = parameter as? IntParameter {
+            intParameter.value = value
+        } else {
+            throw FabricIntentError.unsupportedParameterType(parameterEntity.label)
+        }
+
+        return try self.persistParameterUpdate(graph: loadedGraph, publishedPort: publishedPort, label: parameterEntity.label)
+    }
+
+    func setPublishedText(_ parameterEntity: FabricPublishedParameterEntity, value: String) throws -> FabricPublishedParameterEntity {
+        let loadedGraph = try self.loadGraph(forGraphURL: parameterEntity.graphURL)
+        let publishedPort = try self.publishedPort(withIdentifier: parameterEntity.publishedPortIdentifier, in: loadedGraph.graph)
+        let parameter = try self.parameter(forPublishedPort: publishedPort, label: parameterEntity.label)
+
+        if let stringParameter = parameter as? StringParameter {
+            stringParameter.value = value
+        } else {
+            throw FabricIntentError.unsupportedParameterType(parameterEntity.label)
+        }
+
+        return try self.persistParameterUpdate(graph: loadedGraph, publishedPort: publishedPort, label: parameterEntity.label)
+    }
+
+    func setPublishedVector(_ parameterEntity: FabricPublishedParameterEntity, components: [Double]) throws -> FabricPublishedParameterEntity {
+        let loadedGraph = try self.loadGraph(forGraphURL: parameterEntity.graphURL)
+        let publishedPort = try self.publishedPort(withIdentifier: parameterEntity.publishedPortIdentifier, in: loadedGraph.graph)
+        let parameter = try self.parameter(forPublishedPort: publishedPort, label: parameterEntity.label)
+
+        if let float2Parameter = parameter as? Float2Parameter {
+            guard components.count == 2 else {
+                throw FabricIntentError.invalidValue("Expected 2 components")
+            }
+            float2Parameter.value = simd_float2(Float(components[0]), Float(components[1]))
+        } else if let float3Parameter = parameter as? Float3Parameter {
+            guard components.count == 3 else {
+                throw FabricIntentError.invalidValue("Expected 3 components")
+            }
+            float3Parameter.value = simd_float3(Float(components[0]), Float(components[1]), Float(components[2]))
+        } else if let float4Parameter = parameter as? Float4Parameter {
+            guard components.count == 4 else {
+                throw FabricIntentError.invalidValue("Expected 4 components")
+            }
+            float4Parameter.value = simd_float4(Float(components[0]), Float(components[1]), Float(components[2]), Float(components[3]))
+        } else {
+            throw FabricIntentError.unsupportedParameterType(parameterEntity.label)
+        }
+
+        return try self.persistParameterUpdate(graph: loadedGraph, publishedPort: publishedPort, label: parameterEntity.label)
+    }
+
+    private func persistParameterUpdate(
+        graph loadedGraph: LoadedGraph,
+        publishedPort: Fabric.Port,
+        label: String
+    ) throws -> FabricPublishedParameterEntity {
+        loadedGraph.graph.rebuildPublishedParameterGroup()
+        try self.persistGraph(loadedGraph)
+        let refreshedPort = try self.publishedPort(withIdentifier: publishedPort.id.uuidString, in: loadedGraph.graph)
+        guard let refreshedParameter = refreshedPort.parameter else {
+            throw FabricIntentError.unsupportedParameterType(label)
+        }
+        return self.makePublishedParameterEntity(parameter: refreshedParameter, port: refreshedPort, graphURL: loadedGraph.graphURL)
+    }
+
+    private func publishedParameters(in graph: Graph, graphURL: String) -> [FabricPublishedParameterEntity] {
+        graph.getPublishedPorts().compactMap { port in
+            guard let parameter = port.parameter else { return nil }
+            return self.makePublishedParameterEntity(parameter: parameter, port: port, graphURL: graphURL)
+        }
+    }
+
+    private func loadGraph(for graphEntity: FabricGraphEntity) throws -> LoadedGraph {
+        if let graph = self.untitledGraphs[graphEntity.graphIdentifier] {
+            return LoadedGraph(fileURL: nil, graphURL: self.untitledGraphURL(for: graph.id), graph: graph)
+        }
+        return try self.loadGraph(forGraphURL: graphEntity.graphURL)
+    }
+
+    private func loadGraph(forGraphURL graphURL: String) throws -> LoadedGraph {
+        if let untitledGraph = self.untitledGraph(for: graphURL) {
+            return LoadedGraph(fileURL: nil, graphURL: graphURL, graph: untitledGraph)
+        }
+        let url = try self.graphURL(from: graphURL)
+        return try self.loadGraph(at: url)
+    }
+
+    private func loadGraph(at url: URL) throws -> LoadedGraph {
         let data = try Data(contentsOf: url)
         let decoder = JSONDecoder()
         decoder.context = DecoderContext(documentContext: self.makeContext())
         let graph = try decoder.decode(Graph.self, from: data)
-        return LoadedGraph(url: url, graph: graph)
+        return LoadedGraph(fileURL: url, graphURL: url.absoluteString, graph: graph)
+    }
+
+    private func persistGraph(_ loadedGraph: LoadedGraph) throws {
+        if let fileURL = loadedGraph.fileURL {
+            try self.saveGraph(loadedGraph.graph, to: fileURL)
+        } else {
+            self.untitledGraphs[loadedGraph.graph.id.uuidString] = loadedGraph.graph
+        }
     }
 
     private func saveGraph(_ graph: Graph, to url: URL) throws {
@@ -262,6 +514,14 @@ final class FabricDocumentAutomationService {
         )
     }
 
+    private func graphURL(from file: IntentFile) throws -> URL {
+        guard let fileURL = file.fileURL else {
+            throw FabricIntentError.invalidGraphFile
+        }
+
+        return try self.validateGraphURL(fileURL)
+    }
+
     private func graphURL(from graphURLString: String) throws -> URL {
         let trimmedValue = graphURLString.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedValue.isEmpty else {
@@ -269,10 +529,57 @@ final class FabricDocumentAutomationService {
         }
 
         if let url = URL(string: trimmedValue), url.scheme != nil {
-            return url.standardizedFileURL
+            return try self.validateGraphURL(url.standardizedFileURL)
         }
 
-        return URL(fileURLWithPath: trimmedValue).standardizedFileURL
+        return try self.validateGraphURL(URL(fileURLWithPath: trimmedValue).standardizedFileURL)
+    }
+
+    private func fileURL(for graphEntity: FabricGraphEntity) throws -> URL? {
+        if self.untitledGraphs[graphEntity.graphIdentifier] != nil {
+            return nil
+        }
+        return try self.graphURL(from: graphEntity.graphURL)
+    }
+
+    private func untitledGraphURL(for graphID: UUID) -> String {
+        "\(self.untitledScheme)://\(graphID.uuidString)"
+    }
+
+    private func untitledGraph(for graphURL: String) -> Graph? {
+        guard
+            let url = URL(string: graphURL),
+            url.scheme == self.untitledScheme,
+            let host = url.host(percentEncoded: false) ?? url.host()
+        else {
+            return nil
+        }
+
+        return self.untitledGraphs[host]
+    }
+
+    private func defaultUntitledSaveURL() throws -> URL {
+        let baseDirectory = URL.documentsDirectory
+        let fileManager = FileManager.default
+        var candidateURL = baseDirectory.appending(path: "Untitled.fabric")
+        var suffix = 2
+
+        while fileManager.fileExists(atPath: candidateURL.path) {
+            candidateURL = baseDirectory.appending(path: "Untitled \(suffix).fabric")
+            suffix += 1
+        }
+
+        return candidateURL
+    }
+
+    private func validateGraphURL(_ url: URL) throws -> URL {
+        guard url.isFileURL else {
+            throw FabricIntentError.invalidGraphURL(url.absoluteString)
+        }
+        guard url.pathExtension.localizedCaseInsensitiveCompare("fabric") == .orderedSame else {
+            throw FabricIntentError.unsupportedGraphFile(url)
+        }
+        return url
     }
 
     private func node(withIdentifier nodeIdentifier: String, in graph: Graph) throws -> Node {
@@ -289,28 +596,12 @@ final class FabricDocumentAutomationService {
         return port
     }
 
-    private func publishedPort(label: String, in graph: Graph) throws -> Fabric.Port {
-        let matches = graph
-            .getPublishedPorts()
-            .filter { $0.displayName.localizedStandardContains(label) || $0.displayName == label || $0.name == label }
-
-        if matches.isEmpty {
-            throw FabricIntentError.notAPublishedParameter(label)
+    private func publishedPort(withIdentifier portIdentifier: String, in graph: Graph) throws -> Fabric.Port {
+        let port = try self.port(withIdentifier: portIdentifier, in: graph)
+        guard port.published else {
+            throw FabricIntentError.notAPublishedParameter(portIdentifier)
         }
-
-        if matches.count > 1 {
-            let exactMatches = matches.filter { $0.displayName == label || $0.name == label }
-            if exactMatches.count == 1, let exactMatch = exactMatches.first {
-                return exactMatch
-            }
-            throw FabricIntentError.ambiguousPublishedParameter(label)
-        }
-
-        guard let match = matches.first else {
-            throw FabricIntentError.notAPublishedParameter(label)
-        }
-
-        return match
+        return port
     }
 
     private func parameter(forPublishedPort port: Fabric.Port, label: String) throws -> any Parameter {
@@ -320,160 +611,25 @@ final class FabricDocumentAutomationService {
         return parameter
     }
 
-    private func parseAssignment(_ assignment: String) throws -> (label: String, value: String) {
-        guard let delimiterIndex = assignment.firstIndex(of: "=") else {
-            throw FabricIntentError.invalidValue("Use Label=Value format")
+    private func registryWrapper(for registryNode: FabricRegistryNodeEntity) throws -> NodeClassWrapper {
+        guard let wrapper = NodeRegistry.shared.availableNodes.first(where: { node in
+            node.nodeName == registryNode.nodeName &&
+            String(describing: node.nodeClass) == registryNode.nodeClassName
+        }) else {
+            throw FabricIntentError.registryNodeNotFound(registryNode.nodeName)
         }
 
-        let label = String(assignment[..<delimiterIndex]).trimmingCharacters(in: .whitespacesAndNewlines)
-        let valueStartIndex = assignment.index(after: delimiterIndex)
-        let value = String(assignment[valueStartIndex...]).trimmingCharacters(in: .whitespacesAndNewlines)
-
-        guard !label.isEmpty else {
-            throw FabricIntentError.invalidValue("Missing parameter label")
-        }
-
-        return (label, value)
+        return wrapper
     }
 
-    private func parseFloatComponents(_ rawValue: String, expectedCount: Int) throws -> [Float] {
-        let components = rawValue
-            .split(separator: ",")
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-
-        guard components.count == expectedCount else {
-            throw FabricIntentError.invalidValue("Expected \(expectedCount) comma-separated values")
-        }
-
-        let numbers = try components.map { component -> Float in
-            guard let value = Float(component) else {
-                throw FabricIntentError.invalidValue("'\(component)' is not a number")
-            }
-            return value
-        }
-
-        return numbers
-    }
-
-    private func apply(rawValue: String, to parameter: any Parameter, label: String) throws {
-        if let parameter = parameter as? BoolParameter {
-            guard let value = Bool(rawValue) else {
-                throw FabricIntentError.invalidValue("'\(rawValue)' is not a Bool")
-            }
-            parameter.value = value
-            return
-        }
-
-        if let parameter = parameter as? GenericParameter<Bool> {
-            guard let value = Bool(rawValue) else {
-                throw FabricIntentError.invalidValue("'\(rawValue)' is not a Bool")
-            }
-            parameter.value = value
-            return
-        }
-
-        if let parameter = parameter as? IntParameter {
-            guard let value = Int(rawValue) else {
-                throw FabricIntentError.invalidValue("'\(rawValue)' is not an Int")
-            }
-            parameter.value = value
-            return
-        }
-
-        if let parameter = parameter as? GenericParameter<Int> {
-            guard let value = Int(rawValue) else {
-                throw FabricIntentError.invalidValue("'\(rawValue)' is not an Int")
-            }
-            parameter.value = value
-            return
-        }
-
-        if let parameter = parameter as? FloatParameter {
-            guard let value = Float(rawValue) else {
-                throw FabricIntentError.invalidValue("'\(rawValue)' is not a Float")
-            }
-            parameter.value = value
-            return
-        }
-
-        if let parameter = parameter as? GenericParameter<Float> {
-            guard let value = Float(rawValue) else {
-                throw FabricIntentError.invalidValue("'\(rawValue)' is not a Float")
-            }
-            parameter.value = value
-            return
-        }
-
-        if let parameter = parameter as? StringParameter {
-            parameter.value = rawValue
-            return
-        }
-
-        if let parameter = parameter as? GenericParameter<String> {
-            parameter.value = rawValue
-            return
-        }
-
-        if let parameter = parameter as? Float2Parameter {
-            let values = try self.parseFloatComponents(rawValue, expectedCount: 2)
-            parameter.value = simd_float2(values[0], values[1])
-            return
-        }
-
-        if let parameter = parameter as? GenericParameter<simd_float2> {
-            let values = try self.parseFloatComponents(rawValue, expectedCount: 2)
-            parameter.value = simd_float2(values[0], values[1])
-            return
-        }
-
-        if let parameter = parameter as? Float3Parameter {
-            let values = try self.parseFloatComponents(rawValue, expectedCount: 3)
-            parameter.value = simd_float3(values[0], values[1], values[2])
-            return
-        }
-
-        if let parameter = parameter as? GenericParameter<simd_float3> {
-            let values = try self.parseFloatComponents(rawValue, expectedCount: 3)
-            parameter.value = simd_float3(values[0], values[1], values[2])
-            return
-        }
-
-        if let parameter = parameter as? Float4Parameter {
-            let values = try self.parseFloatComponents(rawValue, expectedCount: 4)
-            parameter.value = simd_float4(values[0], values[1], values[2], values[3])
-            return
-        }
-
-        if let parameter = parameter as? GenericParameter<simd_float4> {
-            let values = try self.parseFloatComponents(rawValue, expectedCount: 4)
-            parameter.value = simd_float4(values[0], values[1], values[2], values[3])
-            return
-        }
-
-        throw FabricIntentError.unsupportedParameterType(label)
-    }
-
-    private func registryWrapper(for entity: FabricRegistryNodeEntity) throws -> NodeClassWrapper {
-        let matchingWrapper = NodeRegistry.shared.availableNodes.first { wrapper in
-            String(describing: wrapper.nodeClass) == entity.nodeClassName
-                && wrapper.nodeName == entity.nodeName
-                && wrapper.fileURL?.path == entity.sourcePath
-        }
-
-        guard let matchingWrapper else {
-            throw FabricIntentError.registryNodeNotFound(entity.nodeName)
-        }
-
-        return matchingWrapper
-    }
-
-    private func makeGraphEntity(graph: Graph, url: URL) -> FabricGraphEntity {
-        let displayName = url.deletingPathExtension().lastPathComponent
+    private func makeGraphEntity(graph: Graph, fileURL: URL?) -> FabricGraphEntity {
+        let publishedParameterCount = graph.getPublishedPorts().count
         return FabricGraphEntity(
-            graphURL: url.absoluteString,
-            displayName: displayName,
-            graphIdentifier: graph.id.uuidString
+            graphURL: fileURL?.absoluteString ?? self.untitledGraphURL(for: graph.id),
+            displayName: fileURL?.deletingPathExtension().lastPathComponent ?? "Untitled",
+            graphIdentifier: graph.id.uuidString,
+            nodeCount: graph.nodes.count,
+            publishedParameterCount: publishedParameterCount
         )
     }
 
@@ -495,18 +651,24 @@ final class FabricDocumentAutomationService {
             portName: port.name,
             portDisplayName: port.displayName,
             kind: port.kind.rawValue,
-            portType: port.portType.rawValue
+            portType: port.portType.rawValue,
+            isPublished: port.published,
+            connectionCount: port.connections.count
         )
     }
 
-    private func makePublishedParameterEntity(parameter: any Parameter, port: Fabric.Port, graphURL: String) -> FabricPublishedParameterEntity {
+    private func makePublishedParameterEntity(
+        parameter: any Parameter,
+        port: Fabric.Port,
+        graphURL: String
+    ) -> FabricPublishedParameterEntity {
         FabricPublishedParameterEntity(
             graphURL: graphURL,
             parameterIdentifier: parameter.id.uuidString,
             publishedPortIdentifier: port.id.uuidString,
             label: port.displayName,
             valueSummary: self.parameterValueSummary(parameter),
-            controlType: parameter.controlType.rawValue,
+            controlType: String(describing: type(of: parameter)),
             parameterType: port.portType.rawValue
         )
     }
@@ -522,62 +684,31 @@ final class FabricDocumentAutomationService {
     }
 
     private func parameterValueSummary(_ parameter: any Parameter) -> String {
-        if let parameter = parameter as? BoolParameter {
-            return String(parameter.value)
-        }
-
-        if let parameter = parameter as? GenericParameter<Bool> {
-            return String(parameter.value)
-        }
-
-        if let parameter = parameter as? IntParameter {
-            return String(parameter.value)
-        }
-
-        if let parameter = parameter as? GenericParameter<Int> {
-            return String(parameter.value)
-        }
-
-        if let parameter = parameter as? FloatParameter {
-            return String(parameter.value)
-        }
-
-        if let parameter = parameter as? GenericParameter<Float> {
-            return String(parameter.value)
-        }
-
-        if let parameter = parameter as? StringParameter {
+        switch parameter {
+        case let parameter as BoolParameter:
+            return parameter.value.description
+        case let parameter as IntParameter:
+            return parameter.value.description
+        case let parameter as FloatParameter:
+            return parameter.value.formatted(.number.precision(.fractionLength(3)))
+        case let parameter as DoubleParameter:
+            return parameter.value.formatted(.number.precision(.fractionLength(3)))
+        case let parameter as StringParameter:
             return parameter.value
+        case let parameter as Float2Parameter:
+            return [parameter.value.x, parameter.value.y]
+                .map { $0.formatted(.number.precision(.fractionLength(3))) }
+                .joined(separator: ", ")
+        case let parameter as Float3Parameter:
+            return [parameter.value.x, parameter.value.y, parameter.value.z]
+                .map { $0.formatted(.number.precision(.fractionLength(3))) }
+                .joined(separator: ", ")
+        case let parameter as Float4Parameter:
+            return [parameter.value.x, parameter.value.y, parameter.value.z, parameter.value.w]
+                .map { $0.formatted(.number.precision(.fractionLength(3))) }
+                .joined(separator: ", ")
+        default:
+            return parameter.description
         }
-
-        if let parameter = parameter as? GenericParameter<String> {
-            return parameter.value
-        }
-
-        if let parameter = parameter as? Float2Parameter {
-            return "\(parameter.value.x), \(parameter.value.y)"
-        }
-
-        if let parameter = parameter as? GenericParameter<simd_float2> {
-            return "\(parameter.value.x), \(parameter.value.y)"
-        }
-
-        if let parameter = parameter as? Float3Parameter {
-            return "\(parameter.value.x), \(parameter.value.y), \(parameter.value.z)"
-        }
-
-        if let parameter = parameter as? GenericParameter<simd_float3> {
-            return "\(parameter.value.x), \(parameter.value.y), \(parameter.value.z)"
-        }
-
-        if let parameter = parameter as? Float4Parameter {
-            return "\(parameter.value.x), \(parameter.value.y), \(parameter.value.z), \(parameter.value.w)"
-        }
-
-        if let parameter = parameter as? GenericParameter<simd_float4> {
-            return "\(parameter.value.x), \(parameter.value.y), \(parameter.value.z), \(parameter.value.w)"
-        }
-
-        return parameter.debugDescription
     }
 }

--- a/Fabric Editor/AppIntents/FabricIntentEntities.swift
+++ b/Fabric Editor/AppIntents/FabricIntentEntities.swift
@@ -1,0 +1,397 @@
+//
+//  FabricIntentEntities.swift
+//  Fabric Editor
+//
+//  Created by Codex on 4/7/26.
+//
+
+import AppIntents
+import Foundation
+
+enum FabricIntentIdentifierCodec {
+    static func encode(_ payload: [String: String]) -> String {
+        let data = try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+        return data?.base64EncodedString() ?? ""
+    }
+
+    static func decode(_ identifier: String) -> [String: String] {
+        guard
+            let data = Data(base64Encoded: identifier),
+            let object = try? JSONSerialization.jsonObject(with: data),
+            let payload = object as? [String: String]
+        else {
+            return [:]
+        }
+
+        return payload
+    }
+}
+
+struct FabricGraphEntity: AppEntity, Sendable {
+    static let typeDisplayRepresentation: TypeDisplayRepresentation = "Fabric Graph"
+    static let defaultQuery = FabricGraphEntityQuery()
+
+    let id: String
+    let graphURL: String
+    let displayName: String
+    let graphIdentifier: String
+
+    var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(
+            title: LocalizedStringResource(stringLiteral: self.displayName),
+            subtitle: LocalizedStringResource(stringLiteral: self.graphURL)
+        )
+    }
+
+    init(graphURL: String, displayName: String, graphIdentifier: String) {
+        self.graphURL = graphURL
+        self.displayName = displayName
+        self.graphIdentifier = graphIdentifier
+        self.id = FabricIntentIdentifierCodec.encode([
+            "kind": "graph",
+            "graphURL": graphURL,
+            "displayName": displayName,
+            "graphIdentifier": graphIdentifier,
+        ])
+    }
+
+    fileprivate init?(id: String) {
+        let payload = FabricIntentIdentifierCodec.decode(id)
+        guard
+            payload["kind"] == "graph",
+            let graphURL = payload["graphURL"],
+            let displayName = payload["displayName"],
+            let graphIdentifier = payload["graphIdentifier"]
+        else {
+            return nil
+        }
+
+        self.id = id
+        self.graphURL = graphURL
+        self.displayName = displayName
+        self.graphIdentifier = graphIdentifier
+    }
+}
+
+struct FabricNodeEntity: AppEntity, Sendable {
+    static let typeDisplayRepresentation: TypeDisplayRepresentation = "Fabric Node"
+    static let defaultQuery = FabricNodeEntityQuery()
+
+    let id: String
+    let graphURL: String
+    let nodeIdentifier: String
+    let displayName: String
+    let nodeClassName: String
+    let nodeTypeDescription: String
+
+    var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(
+            title: LocalizedStringResource(stringLiteral: self.displayName),
+            subtitle: LocalizedStringResource(stringLiteral: "\(self.nodeTypeDescription) • \(self.nodeClassName)")
+        )
+    }
+
+    init(
+        graphURL: String,
+        nodeIdentifier: String,
+        displayName: String,
+        nodeClassName: String,
+        nodeTypeDescription: String
+    ) {
+        self.graphURL = graphURL
+        self.nodeIdentifier = nodeIdentifier
+        self.displayName = displayName
+        self.nodeClassName = nodeClassName
+        self.nodeTypeDescription = nodeTypeDescription
+        self.id = FabricIntentIdentifierCodec.encode([
+            "kind": "node",
+            "graphURL": graphURL,
+            "nodeIdentifier": nodeIdentifier,
+            "displayName": displayName,
+            "nodeClassName": nodeClassName,
+            "nodeTypeDescription": nodeTypeDescription,
+        ])
+    }
+
+    fileprivate init?(id: String) {
+        let payload = FabricIntentIdentifierCodec.decode(id)
+        guard
+            payload["kind"] == "node",
+            let graphURL = payload["graphURL"],
+            let nodeIdentifier = payload["nodeIdentifier"],
+            let displayName = payload["displayName"],
+            let nodeClassName = payload["nodeClassName"],
+            let nodeTypeDescription = payload["nodeTypeDescription"]
+        else {
+            return nil
+        }
+
+        self.id = id
+        self.graphURL = graphURL
+        self.nodeIdentifier = nodeIdentifier
+        self.displayName = displayName
+        self.nodeClassName = nodeClassName
+        self.nodeTypeDescription = nodeTypeDescription
+    }
+}
+
+struct FabricPortEntity: AppEntity, Sendable {
+    static let typeDisplayRepresentation: TypeDisplayRepresentation = "Fabric Port"
+    static let defaultQuery = FabricPortEntityQuery()
+
+    let id: String
+    let graphURL: String
+    let nodeIdentifier: String
+    let portIdentifier: String
+    let portName: String
+    let portDisplayName: String
+    let kind: String
+    let portType: String
+
+    var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(
+            title: LocalizedStringResource(stringLiteral: self.portDisplayName),
+            subtitle: LocalizedStringResource(stringLiteral: "\(self.kind) • \(self.portType)")
+        )
+    }
+
+    init(
+        graphURL: String,
+        nodeIdentifier: String,
+        portIdentifier: String,
+        portName: String,
+        portDisplayName: String,
+        kind: String,
+        portType: String
+    ) {
+        self.graphURL = graphURL
+        self.nodeIdentifier = nodeIdentifier
+        self.portIdentifier = portIdentifier
+        self.portName = portName
+        self.portDisplayName = portDisplayName
+        self.kind = kind
+        self.portType = portType
+        self.id = FabricIntentIdentifierCodec.encode([
+            "kind": "port",
+            "graphURL": graphURL,
+            "nodeIdentifier": nodeIdentifier,
+            "portIdentifier": portIdentifier,
+            "portName": portName,
+            "portDisplayName": portDisplayName,
+            "portKind": kind,
+            "portType": portType,
+        ])
+    }
+
+    fileprivate init?(id: String) {
+        let payload = FabricIntentIdentifierCodec.decode(id)
+        guard
+            payload["kind"] == "port",
+            let graphURL = payload["graphURL"],
+            let nodeIdentifier = payload["nodeIdentifier"],
+            let portIdentifier = payload["portIdentifier"],
+            let portName = payload["portName"],
+            let portDisplayName = payload["portDisplayName"],
+            let kind = payload["portKind"],
+            let portType = payload["portType"]
+        else {
+            return nil
+        }
+
+        self.id = id
+        self.graphURL = graphURL
+        self.nodeIdentifier = nodeIdentifier
+        self.portIdentifier = portIdentifier
+        self.portName = portName
+        self.portDisplayName = portDisplayName
+        self.kind = kind
+        self.portType = portType
+    }
+}
+
+struct FabricPublishedParameterEntity: AppEntity, Sendable {
+    static let typeDisplayRepresentation: TypeDisplayRepresentation = "Fabric Published Parameter"
+    static let defaultQuery = FabricPublishedParameterEntityQuery()
+
+    let id: String
+    let graphURL: String
+    let parameterIdentifier: String
+    let publishedPortIdentifier: String
+    let label: String
+    let valueSummary: String
+    let controlType: String
+    let parameterType: String
+
+    var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(
+            title: LocalizedStringResource(stringLiteral: self.label),
+            subtitle: LocalizedStringResource(stringLiteral: "\(self.parameterType) • \(self.valueSummary)")
+        )
+    }
+
+    init(
+        graphURL: String,
+        parameterIdentifier: String,
+        publishedPortIdentifier: String,
+        label: String,
+        valueSummary: String,
+        controlType: String,
+        parameterType: String
+    ) {
+        self.graphURL = graphURL
+        self.parameterIdentifier = parameterIdentifier
+        self.publishedPortIdentifier = publishedPortIdentifier
+        self.label = label
+        self.valueSummary = valueSummary
+        self.controlType = controlType
+        self.parameterType = parameterType
+        self.id = FabricIntentIdentifierCodec.encode([
+            "kind": "publishedParameter",
+            "graphURL": graphURL,
+            "parameterIdentifier": parameterIdentifier,
+            "publishedPortIdentifier": publishedPortIdentifier,
+            "label": label,
+            "valueSummary": valueSummary,
+            "controlType": controlType,
+            "parameterType": parameterType,
+        ])
+    }
+
+    fileprivate init?(id: String) {
+        let payload = FabricIntentIdentifierCodec.decode(id)
+        guard
+            payload["kind"] == "publishedParameter",
+            let graphURL = payload["graphURL"],
+            let parameterIdentifier = payload["parameterIdentifier"],
+            let publishedPortIdentifier = payload["publishedPortIdentifier"],
+            let label = payload["label"],
+            let valueSummary = payload["valueSummary"],
+            let controlType = payload["controlType"],
+            let parameterType = payload["parameterType"]
+        else {
+            return nil
+        }
+
+        self.id = id
+        self.graphURL = graphURL
+        self.parameterIdentifier = parameterIdentifier
+        self.publishedPortIdentifier = publishedPortIdentifier
+        self.label = label
+        self.valueSummary = valueSummary
+        self.controlType = controlType
+        self.parameterType = parameterType
+    }
+}
+
+struct FabricRegistryNodeEntity: AppEntity, Sendable {
+    static let typeDisplayRepresentation: TypeDisplayRepresentation = "Fabric Registry Node"
+    static let defaultQuery = FabricRegistryNodeEntityQuery()
+
+    let id: String
+    let nodeName: String
+    let nodeClassName: String
+    let nodeTypeDescription: String
+    let nodeDescription: String
+    let sourcePath: String?
+
+    var displayRepresentation: DisplayRepresentation {
+        let subtitleText = self.sourcePath.map { "\(self.nodeTypeDescription) • \($0)" } ?? self.nodeTypeDescription
+        return DisplayRepresentation(
+            title: LocalizedStringResource(stringLiteral: self.nodeName),
+            subtitle: LocalizedStringResource(stringLiteral: subtitleText)
+        )
+    }
+
+    init(
+        nodeName: String,
+        nodeClassName: String,
+        nodeTypeDescription: String,
+        nodeDescription: String,
+        sourcePath: String?
+    ) {
+        self.nodeName = nodeName
+        self.nodeClassName = nodeClassName
+        self.nodeTypeDescription = nodeTypeDescription
+        self.nodeDescription = nodeDescription
+        self.sourcePath = sourcePath
+        self.id = FabricIntentIdentifierCodec.encode([
+            "kind": "registryNode",
+            "nodeName": nodeName,
+            "nodeClassName": nodeClassName,
+            "nodeTypeDescription": nodeTypeDescription,
+            "nodeDescription": nodeDescription,
+            "sourcePath": sourcePath ?? "",
+        ])
+    }
+
+    fileprivate init?(id: String) {
+        let payload = FabricIntentIdentifierCodec.decode(id)
+        guard
+            payload["kind"] == "registryNode",
+            let nodeName = payload["nodeName"],
+            let nodeClassName = payload["nodeClassName"],
+            let nodeTypeDescription = payload["nodeTypeDescription"],
+            let nodeDescription = payload["nodeDescription"]
+        else {
+            return nil
+        }
+
+        self.id = id
+        self.nodeName = nodeName
+        self.nodeClassName = nodeClassName
+        self.nodeTypeDescription = nodeTypeDescription
+        self.nodeDescription = nodeDescription
+        let sourcePath = payload["sourcePath"] ?? ""
+        self.sourcePath = sourcePath.isEmpty ? nil : sourcePath
+    }
+}
+
+struct FabricGraphEntityQuery: EntityQuery {
+    func entities(for identifiers: [String]) async throws -> [FabricGraphEntity] {
+        identifiers.compactMap(FabricGraphEntity.init(id:))
+    }
+
+    func suggestedEntities() async throws -> [FabricGraphEntity] {
+        []
+    }
+}
+
+struct FabricNodeEntityQuery: EntityQuery {
+    func entities(for identifiers: [String]) async throws -> [FabricNodeEntity] {
+        identifiers.compactMap(FabricNodeEntity.init(id:))
+    }
+
+    func suggestedEntities() async throws -> [FabricNodeEntity] {
+        []
+    }
+}
+
+struct FabricPortEntityQuery: EntityQuery {
+    func entities(for identifiers: [String]) async throws -> [FabricPortEntity] {
+        identifiers.compactMap(FabricPortEntity.init(id:))
+    }
+
+    func suggestedEntities() async throws -> [FabricPortEntity] {
+        []
+    }
+}
+
+struct FabricPublishedParameterEntityQuery: EntityQuery {
+    func entities(for identifiers: [String]) async throws -> [FabricPublishedParameterEntity] {
+        identifiers.compactMap(FabricPublishedParameterEntity.init(id:))
+    }
+
+    func suggestedEntities() async throws -> [FabricPublishedParameterEntity] {
+        []
+    }
+}
+
+struct FabricRegistryNodeEntityQuery: EntityQuery {
+    func entities(for identifiers: [String]) async throws -> [FabricRegistryNodeEntity] {
+        identifiers.compactMap(FabricRegistryNodeEntity.init(id:))
+    }
+
+    func suggestedEntities() async throws -> [FabricRegistryNodeEntity] {
+        []
+    }
+}

--- a/Fabric Editor/AppIntents/FabricIntentEntities.swift
+++ b/Fabric Editor/AppIntents/FabricIntentEntities.swift
@@ -35,23 +35,35 @@ struct FabricGraphEntity: AppEntity, Sendable {
     let graphURL: String
     let displayName: String
     let graphIdentifier: String
+    let nodeCount: Int
+    let publishedParameterCount: Int
 
     var displayRepresentation: DisplayRepresentation {
         DisplayRepresentation(
             title: LocalizedStringResource(stringLiteral: self.displayName),
-            subtitle: LocalizedStringResource(stringLiteral: self.graphURL)
+            subtitle: LocalizedStringResource(stringLiteral: "\(self.nodeCount) nodes • \(self.publishedParameterCount) published")
         )
     }
 
-    init(graphURL: String, displayName: String, graphIdentifier: String) {
+    init(
+        graphURL: String,
+        displayName: String,
+        graphIdentifier: String,
+        nodeCount: Int,
+        publishedParameterCount: Int
+    ) {
         self.graphURL = graphURL
         self.displayName = displayName
         self.graphIdentifier = graphIdentifier
+        self.nodeCount = nodeCount
+        self.publishedParameterCount = publishedParameterCount
         self.id = FabricIntentIdentifierCodec.encode([
             "kind": "graph",
             "graphURL": graphURL,
             "displayName": displayName,
             "graphIdentifier": graphIdentifier,
+            "nodeCount": String(nodeCount),
+            "publishedParameterCount": String(publishedParameterCount),
         ])
     }
 
@@ -61,7 +73,11 @@ struct FabricGraphEntity: AppEntity, Sendable {
             payload["kind"] == "graph",
             let graphURL = payload["graphURL"],
             let displayName = payload["displayName"],
-            let graphIdentifier = payload["graphIdentifier"]
+            let graphIdentifier = payload["graphIdentifier"],
+            let nodeCountValue = payload["nodeCount"],
+            let publishedParameterCountValue = payload["publishedParameterCount"],
+            let nodeCount = Int(nodeCountValue),
+            let publishedParameterCount = Int(publishedParameterCountValue)
         else {
             return nil
         }
@@ -70,6 +86,8 @@ struct FabricGraphEntity: AppEntity, Sendable {
         self.graphURL = graphURL
         self.displayName = displayName
         self.graphIdentifier = graphIdentifier
+        self.nodeCount = nodeCount
+        self.publishedParameterCount = publishedParameterCount
     }
 }
 
@@ -147,11 +165,13 @@ struct FabricPortEntity: AppEntity, Sendable {
     let portDisplayName: String
     let kind: String
     let portType: String
+    let isPublished: Bool
+    let connectionCount: Int
 
     var displayRepresentation: DisplayRepresentation {
         DisplayRepresentation(
             title: LocalizedStringResource(stringLiteral: self.portDisplayName),
-            subtitle: LocalizedStringResource(stringLiteral: "\(self.kind) • \(self.portType)")
+            subtitle: LocalizedStringResource(stringLiteral: "\(self.kind) • \(self.portType) • \(self.connectionCount) connections")
         )
     }
 
@@ -162,7 +182,9 @@ struct FabricPortEntity: AppEntity, Sendable {
         portName: String,
         portDisplayName: String,
         kind: String,
-        portType: String
+        portType: String,
+        isPublished: Bool,
+        connectionCount: Int
     ) {
         self.graphURL = graphURL
         self.nodeIdentifier = nodeIdentifier
@@ -171,6 +193,8 @@ struct FabricPortEntity: AppEntity, Sendable {
         self.portDisplayName = portDisplayName
         self.kind = kind
         self.portType = portType
+        self.isPublished = isPublished
+        self.connectionCount = connectionCount
         self.id = FabricIntentIdentifierCodec.encode([
             "kind": "port",
             "graphURL": graphURL,
@@ -180,6 +204,8 @@ struct FabricPortEntity: AppEntity, Sendable {
             "portDisplayName": portDisplayName,
             "portKind": kind,
             "portType": portType,
+            "isPublished": String(isPublished),
+            "connectionCount": String(connectionCount),
         ])
     }
 
@@ -193,7 +219,11 @@ struct FabricPortEntity: AppEntity, Sendable {
             let portName = payload["portName"],
             let portDisplayName = payload["portDisplayName"],
             let kind = payload["portKind"],
-            let portType = payload["portType"]
+            let portType = payload["portType"],
+            let isPublishedValue = payload["isPublished"],
+            let connectionCountValue = payload["connectionCount"],
+            let isPublished = Bool(isPublishedValue),
+            let connectionCount = Int(connectionCountValue)
         else {
             return nil
         }
@@ -206,6 +236,8 @@ struct FabricPortEntity: AppEntity, Sendable {
         self.portDisplayName = portDisplayName
         self.kind = kind
         self.portType = portType
+        self.isPublished = isPublished
+        self.connectionCount = connectionCount
     }
 }
 

--- a/Fabric Editor/Fabric.entitlements
+++ b/Fabric Editor/Fabric.entitlements
@@ -6,5 +6,7 @@
 	<true/>
 	<key>com.apple.security.device.camera</key>
 	<true/>
+	<key>com.apple.security.automation.apple-events</key>
+	<true/>
 </dict>
 </plist>

--- a/Fabric Editor/FabricApp.swift
+++ b/Fabric Editor/FabricApp.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import Fabric
 import AppKit
+import AppIntents
 import Sparkle
 
 
@@ -21,6 +22,7 @@ struct FabricApp: App {
         // If you want to start the updater manually, pass false to startingUpdater and call .startUpdater() later
         // This is where you can also pass an updater delegate if you need one
         updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
+        FabricEditorShortcuts.updateAppShortcutParameters()
     }
     
     
@@ -204,5 +206,4 @@ extension FocusedValues
         }
     }
 }
-
 

--- a/Fabric.xcodeproj/project.pbxproj
+++ b/Fabric.xcodeproj/project.pbxproj
@@ -229,6 +229,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Fabric Editor/Info.plist";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.graphics-design";
+				INFOPLIST_KEY_NSAppleEventsUsageDescription = "Shortcuts compatibility";
 				INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription = "Fabric uses Bluetooth to connect to HID devices like game controllers";
 				INFOPLIST_KEY_NSCameraUsageDescription = "Camera Effects";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
@@ -272,6 +273,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Fabric Editor/Info.plist";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.graphics-design";
+				INFOPLIST_KEY_NSAppleEventsUsageDescription = "Shortcuts compatibility";
 				INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription = "Fabric uses Bluetooth to connect to HID devices like game controllers";
 				INFOPLIST_KEY_NSCameraUsageDescription = "Camera Effects";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";


### PR DESCRIPTION
This draft PR adds App Intents support allowing Shortcuts app to build integrated workflows using Fabric and the newly supported export image / export movie functionality. App Intentents also gives us a venue to add MCP support via both Foundation Models and 3rd party models for agentic workflows (intended to be a separate PR)

Workflow for Shortcuts would be something like

* load a previously authored graph from disk
* introspect published values
* set published values
* export a movie 

ie: make a graph thats a template for a news report intro or sport intro
* load graph
* set name of home team, set name of away team, set score, set logos and colors
* render out an interstitial 

* can be run via finder or some other mechanism. 
* 
<img width="1485" height="1149" alt="image" src="https://github.com/user-attachments/assets/7d1e95dc-efa5-434b-9b52-7549eff4fb1d" />

