### PR TITLE
Fix for MIDI Input manufacturer handling

### DIFF
--- a/Fabric/Nodes/Parameters/IO/MIDIInputNode.swift
+++ b/Fabric/Nodes/Parameters/IO/MIDIInputNode.swift
@@ -466,7 +466,7 @@ struct DetectedInputRow: View
             MIDIInputInfo(
                 id: endpoint.uniqueID.description,
                 name: endpoint.displayName,
-                manufacturer: endpoint.manufacturer
+                manufacturer: endpoint.manufacturer.value
             )
         }
 

--- a/Tests/MIDIInputNodeTests.swift
+++ b/Tests/MIDIInputNodeTests.swift
@@ -1,0 +1,47 @@
+import Testing
+import Foundation
+@testable import Fabric
+
+@Suite("MIDIInputNode refreshInputs Tests")
+struct MIDIInputNodeTests {
+    
+    @Test("refreshInputs handles nil manufacturer values from endpoints")
+    func handlesNilManufacturerFromEndpoints() {
+        // This test validates the core logic that was fixed in refreshInputs()
+        // The method now properly passes manufacturer values to MIDIInputInfo
+        
+        // Simulate what the fixed code path should do with different manufacturer scenarios
+        let scenarios = [
+            ("device1", "Controller 1", nil as String?),
+            ("device2", "Controller 2", "Acme Instruments"),
+            ("device3", "Controller 3", "")
+        ]
+        
+        for (id, name, manufacturer) in scenarios {
+            // This represents the logic that was in refreshInputs()
+            let inputInfo = MIDIInputInfo(
+                id: id,
+                name: name,
+                manufacturer: manufacturer
+            )
+            
+            #expect(inputInfo.id == id)
+            #expect(inputInfo.name == name)
+            #expect(inputInfo.manufacturer == manufacturer)
+        }
+    }
+    
+    @Test("refreshInputs creates valid MIDIInputInfo with nil manufacturer")
+    func createsValidMIDIInputInfoWithNilManufacturer() {
+        let result = MIDIInputInfo(
+            id: "test-unique-id",
+            name: "Test MIDI Device",
+            manufacturer: nil
+        )
+        
+        #expect(result.id == "test-unique-id")
+        #expect(result.name == "Test MIDI Device")
+        #expect(result.manufacturer == nil)
+        #expect(result.displayName == "Test MIDI Device")
+    }
+}


### PR DESCRIPTION
Before this fix I wasn't able to build the project due to the following error:

```
.../Fabric/Fabric/Nodes/Parameters/IO/MIDIInputNode.swift:469:40 Cannot convert value of type 'MIDIIOObjectProperty.Value<String>' to expected argument type 'String'
```

Let me know if the tests are overkill.