### PR TITLE
Feature/satin 2.0 parametric geometry nodes

### DIFF
--- a/Fabric/Graph/Graph.swift
+++ b/Fabric/Graph/Graph.swift
@@ -341,7 +341,7 @@ internal import AnyCodable
     /// Always non-nil while the node is in this graph.
     public func viewModel(for node: Node) -> NodeViewModel
     {
-        nodeViewModels[node.id] ?? NodeViewModel(node: node)
+        nodeViewModels[node.id]!
     }
     
     public func delete(node:Node, disconnect:Bool = true)

--- a/Fabric/Graph/Graph.swift
+++ b/Fabric/Graph/Graph.swift
@@ -341,7 +341,7 @@ internal import AnyCodable
     /// Always non-nil while the node is in this graph.
     public func viewModel(for node: Node) -> NodeViewModel
     {
-        nodeViewModels[node.id]!
+        nodeViewModels[node.id] ?? NodeViewModel(node: node)
     }
     
     public func delete(node:Node, disconnect:Bool = true)

--- a/Fabric/Graph/Port/AnyPort.swift
+++ b/Fabric/Graph/Port/AnyPort.swift
@@ -45,7 +45,7 @@ open class AnyPort: Codable {
             case .Vector4, .Color: self.base = try ProxyPort<simd_float4>(from: portDecoder)
             case .Quaternion: self.base = try ProxyPort<simd_quatf>(from: portDecoder)
             case .Transform: self.base = try ProxyPort<simd_float4x4>(from: portDecoder)
-            case .Geometry: self.base = try ProxyPort<SatinGeometry>(from: portDecoder)
+            case .Geometry: self.base = try ProxyPort<Geometry>(from: portDecoder)
             case .Material: self.base = try ProxyPort<Material>(from: portDecoder)
             case .Image: self.base = try ProxyPort<FabricImage>(from: portDecoder)
             case .Virtual: self.base = try ProxyPort<PortValue>(from: portDecoder)

--- a/Fabric/Graph/Port/NodePort.swift
+++ b/Fabric/Graph/Port/NodePort.swift
@@ -375,7 +375,7 @@ public class NodePort<Value : PortValueRepresentable>: Port
             return Color.nodeTexture
         }
 
-        else if forType == Satin.SatinGeometry.self
+        else if forType == Satin.Geometry.self || forType == Satin.SatinGeometry.self
         {
             return Color.nodeGeometry
         }

--- a/Fabric/Graph/Port/PortType+Factory.swift
+++ b/Fabric/Graph/Port/PortType+Factory.swift
@@ -26,7 +26,7 @@ extension PortType
             
         case .Quaternion : return try NodePort<simd_float4>.init(from: decoder)
         case .Transform : return try NodePort<simd_float4x4>.init(from: decoder)
-        case .Geometry: return try NodePort<Satin.SatinGeometry>.init(from: decoder)
+        case .Geometry: return try NodePort<Satin.Geometry>.init(from: decoder)
         case .Material: return try NodePort<Satin.Material>.init(from: decoder)
         case .Image: return try NodePort<FabricImage>.init(from: decoder)
         case .Virtual: return try NodePort<PortValue>.init(from: decoder)
@@ -45,7 +45,7 @@ extension PortType
                 
             case .Quaternion: return try NodePort<ContiguousArray<simd_float4>>.init(from: decoder)
             case .Transform: return try NodePort<ContiguousArray<simd_float4x4>>.init(from: decoder)
-            case .Geometry: return try NodePort<ContiguousArray<Satin.SatinGeometry>>.init(from: decoder)
+            case .Geometry: return try NodePort<ContiguousArray<Satin.Geometry>>.init(from: decoder)
             case .Material: return try NodePort<ContiguousArray<Satin.Material>>.init(from: decoder)
             case .Image: return try NodePort<ContiguousArray<FabricImage>>.init(from: decoder)
 

--- a/Fabric/Graph/Port/PortType.swift
+++ b/Fabric/Graph/Port/PortType.swift
@@ -147,7 +147,7 @@ public indirect enum PortType : RawRepresentable, Codable, Equatable, CaseIterab
         case .Transform:
             return simd.simd_float4x4.self
         case .Geometry:
-            return Satin.SatinGeometry.self
+            return Satin.Geometry.self
         case .Material:
             return Satin.Material.self
         case .Image:
@@ -215,7 +215,7 @@ extension PortType {
         case .Color:        return ColorPassThroughNode.self
         case .Quaternion:   return PassThroughNode<simd_quatf>.self
         case .Transform:    return PassThroughNode<simd_float4x4>.self
-        case .Geometry:     return PassThroughNode<SatinGeometry>.self
+        case .Geometry:     return PassThroughNode<Geometry>.self
         case .Material:     return PassThroughNode<Material>.self
         case .Image:        return PassThroughNode<FabricImage>.self
         case .Array(portType: let elementType):
@@ -230,7 +230,7 @@ extension PortType {
             case .Color:     return PassThroughNode<ContiguousArray<simd_float4>>.self
             case .Quaternion: return PassThroughNode<ContiguousArray<simd_quatf>>.self
             case .Transform: return PassThroughNode<ContiguousArray<simd_float4x4>>.self
-            case .Geometry:  return PassThroughNode<ContiguousArray<SatinGeometry>>.self
+            case .Geometry:  return PassThroughNode<ContiguousArray<Geometry>>.self
             case .Material:  return PassThroughNode<ContiguousArray<Material>>.self
             case .Image:     return PassThroughNode<ContiguousArray<FabricImage>>.self
             default:         return nil

--- a/Fabric/Graph/Port/PortValueRepresentable.swift
+++ b/Fabric/Graph/Port/PortValueRepresentable.swift
@@ -51,7 +51,7 @@ public indirect enum PortValue : PortValueRepresentable
     case Vector4(simd_float4)
     case Quaternion(simd_quatf)
     case Transform(simd_float4x4)
-    case Geometry(Satin.SatinGeometry)
+    case Geometry(Satin.Geometry)
     case Material(Satin.Material)
     case Image(FabricImage)
     case Virtual(PortValue)
@@ -546,7 +546,7 @@ extension simd.simd_float4x4 : PortValueRepresentable
     }
 }
 
-extension Satin.SatinGeometry : PortValueRepresentable
+extension Satin.Geometry : PortValueRepresentable
 {
     public static var defaultValue: Self? { nil }
     public static var portType: PortType { .Geometry }
@@ -556,7 +556,7 @@ extension Satin.SatinGeometry : PortValueRepresentable
     {
         .Geometry(self)
     }
-    
+
     public static func fromPortValue(_ value: PortValue) ->  Self?
     {
         switch value
@@ -567,12 +567,12 @@ extension Satin.SatinGeometry : PortValueRepresentable
             return nil
         }
     }
-    
+
     public func canConvertTo(other:PortType) -> Bool
     {
         return false
     }
-    
+
     public func convertTo(other:PortType) -> (any PortValueRepresentable)?
     {
         return nil

--- a/Fabric/Nodes/Base/BaseGeometryNode.swift
+++ b/Fabric/Nodes/Base/BaseGeometryNode.swift
@@ -24,18 +24,18 @@ public class BaseGeometryNode : Node
         return ports +
         [
             ("inputPrimitiveType", ParameterPort(parameter:StringParameter("Primitive", "Triangle", ["Point", "Line", "Line Strip", "Triangle", "Triangle Strip"], .dropdown, "Rendering primitive type for the geometry mesh")) ),
-            ("outputGeometry",  NodePort<SatinGeometry>(name: "Geometry", kind: .Outlet, description: "The generated geometry mesh")),
+            ("outputGeometry",  NodePort<Geometry>(name: "Geometry", kind: .Outlet, description: "The generated geometry mesh")),
         ]
     }
     
     public var inputPrimitiveType: NodePort<String>   { port(named: "inputPrimitiveType") }
-    public var outputGeometry: NodePort<SatinGeometry>   { port(named: "outputGeometry") }
+    public var outputGeometry: NodePort<Geometry>   { port(named: "outputGeometry") }
 
-    open var geometry: SatinGeometry {
+    open var geometry: Geometry {
         fatalError("Subclasses must override geometry")
     }
             
-    public func evaluate(geometry:SatinGeometry, atTime:TimeInterval) -> Bool
+    public func evaluate(geometry:Geometry, atTime:TimeInterval) -> Bool
     {
         var shouldOutput = false
         

--- a/Fabric/Nodes/Deprecated/PointPlaneGeometry.swift
+++ b/Fabric/Nodes/Deprecated/PointPlaneGeometry.swift
@@ -23,7 +23,7 @@ public class PointPlaneGeometryNode : Node, NodeProtocol
     public override var inputParameters: [any Parameter] { [inputWidthParam, inputHeightParam, inputResolutionParam] + super.inputParameters }
 
     // Ports
-    public let outputGeometry:NodePort<SatinGeometry>
+    public let outputGeometry:NodePort<Geometry>
     public override var ports:[AnyPort] {  [outputGeometry] + super.ports}
 
     private let geometry = PlaneGeometry(width: 1, height: 1, orientation: .xy)
@@ -34,7 +34,7 @@ public class PointPlaneGeometryNode : Node, NodeProtocol
         self.inputHeightParam = FloatParameter("Height", 1.0, .inputfield)
         self.inputResolutionParam = Int2Parameter("Resolution", simd_int2(repeating: 1), .inputfield)
 
-        self.outputGeometry = NodePort<SatinGeometry>(name: PointPlaneGeometryNode.name, kind: .Outlet)
+        self.outputGeometry = NodePort<Geometry>(name: PointPlaneGeometryNode.name, kind: .Outlet)
 
         self.geometry.primitiveType = .triangle
         
@@ -68,7 +68,7 @@ public class PointPlaneGeometryNode : Node, NodeProtocol
         self.inputWidthParam = try container.decode(FloatParameter.self, forKey: .inputWidthParameter)
         self.inputHeightParam = try container.decode(FloatParameter.self, forKey: .inputHeightParameter)
         self.inputResolutionParam = try container.decode(Int2Parameter.self, forKey: .inputResolutionParameter)
-        self.outputGeometry = try container.decode(NodePort<SatinGeometry>.self, forKey: .outputGeometryPort)
+        self.outputGeometry = try container.decode(NodePort<Geometry>.self, forKey: .outputGeometryPort)
         
         self.geometry.primitiveType = .point
 

--- a/Fabric/Nodes/Geometry/ArcGeometryNode.swift
+++ b/Fabric/Nodes/Geometry/ArcGeometryNode.swift
@@ -41,7 +41,7 @@ public class ArcGeometryNode : BaseGeometryNode
     private lazy var _geometry = ArcGeometry(context:self.context, radius: (inner: 0.25, outer:0.75),
                                         angle: (start:0.0, end:degToRad(90.0)), res: (angular:20, radial:5))
 
-    override public func evaluate(geometry: SatinGeometry, atTime: TimeInterval) -> Bool
+    override public func evaluate(geometry: Geometry, atTime: TimeInterval) -> Bool
     {
         var shouldOutputGeometry = super.evaluate(geometry: geometry, atTime: atTime)
 

--- a/Fabric/Nodes/Geometry/BoxGeometryNode.swift
+++ b/Fabric/Nodes/Geometry/BoxGeometryNode.swift
@@ -35,7 +35,7 @@ public class BoxGeometryNode : BaseGeometryNode
     private lazy var _geometry = BoxGeometry(context:self.context, width: 1, height: 1, depth: 1)
 
     
-    override public func evaluate(geometry: SatinGeometry, atTime: TimeInterval) -> Bool
+    override public func evaluate(geometry: Geometry, atTime: TimeInterval) -> Bool
     {
         var shouldOutputGeometry = super.evaluate(geometry: geometry, atTime: atTime)
         

--- a/Fabric/Nodes/Geometry/CapsuleGeometryNode.swift
+++ b/Fabric/Nodes/Geometry/CapsuleGeometryNode.swift
@@ -36,7 +36,7 @@ public class CapsuleGeometryNode : BaseGeometryNode
 
     private lazy var _geometry = CapsuleGeometry(context:self.context, radius: 1.0, height: 2.0, angularResolution: 30, radialResolution: 30, verticalResolution: 30)
 
-    override public func evaluate(geometry: SatinGeometry, atTime: TimeInterval) -> Bool
+    override public func evaluate(geometry: Geometry, atTime: TimeInterval) -> Bool
     {
         var shouldOutputGeometry = super.evaluate(geometry: geometry, atTime: atTime)
 

--- a/Fabric/Nodes/Geometry/CircleGeometryNode.swift
+++ b/Fabric/Nodes/Geometry/CircleGeometryNode.swift
@@ -31,7 +31,7 @@ public class CircleGeometryNode : BaseGeometryNode
     
     private lazy var _geometry = CircleGeometry(context:self.context, radius: 1.0, angularResolution: 60, radialResolution: 1)
     
-    override public func evaluate(geometry: SatinGeometry, atTime: TimeInterval) -> Bool
+    override public func evaluate(geometry: Geometry, atTime: TimeInterval) -> Bool
     {
         var shouldOutputGeometry = super.evaluate(geometry: geometry, atTime: atTime)
 

--- a/Fabric/Nodes/Geometry/ConeGeometryNode.swift
+++ b/Fabric/Nodes/Geometry/ConeGeometryNode.swift
@@ -38,7 +38,7 @@ public class ConeGeometryNode : BaseGeometryNode
 
     private lazy var _geometry = ConeGeometry(context:self.context, radius: 1.0, height: 2.0, angularResolution: 20, radialResolution: 2, verticalResolution: 2)
 
-    override public func evaluate(geometry: SatinGeometry, atTime: TimeInterval) -> Bool
+    override public func evaluate(geometry: Geometry, atTime: TimeInterval) -> Bool
     {
         var shouldOutputGeometry = super.evaluate(geometry: geometry, atTime: atTime)
 

--- a/Fabric/Nodes/Geometry/CycloramaGeometryNode.swift
+++ b/Fabric/Nodes/Geometry/CycloramaGeometryNode.swift
@@ -51,7 +51,7 @@ public class CycloramaGeometryNode: BaseGeometryNode
         angularResolution: 24
     )
 
-    override public func evaluate(geometry: SatinGeometry, atTime: TimeInterval) -> Bool
+    override public func evaluate(geometry: Geometry, atTime: TimeInterval) -> Bool
     {
         var shouldOutputGeometry = super.evaluate(geometry: geometry, atTime: atTime)
 

--- a/Fabric/Nodes/Geometry/ExtrudedTextGeometryNode.swift
+++ b/Fabric/Nodes/Geometry/ExtrudedTextGeometryNode.swift
@@ -44,7 +44,7 @@ public class ExtrudedTextGeometryNode : BaseGeometryNode
         }
     }
     
-    override public func evaluate(geometry: SatinGeometry, atTime: TimeInterval) -> Bool
+    override public func evaluate(geometry: Geometry, atTime: TimeInterval) -> Bool
     {
         var shouldOutputGeometry = super.evaluate(geometry: geometry, atTime: atTime)
 

--- a/Fabric/Nodes/Geometry/IcoSphereGeometryNode.swift
+++ b/Fabric/Nodes/Geometry/IcoSphereGeometryNode.swift
@@ -31,7 +31,7 @@ public class IcoSphereGeometryNode : BaseGeometryNode
     public override var geometry: IcoSphereGeometry { _geometry }
     private lazy var _geometry = IcoSphereGeometry(context:self.context, radius: 1.0, resolution: 1)
     
-    override public func evaluate(geometry: SatinGeometry, atTime: TimeInterval) -> Bool
+    override public func evaluate(geometry: Geometry, atTime: TimeInterval) -> Bool
     {
         var shouldOutputGeometry = super.evaluate(geometry: geometry, atTime: atTime)
 

--- a/Fabric/Nodes/Geometry/MathExpressionParametricGeometryNode.swift
+++ b/Fabric/Nodes/Geometry/MathExpressionParametricGeometryNode.swift
@@ -1,0 +1,338 @@
+//
+//  MathExpressionParametricGeometryNode.swift
+//  Fabric
+//
+//  Created by Anton Marini on 6/19/26.
+//
+
+import Foundation
+import Satin
+import Metal
+import SwiftUI
+import simd
+internal import MathParser
+
+// MARK: - Settings View
+
+struct MathExpressionParametricView: View
+{
+    @Bindable var model: MathExpressionParametricGeometryNode.SettingsModel
+
+    var body: some View
+    {
+        VStack(alignment: .leading, spacing: 8)
+        {
+            Text("Define a parametric surface as X(u,v), Y(u,v), Z(u,v). u and v are the parametric parameters. Any other variables (e.g. a, b) become input ports.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            expressionRow(label: "X =", text: $model.expressionX, valid: model.statusX)
+            expressionRow(label: "Y =", text: $model.expressionY, valid: model.statusY)
+            expressionRow(label: "Z =", text: $model.expressionZ, valid: model.statusZ)
+        }
+        .padding(10)
+    }
+
+    @ViewBuilder
+    private func expressionRow(label: String, text: Binding<String>, valid: Bool) -> some View
+    {
+        HStack(spacing: 4)
+        {
+            Text(label)
+                .font(.system(size: 11, design: .monospaced))
+                .frame(width: 28, alignment: .trailing)
+            TextField("Expression", text: text)
+                .font(.system(size: 10, design: .monospaced))
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .foregroundStyle(valid ? Color.primary : Color.red)
+        }
+    }
+}
+
+// MARK: - Node
+
+public class MathExpressionParametricGeometryNode: BaseGeometryNode
+{
+    public override class var name: String { "Parametric Expression Geometry" }
+    public override class var nodeDescription: String { "Define a parametric surface by writing X(u,v), Y(u,v), Z(u,v) math expressions. Extra variables become wirable input ports." }
+
+    // Default expressions: unit sphere
+    class var defaultExpressionX: String { "cos(u) * sin(v)" }
+    class var defaultExpressionY: String { "sin(u) * sin(v)" }
+    class var defaultExpressionZ: String { "cos(v)" }
+
+    // u and v are always resolved by the generator; they never become ports.
+    private static let parametricBindings: Set<String> = ["u", "v"]
+
+    // MARK: - Settings Model
+
+    @Observable final class SettingsModel
+    {
+        var expressionX: String
+        {
+            didSet
+            {
+                guard expressionX != node?.expressionX else { return }
+                node?.expressionX = expressionX
+            }
+        }
+        var expressionY: String
+        {
+            didSet
+            {
+                guard expressionY != node?.expressionY else { return }
+                node?.expressionY = expressionY
+            }
+        }
+        var expressionZ: String
+        {
+            didSet
+            {
+                guard expressionZ != node?.expressionZ else { return }
+                node?.expressionZ = expressionZ
+            }
+        }
+
+        var statusX: Bool = true
+        var statusY: Bool = true
+        var statusZ: Bool = true
+
+        private weak var node: MathExpressionParametricGeometryNode?
+
+        init(node: MathExpressionParametricGeometryNode)
+        {
+            self.node = node
+            self.expressionX = node.expressionX
+            self.expressionY = node.expressionY
+            self.expressionZ = node.expressionZ
+        }
+    }
+
+    internal lazy var _settingsModel: SettingsModel = SettingsModel(node: self)
+
+    // MARK: - Codable
+
+    private enum CodingKeys: String, CodingKey
+    {
+        case expressionX, expressionY, expressionZ
+    }
+
+    public required init(from decoder: any Decoder) throws
+    {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.expressionX = try container.decodeIfPresent(String.self, forKey: .expressionX) ?? Self.defaultExpressionX
+        self.expressionY = try container.decodeIfPresent(String.self, forKey: .expressionY) ?? Self.defaultExpressionY
+        self.expressionZ = try container.decodeIfPresent(String.self, forKey: .expressionZ) ?? Self.defaultExpressionZ
+        try super.init(from: decoder)
+        parseExpressions()
+    }
+
+    public override func encode(to encoder: any Encoder) throws
+    {
+        try super.encode(to: encoder)
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(expressionX, forKey: .expressionX)
+        try container.encode(expressionY, forKey: .expressionY)
+        try container.encode(expressionZ, forKey: .expressionZ)
+    }
+
+    public required init(context: Context)
+    {
+        self.expressionX = Self.defaultExpressionX
+        self.expressionY = Self.defaultExpressionY
+        self.expressionZ = Self.defaultExpressionZ
+        super.init(context: context)
+        parseExpressions()
+    }
+
+    // MARK: - Static Ports
+
+    override public class func registerPorts(context: Context) -> [(name: String, port: Port)]
+    {
+        let ports = super.registerPorts(context: context)
+        return [
+            ("inputResolutionU", ParameterPort(parameter: IntParameter("Resolution U",  128,  .inputfield, "Mesh segments along the U direction"))),
+            ("inputResolutionV", ParameterPort(parameter: IntParameter("Resolution V",  128,  .inputfield, "Mesh segments along the V direction"))),
+            ("inputRangeUMin",   ParameterPort(parameter: FloatParameter("Range U Min", -.pi, .inputfield, "Lower bound of the U parameter domain"))),
+            ("inputRangeUMax",   ParameterPort(parameter: FloatParameter("Range U Max",  .pi, .inputfield, "Upper bound of the U parameter domain"))),
+            ("inputRangeVMin",   ParameterPort(parameter: FloatParameter("Range V Min",    0, .inputfield, "Lower bound of the V parameter domain"))),
+            ("inputRangeVMax",   ParameterPort(parameter: FloatParameter("Range V Max",  .pi, .inputfield, "Upper bound of the V parameter domain"))),
+        ] + ports
+    }
+
+    public var inputResolutionU: ParameterPort<Int>   { port(named: "inputResolutionU") }
+    public var inputResolutionV: ParameterPort<Int>   { port(named: "inputResolutionV") }
+    public var inputRangeUMin:   ParameterPort<Float> { port(named: "inputRangeUMin") }
+    public var inputRangeUMax:   ParameterPort<Float> { port(named: "inputRangeUMax") }
+    public var inputRangeVMin:   ParameterPort<Float> { port(named: "inputRangeVMin") }
+    public var inputRangeVMax:   ParameterPort<Float> { port(named: "inputRangeVMax") }
+
+    // MARK: - Geometry
+
+    public override var geometry: ParametricGeometry { _geometry }
+
+    private lazy var _geometry: ParametricGeometry = ParametricGeometry(
+        context: self.context,
+        rangeU: -.pi ... .pi,
+        rangeV: 0 ... .pi,
+        resolution: simd_int2(128, 128),
+        generator: { _, _ in .zero }
+    )
+
+    // MARK: - Expression Parsing
+
+    internal var expressionX: String
+    {
+        didSet
+        {
+            guard oldValue != expressionX else { return }
+            parseExpressions()
+        }
+    }
+    internal var expressionY: String
+    {
+        didSet
+        {
+            guard oldValue != expressionY else { return }
+            parseExpressions()
+        }
+    }
+    internal var expressionZ: String
+    {
+        didSet
+        {
+            guard oldValue != expressionZ else { return }
+            parseExpressions()
+        }
+    }
+
+    private let mathParser = MathParser()
+    private var evalX: Evaluator? = nil
+    private var evalY: Evaluator? = nil
+    private var evalZ: Evaluator? = nil
+    private var _expressionsDirty: Bool = true
+
+    // Names of dynamically-added variable ports (excludes static ports).
+    private var _dynamicVariablePortNames: Set<String> = []
+
+    private func parseExpressions()
+    {
+        switch mathParser.parseResult(expressionX) {
+        case .success(let ev): evalX = ev; _settingsModel.statusX = true
+        case .failure:         evalX = nil; _settingsModel.statusX = false
+        }
+        switch mathParser.parseResult(expressionY) {
+        case .success(let ev): evalY = ev; _settingsModel.statusY = true
+        case .failure:         evalY = nil; _settingsModel.statusY = false
+        }
+        switch mathParser.parseResult(expressionZ) {
+        case .success(let ev): evalZ = ev; _settingsModel.statusZ = true
+        case .failure:         evalZ = nil; _settingsModel.statusZ = false
+        }
+
+        syncVariablePorts()
+        _expressionsDirty = true
+        nameSubject.send()
+    }
+
+    /// Keeps dynamic input ports in sync with the union of free variables across all
+    /// three expressions, minus u and v which are always resolved by the generator.
+    private func syncVariablePorts()
+    {
+        var allVars = Set<String>()
+        if let ev = evalX { allVars.formUnion(ev.unresolved.variables.map { String($0) }) }
+        if let ev = evalY { allVars.formUnion(ev.unresolved.variables.map { String($0) }) }
+        if let ev = evalZ { allVars.formUnion(ev.unresolved.variables.map { String($0) }) }
+
+        let variableNames = allVars.subtracting(Self.parametricBindings)
+
+        for name in _dynamicVariablePortNames.subtracting(variableNames)
+        {
+            if let port: Port = self.findPort(named: name)
+            {
+                self.removePort(port)
+            }
+            _dynamicVariablePortNames.remove(name)
+        }
+
+        for name in variableNames.subtracting(_dynamicVariablePortNames)
+        {
+            self.addDynamicPort(
+                ParameterPort(parameter: FloatParameter(name, 0.0, .inputfield)),
+                name: name
+            )
+            _dynamicVariablePortNames.insert(name)
+        }
+    }
+
+    // MARK: - Settings View
+
+    override public func providesSettingsView() -> Bool { true }
+
+    override public func settingsView() -> AnyView
+    {
+        AnyView(MathExpressionParametricView(model: _settingsModel))
+    }
+
+    override public var settingsSize: SettingsViewSize { .Medium }
+
+    // MARK: - Evaluate
+
+    override public func evaluate(geometry: Geometry, atTime: TimeInterval) -> Bool
+    {
+        var shouldOutput = super.evaluate(geometry: geometry, atTime: atTime)
+        let geo = self.geometry
+
+        let paramsChanged = inputResolutionU.valueDidChange || inputResolutionV.valueDidChange
+            || inputRangeUMin.valueDidChange || inputRangeUMax.valueDidChange
+            || inputRangeVMin.valueDidChange || inputRangeVMax.valueDidChange
+
+        let anyVarChanged = _dynamicVariablePortNames.contains { name in
+            (self.findPort(named: name) as? ParameterPort<Float>)?.valueDidChange == true
+        }
+
+        if paramsChanged || _expressionsDirty || anyVarChanged
+        {
+            let resU = Int32(inputResolutionU.value ?? 128)
+            let resV = Int32(inputResolutionV.value ?? 128)
+            let uMin = inputRangeUMin.value ?? -.pi
+            let uMax = inputRangeUMax.value ??  .pi
+            let vMin = inputRangeVMin.value ??   0
+            let vMax = inputRangeVMax.value ??  .pi
+
+            geo.resolution = simd_int2(resU, resV)
+            geo.rangeU = min(uMin, uMax) ... max(uMin, uMax)
+            geo.rangeV = min(vMin, vMax) ... max(vMin, vMax)
+
+            // Snapshot variable port values so the generator closure is pure.
+            var varSnapshot: [String: Double] = [:]
+            for name in _dynamicVariablePortNames
+            {
+                let value = (self.findPort(named: name) as? ParameterPort<Float>)?.value ?? 0
+                varSnapshot[name] = Double(value)
+            }
+
+            let eX = evalX, eY = evalY, eZ = evalZ
+            geo.generator = { u, v in
+                let vars = { (name: String) -> Double? in
+                    switch name {
+                    case "u": return Double(u)
+                    case "v": return Double(v)
+                    default:  return varSnapshot[name]
+                    }
+                }
+                let x = Float(eX?.eval(variables: vars) ?? 0)
+                let y = Float(eY?.eval(variables: vars) ?? 0)
+                let z = Float(eZ?.eval(variables: vars) ?? 0)
+                let result = simd_make_float3(x, y, z)
+                return result.x.isFinite && result.y.isFinite && result.z.isFinite ? result : .zero
+            }
+
+            _expressionsDirty = false
+            shouldOutput = true
+        }
+
+        return shouldOutput
+    }
+}

--- a/Fabric/Nodes/Geometry/ParametricGeometryNodes.swift
+++ b/Fabric/Nodes/Geometry/ParametricGeometryNodes.swift
@@ -1,0 +1,749 @@
+//
+//  ParametricGeometryNodes.swift
+//  Fabric
+//
+//  Created by Anton Marini on 6/18/26.
+//
+
+import Satin
+import Foundation
+import simd
+import Metal
+
+// MARK: - Helpers (private to this file)
+
+@inline(__always)
+private func _signedPow(_ v: Float, _ e: Float) -> Float {
+    v == 0 ? 0 : (v < 0 ? -1 : 1) * pow(abs(v), e)
+}
+
+@inline(__always)
+private func _sech(_ v: Float) -> Float { 1.0 / cosh(v) }
+
+// MARK: - Möbius Strip
+
+public class MobiusStripGeometryNode: BaseGeometryNode {
+    public override class var name: String { "Mobius Strip Geometry" }
+    public override class var nodeDescription: String { "Generates a Möbius strip — a single-sided surface with a half-twist" }
+
+    override public class func registerPorts(context: Context) -> [(name: String, port: Port)] {
+        let ports = super.registerPorts(context: context)
+        return [
+            ("inputRadius",      ParameterPort(parameter: FloatParameter("Radius",      1.0,  .inputfield, "Distance from center to the midline of the strip"))),
+            ("inputWidth",       ParameterPort(parameter: FloatParameter("Width",        0.35, .inputfield, "Half-width of the strip cross-section"))),
+            ("inputResolutionU", ParameterPort(parameter: IntParameter("Resolution U", 192,   .inputfield, "Segments along the strip length"))),
+            ("inputResolutionV", ParameterPort(parameter: IntParameter("Resolution V",  32,   .inputfield, "Segments across the strip width"))),
+        ] + ports
+    }
+
+    public var inputRadius:      ParameterPort<Float> { port(named: "inputRadius") }
+    public var inputWidth:       ParameterPort<Float> { port(named: "inputWidth") }
+    public var inputResolutionU: ParameterPort<Int>   { port(named: "inputResolutionU") }
+    public var inputResolutionV: ParameterPort<Int>   { port(named: "inputResolutionV") }
+
+    public override var geometry: ParametricGeometry { _geometry }
+    private lazy var _geometry: ParametricGeometry = .mobiusStrip(context: self.context)
+
+    override public func evaluate(geometry: Geometry, atTime: TimeInterval) -> Bool {
+        var shouldOutput = super.evaluate(geometry: geometry, atTime: atTime)
+        let geo = self.geometry
+
+        if inputRadius.valueDidChange || inputWidth.valueDidChange ||
+           inputResolutionU.valueDidChange || inputResolutionV.valueDidChange {
+            let radius = inputRadius.value ?? 1.0
+            let width  = inputWidth.value  ?? 0.35
+            let resU   = Int32(inputResolutionU.value ?? 192)
+            let resV   = Int32(inputResolutionV.value ?? 32)
+            geo.resolution = simd_int2(resU, resV)
+            geo.rangeU = 0 ... (.pi * 2)
+            geo.rangeV = -width ... width
+            geo.generator = { u, v in
+                let cu = cos(u), su = sin(u)
+                let chu = cos(u * 0.5), shu = sin(u * 0.5)
+                let ring = radius + v * chu
+                return [ring * cu, ring * su, v * shu]
+            }
+            shouldOutput = true
+        }
+        return shouldOutput
+    }
+}
+
+// MARK: - Helicoid
+
+public class HelicoidGeometryNode: BaseGeometryNode {
+    public override class var name: String { "Helicoid Geometry" }
+    public override class var nodeDescription: String { "Generates a helicoid — a ruled spiral ramp surface" }
+
+    override public class func registerPorts(context: Context) -> [(name: String, port: Port)] {
+        let ports = super.registerPorts(context: context)
+        return [
+            ("inputRadius",      ParameterPort(parameter: FloatParameter("Radius",      1.5, .inputfield, "Outer radius of the helicoid"))),
+            ("inputPitch",       ParameterPort(parameter: FloatParameter("Pitch",        0.2, .inputfield, "Vertical rise per radian of rotation"))),
+            ("inputTurns",       ParameterPort(parameter: FloatParameter("Turns",        3.0, .inputfield, "Number of complete helical turns"))),
+            ("inputResolutionU", ParameterPort(parameter: IntParameter("Resolution U", 192,  .inputfield, "Segments along the helix angle"))),
+            ("inputResolutionV", ParameterPort(parameter: IntParameter("Resolution V",  64,  .inputfield, "Segments along the radial direction"))),
+        ] + ports
+    }
+
+    public var inputRadius:      ParameterPort<Float> { port(named: "inputRadius") }
+    public var inputPitch:       ParameterPort<Float> { port(named: "inputPitch") }
+    public var inputTurns:       ParameterPort<Float> { port(named: "inputTurns") }
+    public var inputResolutionU: ParameterPort<Int>   { port(named: "inputResolutionU") }
+    public var inputResolutionV: ParameterPort<Int>   { port(named: "inputResolutionV") }
+
+    public override var geometry: ParametricGeometry { _geometry }
+    private lazy var _geometry: ParametricGeometry = .helicoid(context: self.context)
+
+    override public func evaluate(geometry: Geometry, atTime: TimeInterval) -> Bool {
+        var shouldOutput = super.evaluate(geometry: geometry, atTime: atTime)
+        let geo = self.geometry
+
+        if inputRadius.valueDidChange || inputPitch.valueDidChange || inputTurns.valueDidChange ||
+           inputResolutionU.valueDidChange || inputResolutionV.valueDidChange {
+            let radius = inputRadius.value ?? 1.5
+            let pitch  = inputPitch.value  ?? 0.2
+            let turns  = inputTurns.value  ?? 3.0
+            let resU   = Int32(inputResolutionU.value ?? 192)
+            let resV   = Int32(inputResolutionV.value ?? 64)
+            geo.resolution = simd_int2(resU, resV)
+            geo.rangeU = 0 ... (.pi * 2 * turns)
+            geo.rangeV = -radius ... radius
+            geo.generator = { u, v in [v * cos(u), v * sin(u), pitch * u] }
+            shouldOutput = true
+        }
+        return shouldOutput
+    }
+}
+
+// MARK: - Superellipsoid
+
+public class SuperellipsoidGeometryNode: BaseGeometryNode {
+    public override class var name: String { "Superellipsoid Geometry" }
+    public override class var nodeDescription: String { "Generates a superellipsoid — a generalization of spheres and cylinders controlled by two shape exponents" }
+
+    override public class func registerPorts(context: Context) -> [(name: String, port: Port)] {
+        let ports = super.registerPorts(context: context)
+        return [
+            ("inputRadiusX",     ParameterPort(parameter: FloatParameter("Radius X",    1.0, .inputfield, "Scale along the X axis"))),
+            ("inputRadiusY",     ParameterPort(parameter: FloatParameter("Radius Y",    1.0, .inputfield, "Scale along the Y axis"))),
+            ("inputRadiusZ",     ParameterPort(parameter: FloatParameter("Radius Z",    1.0, .inputfield, "Scale along the Z axis"))),
+            ("inputExponentU",   ParameterPort(parameter: FloatParameter("Exponent U",  0.5, .inputfield, "Horizontal cross-section shape exponent (< 1 pinched, > 1 rounded)"))),
+            ("inputExponentV",   ParameterPort(parameter: FloatParameter("Exponent V",  0.5, .inputfield, "Vertical cross-section shape exponent"))),
+            ("inputResolutionU", ParameterPort(parameter: IntParameter("Resolution U", 160, .inputfield, "Segments along the U direction"))),
+            ("inputResolutionV", ParameterPort(parameter: IntParameter("Resolution V",  96, .inputfield, "Segments along the V direction"))),
+        ] + ports
+    }
+
+    public var inputRadiusX:     ParameterPort<Float> { port(named: "inputRadiusX") }
+    public var inputRadiusY:     ParameterPort<Float> { port(named: "inputRadiusY") }
+    public var inputRadiusZ:     ParameterPort<Float> { port(named: "inputRadiusZ") }
+    public var inputExponentU:   ParameterPort<Float> { port(named: "inputExponentU") }
+    public var inputExponentV:   ParameterPort<Float> { port(named: "inputExponentV") }
+    public var inputResolutionU: ParameterPort<Int>   { port(named: "inputResolutionU") }
+    public var inputResolutionV: ParameterPort<Int>   { port(named: "inputResolutionV") }
+
+    public override var geometry: ParametricGeometry { _geometry }
+    private lazy var _geometry: ParametricGeometry = .superellipsoid(context: self.context)
+
+    override public func evaluate(geometry: Geometry, atTime: TimeInterval) -> Bool {
+        var shouldOutput = super.evaluate(geometry: geometry, atTime: atTime)
+        let geo = self.geometry
+
+        if inputRadiusX.valueDidChange || inputRadiusY.valueDidChange || inputRadiusZ.valueDidChange ||
+           inputExponentU.valueDidChange || inputExponentV.valueDidChange ||
+           inputResolutionU.valueDidChange || inputResolutionV.valueDidChange {
+            let rx  = inputRadiusX.value   ?? 1.0
+            let ry  = inputRadiusY.value   ?? 1.0
+            let rz  = inputRadiusZ.value   ?? 1.0
+            let eu  = inputExponentU.value ?? 0.5
+            let ev  = inputExponentV.value ?? 0.5
+            let resU = Int32(inputResolutionU.value ?? 160)
+            let resV = Int32(inputResolutionV.value ?? 96)
+            geo.resolution = simd_int2(resU, resV)
+            geo.rangeU = -.pi ... .pi
+            geo.rangeV = (-.pi * 0.5) ... (.pi * 0.5)
+            geo.generator = { u, v in
+                let cv = _signedPow(cos(v), ev), sv = _signedPow(sin(v), ev)
+                let cu = _signedPow(cos(u), eu), su = _signedPow(sin(u), eu)
+                return [rx * cv * cu, ry * cv * su, rz * sv]
+            }
+            shouldOutput = true
+        }
+        return shouldOutput
+    }
+}
+
+// MARK: - Klein Bottle
+
+public class KleinBottleGeometryNode: BaseGeometryNode {
+    public override class var name: String { "Klein Bottle Geometry" }
+    public override class var nodeDescription: String { "Generates a Klein bottle — a non-orientable closed surface with no interior" }
+
+    override public class func registerPorts(context: Context) -> [(name: String, port: Port)] {
+        let ports = super.registerPorts(context: context)
+        return [
+            ("inputRadius",      ParameterPort(parameter: FloatParameter("Radius",      2.0,  .inputfield, "Overall scale of the bottle"))),
+            ("inputTube",        ParameterPort(parameter: FloatParameter("Tube Radius",  0.55, .inputfield, "Radius of the tubular cross-section"))),
+            ("inputResolutionU", ParameterPort(parameter: IntParameter("Resolution U", 192,   .inputfield, "Segments around the bottle axis"))),
+            ("inputResolutionV", ParameterPort(parameter: IntParameter("Resolution V",  96,   .inputfield, "Segments around the tube cross-section"))),
+        ] + ports
+    }
+
+    public var inputRadius:      ParameterPort<Float> { port(named: "inputRadius") }
+    public var inputTube:        ParameterPort<Float> { port(named: "inputTube") }
+    public var inputResolutionU: ParameterPort<Int>   { port(named: "inputResolutionU") }
+    public var inputResolutionV: ParameterPort<Int>   { port(named: "inputResolutionV") }
+
+    public override var geometry: ParametricGeometry { _geometry }
+    private lazy var _geometry: ParametricGeometry = .kleinBottle(context: self.context)
+
+    override public func evaluate(geometry: Geometry, atTime: TimeInterval) -> Bool {
+        let geo = self.geometry
+        var shouldOutput = super.evaluate(geometry: geo, atTime: atTime)
+
+        if inputRadius.valueDidChange || inputTube.valueDidChange ||
+           inputResolutionU.valueDidChange || inputResolutionV.valueDidChange {
+            let radius = inputRadius.value ?? 2.0
+            let tube   = inputTube.value   ?? 0.55
+            let resU   = Int32(inputResolutionU.value ?? 192)
+            let resV   = Int32(inputResolutionV.value ?? 96)
+            geo.resolution = simd_int2(resU, resV)
+            geo.rangeU = 0 ... (.pi * 2)
+            geo.rangeV = 0 ... (.pi * 2)
+            geo.generator = { u, v in
+                let cu = cos(u), su = sin(u)
+                let hu = u * 0.5
+                let chu = cos(hu), shu = sin(hu)
+                let sv = sin(v), s2v = sin(2 * v)
+                let ring = radius + tube * (chu * sv - shu * s2v)
+                let z = tube * (shu * sv + chu * s2v)
+                return [ring * cu, ring * su, z]
+            }
+            shouldOutput = true
+        }
+        return shouldOutput
+    }
+}
+
+// MARK: - Catenoid
+
+public class CatenoidGeometryNode: BaseGeometryNode {
+    public override class var name: String { "Catenoid Geometry" }
+    public override class var nodeDescription: String { "Generates a catenoid — the minimal surface of revolution formed by a catenary" }
+
+    override public class func registerPorts(context: Context) -> [(name: String, port: Port)] {
+        let ports = super.registerPorts(context: context)
+        return [
+            ("inputRadius",      ParameterPort(parameter: FloatParameter("Radius",      0.75, .inputfield, "Radius of the waist (narrowest point)"))),
+            ("inputHeight",      ParameterPort(parameter: FloatParameter("Height",       2.0,  .inputfield, "Total height of the surface"))),
+            ("inputResolutionU", ParameterPort(parameter: IntParameter("Resolution U", 160,   .inputfield, "Segments around the axis"))),
+            ("inputResolutionV", ParameterPort(parameter: IntParameter("Resolution V",  96,   .inputfield, "Segments along the height"))),
+        ] + ports
+    }
+
+    public var inputRadius:      ParameterPort<Float> { port(named: "inputRadius") }
+    public var inputHeight:      ParameterPort<Float> { port(named: "inputHeight") }
+    public var inputResolutionU: ParameterPort<Int>   { port(named: "inputResolutionU") }
+    public var inputResolutionV: ParameterPort<Int>   { port(named: "inputResolutionV") }
+
+    public override var geometry: ParametricGeometry { _geometry }
+    private lazy var _geometry: ParametricGeometry = .catenoid(context: self.context)
+
+    override public func evaluate(geometry: Geometry, atTime: TimeInterval) -> Bool {
+        var shouldOutput = super.evaluate(geometry: geometry, atTime: atTime)
+        let geo = self.geometry
+
+        if inputRadius.valueDidChange || inputHeight.valueDidChange ||
+           inputResolutionU.valueDidChange || inputResolutionV.valueDidChange {
+            let radius = inputRadius.value ?? 0.75
+            let height = inputHeight.value ?? 2.0
+            let resU   = Int32(inputResolutionU.value ?? 160)
+            let resV   = Int32(inputResolutionV.value ?? 96)
+            let halfH  = height * 0.5
+            geo.resolution = simd_int2(resU, resV)
+            geo.rangeU = 0 ... (.pi * 2)
+            geo.rangeV = -halfH ... halfH
+            geo.generator = { u, v in
+                let r = radius * cosh(v / max(radius, 0.0001))
+                return [r * cos(u), r * sin(u), v]
+            }
+            shouldOutput = true
+        }
+        return shouldOutput
+    }
+}
+
+// MARK: - Paraboloid
+
+public class ParaboloidGeometryNode: BaseGeometryNode {
+    public override class var name: String { "Paraboloid Geometry" }
+    public override class var nodeDescription: String { "Generates an elliptic paraboloid — a bowl-shaped quadric surface" }
+
+    override public class func registerPorts(context: Context) -> [(name: String, port: Port)] {
+        let ports = super.registerPorts(context: context)
+        return [
+            ("inputRadiusX",     ParameterPort(parameter: FloatParameter("Radius X",    1.0, .inputfield, "Horizontal scale along the X axis"))),
+            ("inputRadiusY",     ParameterPort(parameter: FloatParameter("Radius Y",    1.0, .inputfield, "Horizontal scale along the Y axis"))),
+            ("inputHeight",      ParameterPort(parameter: FloatParameter("Height",       2.0, .inputfield, "Vertical scale of the paraboloid"))),
+            ("inputResolutionU", ParameterPort(parameter: IntParameter("Resolution U", 160, .inputfield, "Segments around the axis"))),
+            ("inputResolutionV", ParameterPort(parameter: IntParameter("Resolution V",  80, .inputfield, "Segments along the radial direction"))),
+        ] + ports
+    }
+
+    public var inputRadiusX:     ParameterPort<Float> { port(named: "inputRadiusX") }
+    public var inputRadiusY:     ParameterPort<Float> { port(named: "inputRadiusY") }
+    public var inputHeight:      ParameterPort<Float> { port(named: "inputHeight") }
+    public var inputResolutionU: ParameterPort<Int>   { port(named: "inputResolutionU") }
+    public var inputResolutionV: ParameterPort<Int>   { port(named: "inputResolutionV") }
+
+    public override var geometry: ParametricGeometry { _geometry }
+    private lazy var _geometry: ParametricGeometry = .paraboloid(context: self.context)
+
+    override public func evaluate(geometry: Geometry, atTime: TimeInterval) -> Bool {
+        var shouldOutput = super.evaluate(geometry: geometry, atTime: atTime)
+        let geo = self.geometry
+
+        if inputRadiusX.valueDidChange || inputRadiusY.valueDidChange || inputHeight.valueDidChange ||
+           inputResolutionU.valueDidChange || inputResolutionV.valueDidChange {
+            let rx = inputRadiusX.value ?? 1.0
+            let ry = inputRadiusY.value ?? 1.0
+            let h  = inputHeight.value  ?? 2.0
+            let resU = Int32(inputResolutionU.value ?? 160)
+            let resV = Int32(inputResolutionV.value ?? 80)
+            geo.resolution = simd_int2(resU, resV)
+            geo.rangeU = 0 ... (.pi * 2)
+            geo.rangeV = 0 ... 1
+            geo.generator = { u, v in [rx * v * cos(u), ry * v * sin(u), h * v * v] }
+            shouldOutput = true
+        }
+        return shouldOutput
+    }
+}
+
+// MARK: - Enneper Surface
+
+public class EnneperSurfaceGeometryNode: BaseGeometryNode {
+    public override class var name: String { "Enneper Surface Geometry" }
+    public override class var nodeDescription: String { "Generates an Enneper surface — a self-intersecting minimal surface with cubic saddle geometry" }
+
+    override public class func registerPorts(context: Context) -> [(name: String, port: Port)] {
+        let ports = super.registerPorts(context: context)
+        return [
+            ("inputScale",       ParameterPort(parameter: FloatParameter("Scale",        0.35, .inputfield, "Uniform scale applied to the surface"))),
+            ("inputExtent",      ParameterPort(parameter: FloatParameter("Extent",        2.25, .inputfield, "Parameter domain half-extent for both U and V"))),
+            ("inputResolutionU", ParameterPort(parameter: IntParameter("Resolution U", 160,   .inputfield, "Segments along the U direction"))),
+            ("inputResolutionV", ParameterPort(parameter: IntParameter("Resolution V", 160,   .inputfield, "Segments along the V direction"))),
+        ] + ports
+    }
+
+    public var inputScale:       ParameterPort<Float> { port(named: "inputScale") }
+    public var inputExtent:      ParameterPort<Float> { port(named: "inputExtent") }
+    public var inputResolutionU: ParameterPort<Int>   { port(named: "inputResolutionU") }
+    public var inputResolutionV: ParameterPort<Int>   { port(named: "inputResolutionV") }
+
+    public override var geometry: ParametricGeometry { _geometry }
+    private lazy var _geometry: ParametricGeometry = .enneperSurface(context: self.context)
+
+    override public func evaluate(geometry: Geometry, atTime: TimeInterval) -> Bool {
+        var shouldOutput = super.evaluate(geometry: geometry, atTime: atTime)
+        let geo = self.geometry
+
+        if inputScale.valueDidChange || inputExtent.valueDidChange ||
+           inputResolutionU.valueDidChange || inputResolutionV.valueDidChange {
+            let scale  = inputScale.value  ?? 0.35
+            let extent = inputExtent.value ?? 2.25
+            let resU   = Int32(inputResolutionU.value ?? 160)
+            let resV   = Int32(inputResolutionV.value ?? 160)
+            geo.resolution = simd_int2(resU, resV)
+            geo.rangeU = -extent ... extent
+            geo.rangeV = -extent ... extent
+            geo.generator = { u, v in
+                let x = u - (u * u * u) / 3.0 + u * v * v
+                let y = v - (v * v * v) / 3.0 + v * u * u
+                let z = u * u - v * v
+                return scale * simd_make_float3(x, y, z)
+            }
+            shouldOutput = true
+        }
+        return shouldOutput
+    }
+}
+
+// MARK: - Pseudosphere
+
+public class PseudosphereGeometryNode: BaseGeometryNode {
+    public override class var name: String { "Pseudosphere Geometry" }
+    public override class var nodeDescription: String { "Generates a pseudosphere — a surface of constant negative Gaussian curvature" }
+
+    override public class func registerPorts(context: Context) -> [(name: String, port: Port)] {
+        let ports = super.registerPorts(context: context)
+        return [
+            ("inputRadius",       ParameterPort(parameter: FloatParameter("Radius",        1.0, .inputfield, "Radius of the pseudosphere"))),
+            ("inputHeightExtent", ParameterPort(parameter: FloatParameter("Height Extent",  3.0, .inputfield, "Half-height of the parameter domain along the axis"))),
+            ("inputResolutionU",  ParameterPort(parameter: IntParameter("Resolution U",  192, .inputfield, "Segments around the axis"))),
+            ("inputResolutionV",  ParameterPort(parameter: IntParameter("Resolution V",   96, .inputfield, "Segments along the height"))),
+        ] + ports
+    }
+
+    public var inputRadius:       ParameterPort<Float> { port(named: "inputRadius") }
+    public var inputHeightExtent: ParameterPort<Float> { port(named: "inputHeightExtent") }
+    public var inputResolutionU:  ParameterPort<Int>   { port(named: "inputResolutionU") }
+    public var inputResolutionV:  ParameterPort<Int>   { port(named: "inputResolutionV") }
+
+    public override var geometry: ParametricGeometry { _geometry }
+    private lazy var _geometry: ParametricGeometry = .pseudosphere(context: self.context)
+
+    override public func evaluate(geometry: Geometry, atTime: TimeInterval) -> Bool {
+        var shouldOutput = super.evaluate(geometry: geometry, atTime: atTime)
+        let geo = self.geometry
+
+        if inputRadius.valueDidChange || inputHeightExtent.valueDidChange ||
+           inputResolutionU.valueDidChange || inputResolutionV.valueDidChange {
+            let radius = inputRadius.value       ?? 1.0
+            let extent = inputHeightExtent.value ?? 3.0
+            let resU   = Int32(inputResolutionU.value ?? 192)
+            let resV   = Int32(inputResolutionV.value ?? 96)
+            geo.resolution = simd_int2(resU, resV)
+            geo.rangeU = 0 ... (.pi * 2)
+            geo.rangeV = -extent ... extent
+            geo.generator = { u, v in
+                let sv = _sech(v)
+                let z  = v - tanh(v)
+                return radius * simd_make_float3(sv * cos(u), sv * sin(u), z)
+            }
+            shouldOutput = true
+        }
+        return shouldOutput
+    }
+}
+
+// MARK: - Dupin Cyclide
+
+public class DupinCyclideGeometryNode: BaseGeometryNode {
+    public override class var name: String { "Dupin Cyclide Geometry" }
+    public override class var nodeDescription: String { "Generates a Dupin cyclide — a family of surfaces related to tori via sphere inversion" }
+
+    override public class func registerPorts(context: Context) -> [(name: String, port: Port)] {
+        let ports = super.registerPorts(context: context)
+        return [
+            ("inputMajorRadius",    ParameterPort(parameter: FloatParameter("Major Radius",    1.5, .inputfield, "Major radius of the base torus before inversion"))),
+            ("inputMinorRadius",    ParameterPort(parameter: FloatParameter("Minor Radius",    0.45, .inputfield, "Minor (tube) radius of the base torus before inversion"))),
+            ("inputTorusOffset",    ParameterPort(parameter: FloatParameter("Torus Offset",    2.4,  .inputfield, "Translation offset applied to the torus before inversion"))),
+            ("inputInversionRadius",ParameterPort(parameter: FloatParameter("Inversion Radius",1.0,  .inputfield, "Radius of the inversion sphere"))),
+            ("inputResolutionU",    ParameterPort(parameter: IntParameter("Resolution U",    192, .inputfield, "Segments around the primary axis"))),
+            ("inputResolutionV",    ParameterPort(parameter: IntParameter("Resolution V",     96, .inputfield, "Segments around the tube cross-section"))),
+        ] + ports
+    }
+
+    public var inputMajorRadius:     ParameterPort<Float> { port(named: "inputMajorRadius") }
+    public var inputMinorRadius:     ParameterPort<Float> { port(named: "inputMinorRadius") }
+    public var inputTorusOffset:     ParameterPort<Float> { port(named: "inputTorusOffset") }
+    public var inputInversionRadius: ParameterPort<Float> { port(named: "inputInversionRadius") }
+    public var inputResolutionU:     ParameterPort<Int>   { port(named: "inputResolutionU") }
+    public var inputResolutionV:     ParameterPort<Int>   { port(named: "inputResolutionV") }
+
+    public override var geometry: ParametricGeometry { _geometry }
+    private lazy var _geometry: ParametricGeometry = .dupinCyclide(context: self.context)
+
+    override public func evaluate(geometry: Geometry, atTime: TimeInterval) -> Bool {
+        var shouldOutput = super.evaluate(geometry: geometry, atTime: atTime)
+        let geo = self.geometry
+
+        if inputMajorRadius.valueDidChange || inputMinorRadius.valueDidChange ||
+           inputTorusOffset.valueDidChange || inputInversionRadius.valueDidChange ||
+           inputResolutionU.valueDidChange || inputResolutionV.valueDidChange {
+            let major = inputMajorRadius.value     ?? 1.5
+            let minor = inputMinorRadius.value     ?? 0.45
+            let offset = inputTorusOffset.value    ?? 2.4
+            let invR  = inputInversionRadius.value ?? 1.0
+            let resU  = Int32(inputResolutionU.value ?? 192)
+            let resV  = Int32(inputResolutionV.value ?? 96)
+            geo.resolution = simd_int2(resU, resV)
+            geo.rangeU = 0 ... (.pi * 2)
+            geo.rangeV = 0 ... (.pi * 2)
+            geo.generator = { u, v in
+                let ring = major + minor * cos(v)
+                let pt = simd_make_float3(ring * cos(u) + offset, ring * sin(u), minor * sin(v))
+                let lenSq = max(simd_length_squared(pt), 0.0001)
+                return pt * ((invR * invR) / lenSq)
+            }
+            shouldOutput = true
+        }
+        return shouldOutput
+    }
+}
+
+// MARK: - Roman Surface
+
+public class RomanSurfaceGeometryNode: BaseGeometryNode {
+    public override class var name: String { "Roman Surface Geometry" }
+    public override class var nodeDescription: String { "Generates Steiner's Roman surface — a self-intersecting immersion of the real projective plane" }
+
+    override public class func registerPorts(context: Context) -> [(name: String, port: Port)] {
+        let ports = super.registerPorts(context: context)
+        return [
+            ("inputScale",       ParameterPort(parameter: FloatParameter("Scale",        2.0, .inputfield, "Uniform scale of the surface"))),
+            ("inputResolutionU", ParameterPort(parameter: IntParameter("Resolution U", 160, .inputfield, "Segments around the U direction"))),
+            ("inputResolutionV", ParameterPort(parameter: IntParameter("Resolution V",  96, .inputfield, "Segments around the V direction"))),
+        ] + ports
+    }
+
+    public var inputScale:       ParameterPort<Float> { port(named: "inputScale") }
+    public var inputResolutionU: ParameterPort<Int>   { port(named: "inputResolutionU") }
+    public var inputResolutionV: ParameterPort<Int>   { port(named: "inputResolutionV") }
+
+    public override var geometry: ParametricGeometry { _geometry }
+    private lazy var _geometry: ParametricGeometry = .romanSurface(context: self.context)
+
+    override public func evaluate(geometry: Geometry, atTime: TimeInterval) -> Bool {
+        var shouldOutput = super.evaluate(geometry: geometry, atTime: atTime)
+        let geo = self.geometry
+
+        if inputScale.valueDidChange || inputResolutionU.valueDidChange || inputResolutionV.valueDidChange {
+            let scale = inputScale.value ?? 2.0
+            let resU  = Int32(inputResolutionU.value ?? 160)
+            let resV  = Int32(inputResolutionV.value ?? 96)
+            geo.resolution = simd_int2(resU, resV)
+            geo.rangeU = 0 ... (.pi * 2)
+            geo.rangeV = (-.pi * 0.5) ... (.pi * 0.5)
+            geo.generator = { u, v in
+                let sx = cos(u) * cos(v), sy = sin(u) * cos(v), sz = sin(v)
+                return scale * simd_make_float3(sy * sz, sz * sx, sx * sy)
+            }
+            shouldOutput = true
+        }
+        return shouldOutput
+    }
+}
+
+// MARK: - Cross Cap
+
+public class CrossCapGeometryNode: BaseGeometryNode {
+    public override class var name: String { "Cross Cap Geometry" }
+    public override class var nodeDescription: String { "Generates a cross-cap — another immersion of the real projective plane with two self-intersection lines" }
+
+    override public class func registerPorts(context: Context) -> [(name: String, port: Port)] {
+        let ports = super.registerPorts(context: context)
+        return [
+            ("inputScale",       ParameterPort(parameter: FloatParameter("Scale",        2.0, .inputfield, "Uniform scale of the surface"))),
+            ("inputResolutionU", ParameterPort(parameter: IntParameter("Resolution U", 160, .inputfield, "Segments along the U direction"))),
+            ("inputResolutionV", ParameterPort(parameter: IntParameter("Resolution V",  96, .inputfield, "Segments along the V direction"))),
+        ] + ports
+    }
+
+    public var inputScale:       ParameterPort<Float> { port(named: "inputScale") }
+    public var inputResolutionU: ParameterPort<Int>   { port(named: "inputResolutionU") }
+    public var inputResolutionV: ParameterPort<Int>   { port(named: "inputResolutionV") }
+
+    public override var geometry: ParametricGeometry { _geometry }
+    private lazy var _geometry: ParametricGeometry = .crossCap(context: self.context)
+
+    override public func evaluate(geometry: Geometry, atTime: TimeInterval) -> Bool {
+        var shouldOutput = super.evaluate(geometry: geometry, atTime: atTime)
+        let geo = self.geometry
+
+        if inputScale.valueDidChange || inputResolutionU.valueDidChange || inputResolutionV.valueDidChange {
+            let scale = inputScale.value ?? 2.0
+            let resU  = Int32(inputResolutionU.value ?? 160)
+            let resV  = Int32(inputResolutionV.value ?? 96)
+            geo.resolution = simd_int2(resU, resV)
+            geo.rangeU = 0 ... .pi
+            geo.rangeV = 0 ... (.pi * 2)
+            geo.generator = { u, v in
+                let x = sin(u) * sin(u) * sin(2 * v) * 0.5
+                let y = sin(2 * u) * sin(v) * 0.5
+                let z = sin(2 * u) * cos(v) * 0.5
+                return scale * simd_make_float3(x, y, z)
+            }
+            shouldOutput = true
+        }
+        return shouldOutput
+    }
+}
+
+// MARK: - Bour Surface
+
+public class BourSurfaceGeometryNode: BaseGeometryNode {
+    public override class var name: String { "Bour Surface Geometry" }
+    public override class var nodeDescription: String { "Generates a Bour surface — a minimal surface discovered by Edmond Bour in 1862" }
+
+    override public class func registerPorts(context: Context) -> [(name: String, port: Port)] {
+        let ports = super.registerPorts(context: context)
+        return [
+            ("inputRadius",      ParameterPort(parameter: FloatParameter("Radius",      1.35, .inputfield, "Radial extent of the parameter domain"))),
+            ("inputTurns",       ParameterPort(parameter: FloatParameter("Turns",        4.0,  .inputfield, "Number of turns (multiples of π) in the angular domain"))),
+            ("inputScale",       ParameterPort(parameter: FloatParameter("Scale",        0.65, .inputfield, "Uniform scale applied to the output surface"))),
+            ("inputResolutionU", ParameterPort(parameter: IntParameter("Resolution U", 192,   .inputfield, "Segments along the radial direction"))),
+            ("inputResolutionV", ParameterPort(parameter: IntParameter("Resolution V",  96,   .inputfield, "Segments along the angular direction"))),
+        ] + ports
+    }
+
+    public var inputRadius:      ParameterPort<Float> { port(named: "inputRadius") }
+    public var inputTurns:       ParameterPort<Float> { port(named: "inputTurns") }
+    public var inputScale:       ParameterPort<Float> { port(named: "inputScale") }
+    public var inputResolutionU: ParameterPort<Int>   { port(named: "inputResolutionU") }
+    public var inputResolutionV: ParameterPort<Int>   { port(named: "inputResolutionV") }
+
+    public override var geometry: ParametricGeometry { _geometry }
+    private lazy var _geometry: ParametricGeometry = .bourSurface(context: self.context)
+
+    override public func evaluate(geometry: Geometry, atTime: TimeInterval) -> Bool {
+        var shouldOutput = super.evaluate(geometry: geometry, atTime: atTime)
+        let geo = self.geometry
+
+        if inputRadius.valueDidChange || inputTurns.valueDidChange || inputScale.valueDidChange ||
+           inputResolutionU.valueDidChange || inputResolutionV.valueDidChange {
+            let radius = inputRadius.value ?? 1.35
+            let turns  = inputTurns.value  ?? 4.0
+            let scale  = inputScale.value  ?? 0.65
+            let resU   = Int32(inputResolutionU.value ?? 192)
+            let resV   = Int32(inputResolutionV.value ?? 96)
+            geo.resolution = simd_int2(resU, resV)
+            geo.rangeU = 0 ... radius
+            geo.rangeV = 0 ... (.pi * turns)
+            geo.generator = { r, theta in
+                let x = r * cos(theta) - 0.5 * r * r * cos(2 * theta)
+                let y = -r * sin(theta) - 0.5 * r * r * sin(2 * theta)
+                let z = (4.0 / 3.0) * pow(max(r, 0.0), 1.5) * cos(1.5 * theta)
+                return scale * simd_make_float3(x, y, z)
+            }
+            shouldOutput = true
+        }
+        return shouldOutput
+    }
+}
+
+// MARK: - Breather Surface
+
+public class BreatherSurfaceGeometryNode: BaseGeometryNode {
+    public override class var name: String { "Breather Surface Geometry" }
+    public override class var nodeDescription: String { "Generates a breather surface — a pseudo-spherical surface related to solutions of the sine-Gordon equation" }
+
+    override public class func registerPorts(context: Context) -> [(name: String, port: Port)] {
+        let ports = super.registerPorts(context: context)
+        return [
+            ("inputParameterA",  ParameterPort(parameter: FloatParameter("Parameter A",    0.4,   .inputfield, "Shape parameter in (0, 1); values near 0 or 1 collapse the surface"))),
+            ("inputRangeUMin",   ParameterPort(parameter: FloatParameter("Range U Min",   -14.0,  .inputfield, "Lower bound of the U parameter domain"))),
+            ("inputRangeUMax",   ParameterPort(parameter: FloatParameter("Range U Max",    14.0,  .inputfield, "Upper bound of the U parameter domain"))),
+            ("inputRangeVMin",   ParameterPort(parameter: FloatParameter("Range V Min",   -37.4,  .inputfield, "Lower bound of the V parameter domain"))),
+            ("inputRangeVMax",   ParameterPort(parameter: FloatParameter("Range V Max",    37.4,  .inputfield, "Upper bound of the V parameter domain"))),
+            ("inputScale",       ParameterPort(parameter: FloatParameter("Scale",            0.2,  .inputfield, "Uniform scale applied to the output surface"))),
+            ("inputResolutionU", ParameterPort(parameter: IntParameter("Resolution U",    192,    .inputfield, "Segments along the U direction"))),
+            ("inputResolutionV", ParameterPort(parameter: IntParameter("Resolution V",    160,    .inputfield, "Segments along the V direction"))),
+        ] + ports
+    }
+
+    public var inputParameterA:  ParameterPort<Float> { port(named: "inputParameterA") }
+    public var inputRangeUMin:   ParameterPort<Float> { port(named: "inputRangeUMin") }
+    public var inputRangeUMax:   ParameterPort<Float> { port(named: "inputRangeUMax") }
+    public var inputRangeVMin:   ParameterPort<Float> { port(named: "inputRangeVMin") }
+    public var inputRangeVMax:   ParameterPort<Float> { port(named: "inputRangeVMax") }
+    public var inputScale:       ParameterPort<Float> { port(named: "inputScale") }
+    public var inputResolutionU: ParameterPort<Int>   { port(named: "inputResolutionU") }
+    public var inputResolutionV: ParameterPort<Int>   { port(named: "inputResolutionV") }
+
+    public override var geometry: ParametricGeometry { _geometry }
+    private lazy var _geometry: ParametricGeometry = .breatherSurface(context: self.context)
+
+    override public func evaluate(geometry: Geometry, atTime: TimeInterval) -> Bool {
+        var shouldOutput = super.evaluate(geometry: geometry, atTime: atTime)
+        let geo = self.geometry
+
+        if inputParameterA.valueDidChange || inputRangeUMin.valueDidChange || inputRangeUMax.valueDidChange ||
+           inputRangeVMin.valueDidChange  || inputRangeVMax.valueDidChange  || inputScale.valueDidChange ||
+           inputResolutionU.valueDidChange || inputResolutionV.valueDidChange {
+            let rawA   = inputParameterA.value ?? 0.4
+            let a      = simd_clamp(rawA, 0.05, 0.95)
+            let b      = sqrt(max(1.0 - a * a, 0.0001))
+            let uMin   = inputRangeUMin.value ?? -14.0
+            let uMax   = inputRangeUMax.value ??  14.0
+            let vMin   = inputRangeVMin.value ?? -37.4
+            let vMax   = inputRangeVMax.value ??  37.4
+            let scale  = inputScale.value ?? 0.2
+            let resU   = Int32(inputResolutionU.value ?? 192)
+            let resV   = Int32(inputResolutionV.value ?? 160)
+            geo.resolution = simd_int2(resU, resV)
+            geo.rangeU = min(uMin, uMax) ... max(uMin, uMax)
+            geo.rangeV = min(vMin, vMax) ... max(vMin, vMax)
+            geo.generator = { u, v in
+                let au = a * u
+                let cau = cosh(au), sau = sinh(au)
+                let sbv = sin(b * v), cbv = cos(b * v)
+                let w0 = (1.0 - a * a) * cau * cau
+                let w1 = a * a * sbv * sbv
+                let w  = max(a * (w0 + w1), 0.0001)
+                let x  = -u + 2.0 * (1.0 - a * a) * cau * sau / w
+                let y  = 2.0 * b * cau * (-b * cos(v) * cbv - sin(v) * sbv) / w
+                let z  = 2.0 * b * cau * (-b * sin(v) * cbv + cos(v) * sbv) / w
+                return scale * simd_make_float3(x, y, z)
+            }
+            shouldOutput = true
+        }
+        return shouldOutput
+    }
+}
+
+// MARK: - Dini Surface
+
+public class DiniSurfaceGeometryNode: BaseGeometryNode {
+    public override class var name: String { "Dini Surface Geometry" }
+    public override class var nodeDescription: String { "Generates a Dini surface — a pseudo-spherical surface that looks like a twisted trumpet" }
+
+    override public class func registerPorts(context: Context) -> [(name: String, port: Port)] {
+        let ports = super.registerPorts(context: context)
+        return [
+            ("inputRadius",      ParameterPort(parameter: FloatParameter("Radius",       1.0,           .inputfield, "Overall radius of the surface"))),
+            ("inputTwist",       ParameterPort(parameter: FloatParameter("Twist",         0.2,           .inputfield, "Axial twist applied per unit of U"))),
+            ("inputRangeUMin",   ParameterPort(parameter: FloatParameter("Range U Min",   0.0,           .inputfield, "Lower bound of the U parameter domain"))),
+            ("inputRangeUMax",   ParameterPort(parameter: FloatParameter("Range U Max",   .pi * 4.0,     .inputfield, "Upper bound of the U parameter domain"))),
+            ("inputRangeVMin",   ParameterPort(parameter: FloatParameter("Range V Min",   0.08,          .inputfield, "Lower bound of the V parameter domain (avoid 0 singularity)"))),
+            ("inputRangeVMax",   ParameterPort(parameter: FloatParameter("Range V Max",   1.45,          .inputfield, "Upper bound of the V parameter domain (avoid π singularity)"))),
+            ("inputResolutionU", ParameterPort(parameter: IntParameter("Resolution U", 192,             .inputfield, "Segments along the U direction"))),
+            ("inputResolutionV", ParameterPort(parameter: IntParameter("Resolution V",  96,             .inputfield, "Segments along the V direction"))),
+        ] + ports
+    }
+
+    public var inputRadius:      ParameterPort<Float> { port(named: "inputRadius") }
+    public var inputTwist:       ParameterPort<Float> { port(named: "inputTwist") }
+    public var inputRangeUMin:   ParameterPort<Float> { port(named: "inputRangeUMin") }
+    public var inputRangeUMax:   ParameterPort<Float> { port(named: "inputRangeUMax") }
+    public var inputRangeVMin:   ParameterPort<Float> { port(named: "inputRangeVMin") }
+    public var inputRangeVMax:   ParameterPort<Float> { port(named: "inputRangeVMax") }
+    public var inputResolutionU: ParameterPort<Int>   { port(named: "inputResolutionU") }
+    public var inputResolutionV: ParameterPort<Int>   { port(named: "inputResolutionV") }
+
+    public override var geometry: ParametricGeometry { _geometry }
+    private lazy var _geometry: ParametricGeometry = .diniSurface(context: self.context)
+
+    override public func evaluate(geometry: Geometry, atTime: TimeInterval) -> Bool {
+        var shouldOutput = super.evaluate(geometry: geometry, atTime: atTime)
+        let geo = self.geometry
+
+        if inputRadius.valueDidChange || inputTwist.valueDidChange ||
+           inputRangeUMin.valueDidChange || inputRangeUMax.valueDidChange ||
+           inputRangeVMin.valueDidChange || inputRangeVMax.valueDidChange ||
+           inputResolutionU.valueDidChange || inputResolutionV.valueDidChange {
+            let radius = inputRadius.value    ?? 1.0
+            let twist  = inputTwist.value     ?? 0.2
+            let uMin   = inputRangeUMin.value ?? 0.0
+            let uMax   = inputRangeUMax.value ?? (.pi * 4.0)
+            let vMin   = inputRangeVMin.value ?? 0.08
+            let vMax   = inputRangeVMax.value ?? 1.45
+            let resU   = Int32(inputResolutionU.value ?? 192)
+            let resV   = Int32(inputResolutionV.value ?? 96)
+            geo.resolution = simd_int2(resU, resV)
+            geo.rangeU = min(uMin, uMax) ... max(uMin, uMax)
+            geo.rangeV = min(vMin, vMax) ... max(vMin, vMax)
+            geo.generator = { u, v in
+                let safeV = simd_clamp(v, 0.0001, .pi - 0.0001)
+                let x = radius * cos(u) * sin(safeV)
+                let y = radius * sin(u) * sin(safeV)
+                let z = radius * (cos(safeV) + log(tan(safeV * 0.5))) + twist * u
+                return simd_make_float3(x, y, z)
+            }
+            shouldOutput = true
+        }
+        return shouldOutput
+    }
+}

--- a/Fabric/Nodes/Geometry/PerspectiveQuadGeometryNode.swift
+++ b/Fabric/Nodes/Geometry/PerspectiveQuadGeometryNode.swift
@@ -134,7 +134,7 @@ public class PerspectiveQuadGeometryNode : BaseGeometryNode
 
     private lazy var _geometry = PerspectiveQuadGeometry(context:self.context)
 
-    override public func evaluate(geometry: SatinGeometry, atTime: TimeInterval) -> Bool
+    override public func evaluate(geometry: Geometry, atTime: TimeInterval) -> Bool
     {
         var shouldOutputGeometry = super.evaluate(geometry: geometry, atTime: atTime)
 

--- a/Fabric/Nodes/Geometry/PixelArrayToGeometryNode.swift
+++ b/Fabric/Nodes/Geometry/PixelArrayToGeometryNode.swift
@@ -47,7 +47,7 @@ public class PixelArrayToGeometryNode : BaseGeometryNode
                                                     normals: [],
                                                     uvs: [])
 
-    override public func evaluate(geometry: SatinGeometry, atTime: TimeInterval) -> Bool
+    override public func evaluate(geometry: Geometry, atTime: TimeInterval) -> Bool
     {
         // Base applies primitive-type changes / dirty state to the current geometry.
         var shouldOutput = super.evaluate(geometry: geometry, atTime: atTime)

--- a/Fabric/Nodes/Geometry/PlaneGeometryNode.swift
+++ b/Fabric/Nodes/Geometry/PlaneGeometryNode.swift
@@ -39,7 +39,7 @@ public class PlaneGeometryNode : BaseGeometryNode
 
     private lazy var _geometry = PlaneGeometry(context:self.context, width: 1, height: 1, orientation: .xy)
     
-    override public func evaluate(geometry: SatinGeometry, atTime: TimeInterval) -> Bool
+    override public func evaluate(geometry: Geometry, atTime: TimeInterval) -> Bool
     {
         var shouldOutputGeometry = super.evaluate(geometry: geometry, atTime: atTime)
 

--- a/Fabric/Nodes/Geometry/RoundBoxGeometryNode.swift
+++ b/Fabric/Nodes/Geometry/RoundBoxGeometryNode.swift
@@ -36,7 +36,7 @@ public class RoundBoxGeometryNode : BaseGeometryNode
 
     private lazy var _geometry = RoundedBoxGeometry(context:self.context, size: .init(repeating: 2.0), radius: 0.25, resolution: 3)
     
-    override public func evaluate(geometry: SatinGeometry, atTime: TimeInterval) -> Bool
+    override public func evaluate(geometry: Geometry, atTime: TimeInterval) -> Bool
     {
         var shouldOutputGeometry = super.evaluate(geometry: geometry, atTime: atTime)
       

--- a/Fabric/Nodes/Geometry/RoundRectGeometryNode.swift
+++ b/Fabric/Nodes/Geometry/RoundRectGeometryNode.swift
@@ -40,7 +40,7 @@ public class RoundRectGeometryNode : BaseGeometryNode
 
     private lazy var _geometry = RoundedRectGeometry(context:self.context, width: 1, height: 1, radius: 0.2, angularResolution: 32, radialResolution: 32)
     
-    override public func evaluate(geometry: SatinGeometry, atTime: TimeInterval) -> Bool
+    override public func evaluate(geometry: Geometry, atTime: TimeInterval) -> Bool
     {
         var shouldOutputGeometry = super.evaluate(geometry: geometry, atTime: atTime)
 

--- a/Fabric/Nodes/Geometry/SphereGeometryNode.swift
+++ b/Fabric/Nodes/Geometry/SphereGeometryNode.swift
@@ -34,7 +34,7 @@ public class SphereGeometryNode : BaseGeometryNode
 
     private lazy var _geometry = SphereGeometry(context:self.context, radius: 1.0, angularResolution: 60, verticalResolution: 30)
     
-    override public func evaluate(geometry: SatinGeometry, atTime: TimeInterval) -> Bool
+    override public func evaluate(geometry: Geometry, atTime: TimeInterval) -> Bool
     {
         var shouldOutputGeometry = super.evaluate(geometry: geometry, atTime: atTime)
 

--- a/Fabric/Nodes/Geometry/SuperShape/SuperShapeGeometryNode.swift
+++ b/Fabric/Nodes/Geometry/SuperShape/SuperShapeGeometryNode.swift
@@ -192,7 +192,7 @@ class SuperShapeGeometryNode : BaseGeometryNode
                                                     n32: self.n32Param.value ?? 0.0,
                                                     res: self.resParam.value ?? 0)
     
-    override public func evaluate(geometry: SatinGeometry, atTime: TimeInterval) -> Bool {
+    override public func evaluate(geometry: Geometry, atTime: TimeInterval) -> Bool {
         
         var shouldOutput = super.evaluate(geometry: geometry, atTime: atTime)
         

--- a/Fabric/Nodes/Geometry/TesselatedTextGeometryNode.swift
+++ b/Fabric/Nodes/Geometry/TesselatedTextGeometryNode.swift
@@ -43,7 +43,7 @@ public class TesselatedTextGeometryNode : BaseGeometryNode
         }
     }
     
-    override public func evaluate(geometry: SatinGeometry, atTime: TimeInterval) -> Bool
+    override public func evaluate(geometry: Geometry, atTime: TimeInterval) -> Bool
     {
         var shouldOutputGeometry = false 
         if self.inputText.valueDidChange,

--- a/Fabric/Nodes/Geometry/TorusGeometryNode.swift
+++ b/Fabric/Nodes/Geometry/TorusGeometryNode.swift
@@ -36,7 +36,7 @@ public class TorusGeometryNode : BaseGeometryNode
 
     private lazy var _geometry = TorusGeometry(context:self.context, minorRadius: 5.0, majorRadius: 0.25, minorResolution: 20, majorResolution: 20)
 
-    override public func evaluate(geometry: SatinGeometry, atTime: TimeInterval) -> Bool
+    override public func evaluate(geometry: Geometry, atTime: TimeInterval) -> Bool
     {
         var shouldOutputGeometry = super.evaluate(geometry: geometry, atTime: atTime)
 

--- a/Fabric/Nodes/Geometry/TriangleGeometryNode.swift
+++ b/Fabric/Nodes/Geometry/TriangleGeometryNode.swift
@@ -31,7 +31,7 @@ public class TriangleGeometryNode : BaseGeometryNode
     
     private lazy var _geometry = TriangleGeometry(context:self.context, size: 1.0)
 
-    override public func evaluate(geometry: SatinGeometry, atTime: TimeInterval) -> Bool
+    override public func evaluate(geometry: Geometry, atTime: TimeInterval) -> Bool
     {
         var shouldOutputGeometry = super.evaluate(geometry: geometry, atTime: atTime)
 

--- a/Fabric/Nodes/Geometry/TubeGeometryNode.swift
+++ b/Fabric/Nodes/Geometry/TubeGeometryNode.swift
@@ -40,7 +40,7 @@ public class TubeGeometryNode : BaseGeometryNode
 
     private lazy var _geometry = TubeGeometry(context:self.context, radius: 0.25, height: 0.75, startAngle: 0.0, endAngle: degToRad(90.0), angularResolution: 20, verticalResolution: 5)
 
-    override public func evaluate(geometry: SatinGeometry, atTime: TimeInterval) -> Bool
+    override public func evaluate(geometry: Geometry, atTime: TimeInterval) -> Bool
     {
         var shouldOutputGeometry = super.evaluate(geometry: geometry, atTime: atTime)
 

--- a/Fabric/Nodes/NodeRegistry.swift
+++ b/Fabric/Nodes/NodeRegistry.swift
@@ -45,9 +45,14 @@ public class NodeRegistry {
     }()
 
     private lazy var nodesClassLookup: [String: Node.Type] =  {
-        self.nodesClasses.reduce(into: [:]) { result, nodeClass in
+        var result = self.nodesClasses.reduce(into: [String: Node.Type]()) { result, nodeClass in
             result[String(describing: nodeClass)] = nodeClass
         }
+        // Legacy class-name aliases: old saved graphs used SatinGeometry in generic type params.
+        // Both module-qualified and bare forms are covered since Swift's output can vary.
+        result["PassThroughNode<SatinGeometry>"] = PassThroughNode<Geometry>.self
+        result["PassThroughNode<Satin.SatinGeometry>"] = PassThroughNode<Geometry>.self
+        return result
     }()
     
     private lazy var nodeFileLoadingClasses: [(any NodeFileLoadingProtocol.Type)] =  {
@@ -89,7 +94,7 @@ public class NodeRegistry {
     ]
     
     private var geometryNodeClasses: [Node.Type] = [ // Geometry
-        PassThroughNode<SatinGeometry>.self,
+        PassThroughNode<Geometry>.self,
         PlaneGeometryNode.self,
         PerspectiveQuadGeometryNode.self,
         RoundRectGeometryNode.self,
@@ -110,6 +115,20 @@ public class NodeRegistry {
         ExtrudedTextGeometryNode.self,
         PixelArrayToGeometryNode.self,
         SuperShapeGeometryNode.self,
+        MobiusStripGeometryNode.self,
+        HelicoidGeometryNode.self,
+        SuperellipsoidGeometryNode.self,
+        KleinBottleGeometryNode.self,
+        CatenoidGeometryNode.self,
+        ParaboloidGeometryNode.self,
+        EnneperSurfaceGeometryNode.self,
+        PseudosphereGeometryNode.self,
+        DupinCyclideGeometryNode.self,
+        RomanSurfaceGeometryNode.self,
+        CrossCapGeometryNode.self,
+        BourSurfaceGeometryNode.self,
+        BreatherSurfaceGeometryNode.self,
+        DiniSurfaceGeometryNode.self,
     ]
         
     private var materialNodeClasses:[Node.Type] = [

--- a/Fabric/Nodes/NodeRegistry.swift
+++ b/Fabric/Nodes/NodeRegistry.swift
@@ -129,6 +129,7 @@ public class NodeRegistry {
         BourSurfaceGeometryNode.self,
         BreatherSurfaceGeometryNode.self,
         DiniSurfaceGeometryNode.self,
+        MathExpressionParametricGeometryNode.self,
     ]
         
     private var materialNodeClasses:[Node.Type] = [

--- a/Fabric/Nodes/Object/Lights/DirectionalLightNode.swift
+++ b/Fabric/Nodes/Object/Lights/DirectionalLightNode.swift
@@ -59,7 +59,6 @@ public class DirectionalLightNode : ObjectNode<DirectionalLight>
         self.light.castShadow = true
         self.light.shadow.resolution = (1024, 1024)
         self.light.shadow.bias = 0.0005
-        self.light.shadow.normalBias = 0.0005
         self.light.shadow.strength = 0.5
         self.light.shadow.radius = 2
 
@@ -107,7 +106,6 @@ public class DirectionalLightNode : ObjectNode<DirectionalLight>
            let inputShadowBias = self.inputShadowBias.value
         {
             self.light.shadow.bias = inputShadowBias
-            self.light.shadow.normalBias = inputShadowBias
             shouldOutput = true
         }
         

--- a/Fabric/Nodes/Object/Lights/DirectionalLightNode.swift
+++ b/Fabric/Nodes/Object/Lights/DirectionalLightNode.swift
@@ -59,6 +59,7 @@ public class DirectionalLightNode : ObjectNode<DirectionalLight>
         self.light.castShadow = true
         self.light.shadow.resolution = (1024, 1024)
         self.light.shadow.bias = 0.0005
+        self.light.shadow.normalBias = 0.0005
         self.light.shadow.strength = 0.5
         self.light.shadow.radius = 2
 
@@ -106,6 +107,7 @@ public class DirectionalLightNode : ObjectNode<DirectionalLight>
            let inputShadowBias = self.inputShadowBias.value
         {
             self.light.shadow.bias = inputShadowBias
+            self.light.shadow.normalBias = inputShadowBias
             shouldOutput = true
         }
         

--- a/Fabric/Nodes/Object/Renderables/InstancedMeshNode.swift
+++ b/Fabric/Nodes/Object/Renderables/InstancedMeshNode.swift
@@ -21,7 +21,7 @@ public class InstancedMeshNode : BaseRenderableNode<InstancedMesh>
         let ports = super.registerPorts(context: context)
         
         return [
-            ("inputGeometry", NodePort<SatinGeometry>(name: "Geometry", kind: .Inlet, description: "Geometry mesh to render")),
+            ("inputGeometry", NodePort<Geometry>(name: "Geometry", kind: .Inlet, description: "Geometry mesh to render")),
             ("inputMaterial", NodePort<Material>(name: "Material", kind: .Inlet, description: "Material to apply to the geometry")),
             ("inputTransforms", NodePort<ContiguousArray<simd_float4x4>>(name: "Transforms", kind: .Inlet, description: "Array of transforms for each instance")),
             ("inputCastsShadow", ParameterPort(parameter:BoolParameter("Enable Shadows", true, .button, "When enabled, the mesh casts and receives shadows"))),
@@ -30,7 +30,7 @@ public class InstancedMeshNode : BaseRenderableNode<InstancedMesh>
         ] + ports
     }
     // Proxy Ports
-    public var inputGeometry:NodePort<SatinGeometry> { port(named: "inputGeometry") }
+    public var inputGeometry:NodePort<Geometry> { port(named: "inputGeometry") }
     public var inputMaterial:NodePort<Material> { port(named: "inputMaterial") }
     public var inputTransforms:NodePort<ContiguousArray<simd_float4x4>> { port(named: "inputTransforms") }
     public var inputCastsShadow:ParameterPort<Bool> { port(named: "inputCastsShadow") }

--- a/Fabric/Nodes/Object/Renderables/MeshNode.swift
+++ b/Fabric/Nodes/Object/Renderables/MeshNode.swift
@@ -22,7 +22,7 @@ public class MeshNode : BaseRenderableNode<Mesh>
         let ports = super.registerPorts(context: context)
         
         return ports + [
-            ("inputGeometry",  NodePort<SatinGeometry>(name: "Geometry", kind: .Inlet, description: "Geometry mesh to render")),
+            ("inputGeometry",  NodePort<Geometry>(name: "Geometry", kind: .Inlet, description: "Geometry mesh to render")),
             ("inputMaterial",  NodePort<Material>(name: "Material", kind: .Inlet, description: "Material to apply to the geometry")),
             ("inputCastsShadow",  ParameterPort(parameter: BoolParameter("Enable Shadows", true, .button, "When enabled, the mesh casts and receives shadows") ) ),
             ("inputDoubleSided",  ParameterPort(parameter: BoolParameter("Double Sided", false, .button, "When enabled, renders both front and back faces") ) ),
@@ -31,7 +31,7 @@ public class MeshNode : BaseRenderableNode<Mesh>
     }
         
     // Ergonomic access (no storage assignment needed)
-    public var inputGeometry: NodePort<SatinGeometry>   { port(named: "inputGeometry") }
+    public var inputGeometry: NodePort<Geometry>   { port(named: "inputGeometry") }
     public var inputMaterial: NodePort<Material>   { port(named: "inputMaterial") }
     public var inputCastsShadow: ParameterPort<Bool>   { port(named: "inputCastsShadow") }
     public var inputDoubleSided: ParameterPort<Bool>   { port(named: "inputDoubleSided") }

--- a/Fabric/Nodes/Object/SubGraph/SubgraphNode.swift
+++ b/Fabric/Nodes/Object/SubGraph/SubgraphNode.swift
@@ -79,7 +79,7 @@ public class SubgraphNode: BaseObjectNode
         case let p as NodePort<simd_float3>:                        return ProxyPort(wrapping: p)
         case let p as NodePort<simd_float4>:                        return ProxyPort(wrapping: p)
         case let p as NodePort<FabricImage>:                        return ProxyPort(wrapping: p)
-        case let p as NodePort<SatinGeometry>:                      return ProxyPort(wrapping: p)
+        case let p as NodePort<Geometry>:                           return ProxyPort(wrapping: p)
         case let p as NodePort<Material>:                           return ProxyPort(wrapping: p)
         case let p as NodePort<PortValue>:                          return ProxyPort(wrapping: p)
         case let p as NodePort<simd_quatf>:                         return ProxyPort(wrapping: p)

--- a/Fabric/Nodes/Parameters/Array/GeometryToTransformArrayNode.swift
+++ b/Fabric/Nodes/Parameters/Array/GeometryToTransformArrayNode.swift
@@ -36,13 +36,13 @@ public class GeometryToTransformArrayNode : StrategyNode
 
         return ports +
         [
-            ("inputPort", NodePort<SatinGeometry>(name: "Geometry", kind: .Inlet, description: "Source geometry to extract vertex positions and normals from")),
+            ("inputPort", NodePort<Geometry>(name: "Geometry", kind: .Inlet, description: "Source geometry to extract vertex positions and normals from")),
             ("inputTransform", NodePort<simd_float4x4>(name: "Transform", kind: .Inlet, description: "Transform to apply to each point")),
         ]
     }
 
     // Port Proxy
-    public var inputPort:NodePort<SatinGeometry> { port(named: "inputPort") }
+    public var inputPort:NodePort<Geometry> { port(named: "inputPort") }
     public var inputTransform:NodePort<simd_float4x4> { port(named: "inputTransform") }
 
     private static let allDynamicNames: Set<String> = [
@@ -92,21 +92,34 @@ public class GeometryToTransformArrayNode : StrategyNode
         // This is subtle: the geometry POINTER can stay identical while its
         // backing buffer changes, so we re-extract every frame rather than
         // gating on valueDidChange.
-        guard let geometry = self.inputPort.value else { return }
+        guard let inputGeometry = self.inputPort.value else { return }
 
-        // The geometry is not necessarily attached to a mesh, so its update
-        // function may not have run — call it manually here.
-        geometry.update()
+        // Resolve vertex data depending on geometry type.
+        // SatinGeometry exposes a C GeometryData struct; ParametricGeometry
+        // stores vertices in a public Swift array. Both contain SatinVertex.
+        let vertices: [SatinVertex]
+        if let satinGeo = inputGeometry as? SatinGeometry {
+            // Geometry is not necessarily attached to a mesh, so its update
+            // function may not have run — call it manually here.
+            satinGeo.update()
+            let count = Int(satinGeo.geometryData.vertexCount)
+            vertices = Array(UnsafeBufferPointer(start: satinGeo.geometryData.vertexData, count: count))
+        } else if let parametricGeo = inputGeometry as? ParametricGeometry {
+            // generateGeometry() re-evaluates the parametric surface using the
+            // current generator/ranges set by the upstream node's evaluate call.
+//            parametricGeo.generateGeometry()
+            vertices = parametricGeo.vertexData
+        } else {
+            return
+        }
 
+        let vertexCount = vertices.count
         let inputTransform = self.inputTransform.value ?? matrix_identity_float4x4
-        let vertexCount = Int(geometry.geometryData.vertexCount)
 
         switch self.strategy
         {
         case "Transform":
             guard let outputTransforms: NodePort<ContiguousArray<simd_float4x4>> = findPort(named: "outputTransforms") else { return }
-
-            let vertices = UnsafeBufferPointer(start: geometry.geometryData.vertexData, count: vertexCount)
 
             var output = ContiguousArray<simd_float4x4>()
             output.reserveCapacity(vertexCount)
@@ -131,8 +144,6 @@ public class GeometryToTransformArrayNode : StrategyNode
             // it once and compose it with each per-vertex normal orientation.
             // Scale is intentionally dropped — a point has no meaningful scale.
             let inputRotation = inputTransform.decomposedTRS.rotation
-
-            let vertices = UnsafeBufferPointer(start: geometry.geometryData.vertexData, count: vertexCount)
 
             var positions = ContiguousArray<simd_float3>(); positions.reserveCapacity(vertexCount)
             var orientations = ContiguousArray<simd_float4>(); orientations.reserveCapacity(vertexCount)

--- a/NODES.md
+++ b/NODES.md
@@ -21,10 +21,10 @@ A list of Nodes (planned and implemented) for Fabric.
 
 <img width="1184" height="671" alt="image" src="https://github.com/user-attachments/assets/345dab62-c203-418b-ac5a-24fb6f6f9b6d" />
 
+### Primitives
 - [ ] Line
 - [x] Plane
-- [ ] Image Mesh
-- [x] Point Plane (Temp until #15 is fixed)
+- [x] Perspective Quad
 - [x] Rounded Rect
 - [x] Triangle
 - [x] Circle
@@ -39,12 +39,27 @@ A list of Nodes (planned and implemented) for Fabric.
 - [x] Sphere
 - [x] Tube
 - [x] Torus
-- [x] Tesselated Text
-- [x] Extruded Text
-- [x] Supershape
-- [x] Skybox
-- [x] Geometry from 2D PolyLine (needs better Triangulation)
-- [ ] Parametric
+- [x] Cyclorama
+- [x] Tesselated Text (2D)
+- [x] Extruded Text (3D)
+- [x] Super Shape (3D Supershape formula)
+- [x] Geometry Compose (Pixel Array → Geometry)
+
+### Parametric Surfaces
+- [x] Möbius Strip
+- [x] Helicoid
+- [x] Superellipsoid
+- [x] Klein Bottle
+- [x] Catenoid
+- [x] Paraboloid
+- [x] Enneper Surface
+- [x] Pseudosphere
+- [x] Dupin Cyclide
+- [x] Roman Surface
+- [x] Cross Cap
+- [x] Bour Surface
+- [x] Breather Surface
+- [x] Dini Surface
 
 # Object
 


### PR DESCRIPTION
This PR adds some Parametric Geometry nodes to Fabric (some are kind of fun) - however one nuance is that Fabric's Geometry ports relied on SatinGeometry - a Geometry subclass in Satin which leverages SatinCore. 

But ParametricGeometry is pure swift, and based off of Geometry base class. This meant that Parametric Geometry was not compatible out of the box with Fabric.

This PR also 'downcasts' Geometry ports from SatinGeometry (specialized sub class) to vanilla Geometry, so its a bit of a larger PR. 