### PR TITLE
Fix cherry pick merge

### DIFF
--- a/Fabric/Nodes/Image/TextureCropNode.swift
+++ b/Fabric/Nodes/Image/TextureCropNode.swift
@@ -41,11 +41,18 @@ public class TextureCropNode: Node
 
         let srcTex = sourceImage.texture
         let x = max(0, min(inputCropX.value ?? 0, srcTex.width - 1))
-        let y = max(0, min(inputCropY.value ?? 0, srcTex.height - 1))
+        var y = max(0, min(inputCropY.value ?? 0, srcTex.height - 1))
         let w = max(1, min(inputCropWidth.value ?? 1920, srcTex.width - x))
         let h = max(1, min(inputCropHeight.value ?? 1080, srcTex.height - y))
 
         guard let outImage = renderer.newImage(withWidth: w, height: h, format: sourceImage.texture.pixelFormat) else { return }
+        // For flipped sources (e.g. Syphon/OpenGL with bottom-left origin),
+        // the visual top of the image is stored at the bottom of texture
+        // memory. Invert the Y coordinate so crop regions specified in
+        // visual space select the correct memory rows.
+        if sourceImage.isFlipped {
+            y = max(0, srcTex.height - y - h)
+        }
 
         guard let encoder = commandBuffer.makeBlitCommandEncoder() else { return }
         encoder.copy(
@@ -59,6 +66,9 @@ public class TextureCropNode: Node
         )
         encoder.endEncoding()
 
+        // Preserve the source's flip flag so downstream material nodes
+        // apply the correct UV orientation.
+        outImage.isFlipped = sourceImage.isFlipped
         outputTexture.send(outImage)
     }
 }


### PR DESCRIPTION
Handle flipped textures in TextureCropNode
Preserve the source image's isFlipped flag on the cropped output so
downstream material nodes apply the correct UV orientation.

Adjust crop Y coordinates for flipped sources: when isFlipped is true,
the visual top of the image is at the bottom of texture memory. Invert
Y before the blit so crop regions specified in visual space (e.g. from
a SliceDefinition) select the correct memory rows. The output pixel
data retains the source's row order, so isFlipped is still propagated.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>