### PR TITLE
Math Expression: debounced eval + coalesced undo

### DIFF
--- a/Fabric/Nodes/Parameters/Number/MathExpressionNode.swift
+++ b/Fabric/Nodes/Parameters/Number/MathExpressionNode.swift
@@ -14,20 +14,102 @@ internal import MathParser
 struct MathExpressionView : View
 {
     @Bindable var node:MathExpressionNode
-    
+
+    /// Local edit buffer between the TextField and the node.
+    ///
+    /// Why this exists: binding the TextField directly to an
+    /// `@Observable` `node.stringExpression` causes the field to
+    /// select-all-on-update on every keystroke. Each write
+    /// invalidates the body, `@Bindable` synthesises a fresh
+    /// `Binding<String>`, and SwiftUI's macOS TextField representable
+    /// reads that as an external change — pushing the value back
+    /// into the underlying `NSTextField`, whose `stringValue` setter
+    /// selects-all by default. With `@State` here, SwiftUI's
+    /// value-equality optimisation kicks in (the value the field just
+    /// emitted equals the value the binding now reports) and the
+    /// AppKit field is left untouched. The cursor / selection
+    /// survives the eval.
+    @State private var buffer: String = ""
+    /// Tracks the in-flight debounce. Cancelled on each keystroke so
+    /// only the trailing edit triggers a re-parse + port rebuild.
+    @State private var debounceTask: Task<Void, Never>?
+    @FocusState private var focused: Bool
+
+    /// How long the field has to stay quiet before the expression
+    /// auto-commits. Enter and defocus bypass this and commit
+    /// immediately.
+    private static let debounceSeconds: Double = 1.0
+
     var body: some View
     {
         VStack(alignment: .leading)
         {
             Text("By writing a mathematical expression, you can expose variables and use built in functions or constants to compute a single output value. \n\n [Swift-Math-Expression Documentation](https://github.com/bradhowes/swift-math-parser).")
-            
+
             Spacer()
-            
-            TextField("Math Expression", text: $node.stringExpression)
+
+            TextField("Math Expression", text: $buffer)
                 .lineLimit(1)
                 .font(.system(size: 10))
                 .textFieldStyle(RoundedBorderTextFieldStyle())
+                .focused($focused)
+                .onAppear { buffer = node.stringExpression }
+                .onSubmit { commit() }
+                .onChange(of: focused) { _, isFocused in
+                    if !isFocused { commit() }
+                }
+                .onChange(of: buffer) { _, _ in
+                    // Schedule the eval. Until it fires (or Enter /
+                    // defocus pre-empts), the buffer is the source of
+                    // truth — the node's `stringExpression` is left
+                    // alone so AppKit doesn't see a re-write of the
+                    // text and reset selection.
+                    debounceTask?.cancel()
+                    debounceTask = Task {
+                        try? await Task.sleep(for: .seconds(Self.debounceSeconds))
+                        guard !Task.isCancelled else { return }
+                        commit()
+                    }
+                }
+                .onChange(of: node.stringExpression) { _, new in
+                    // External edit (undo / redo / scripted). Sync
+                    // the buffer when we're not focused — while the
+                    // user is typing, the buffer is authoritative.
+                    if !focused, buffer != new {
+                        buffer = new
+                    }
+                }
         }
+    }
+
+    private func commit() {
+        debounceTask?.cancel()
+        let old = node.stringExpression
+        let new = buffer
+        if new != old {
+            registerUndo(from: old, to: new)
+            node.stringExpression = new
+        }
+        node.commitExpression()
+    }
+
+    /// Register a single undo step covering this commit's full edit
+    /// (every keystroke since the last commit collapses into one
+    /// ⌘Z). The symmetric pattern — undo handler registers redo —
+    /// bounces back and forth across redo / undo cycles.
+    private func registerUndo(from old: String, to new: String) {
+        guard let undo = node.graph?.undoManager else { return }
+        undo.registerUndo(withTarget: node) { n in
+            let redoTarget = n.stringExpression
+            n.graph?.undoManager?.registerUndo(withTarget: n) { n2 in
+                n2.stringExpression = redoTarget
+                n2.commitExpression()
+            }
+            n.graph?.undoManager?.setActionName("Edit Math Expression")
+            n.stringExpression = old
+            n.commitExpression()
+        }
+        undo.setActionName("Edit Math Expression")
     }
 }
 
@@ -84,12 +166,21 @@ struct MathExpressionView : View
 
     // MARK: - Properties
 
-    @ObservationIgnored fileprivate var stringExpression:String = "sin(x) + y^2"
+    /// Live edit buffer — observable so the inspector's TextField
+    /// binding stays in sync with undo/redo + scripted edits, and
+    /// the View can `.onChange` it to drive the debounce. Writing to
+    /// this property no longer auto-runs the parser; the parse +
+    /// port rebuild is gated by `commitExpression()` so it happens
+    /// only on the trailing edit (debounce / Enter / defocus).
+    public var stringExpression: String = "sin(x) + y^2"
+
+    /// Re-parse the current `stringExpression`, rebuild the variable
+    /// ports, and refresh the title. Called by the inspector view
+    /// on debounce / Enter / defocus, and by the decoder /
+    /// convenience init right after seeding the expression.
+    public func commitExpression()
     {
-        didSet
-        {
-            self.evalExpression()
-        }
+        evalExpression()
     }
 
     /// Updated by evalExpression() — shows the expression on success, or an


### PR DESCRIPTION
Stop re-parsing on every keystroke. Typing "sin(x" used to add the `x` port, fail to parse the next half-formed expression, drop ports, re-add them — every character. Now:

- The TextField writes to a local @State buffer instead of the node's expression, so the AppKit field never gets a re-write of its own text and the cursor / selection survives the eval. (Direct binding to an @Observable property rebuilds the binding on each keystroke, which the macOS TextField representable treats as an external change and pushes back into NSTextField — whose stringValue setter selects-all by default.)
- Each buffer change reschedules a 1s debounce task. Trailing edit fires `commit()`. Enter / defocus pre-empts the debounce and commits immediately. The buffer is the source of truth until then; `node.stringExpression` is left alone so external observers see the user's intended state, not every intermediate keystroke.
- `commit()` registers a single coalesced undo step capturing the full edit range. The symmetric undo→redo pattern bounces correctly on repeated ⌘Z / ⌘⇧Z; both sides re-run `commitExpression()` so the variable ports follow the restored expression.
- External edits (undo / redo / scripted) sync the buffer via `.onChange(of: node.stringExpression)` when the field isn't focused; while the user is typing the buffer stays authoritative.

Node-side: `stringExpression` is now a plain `@Observable` `var` (no `@ObservationIgnored`, no `didSet`) so the View can `.onChange` it. Eval is invoked explicitly via the new public `commitExpression()` from the View, the decoder, and the convenience initialiser — same call sites as before, just spelled out instead of riding `didSet`.