### PR TITLE
Feature – Editor focus coherence

### DIFF
--- a/Fabric Editor/FabricApp.swift
+++ b/Fabric Editor/FabricApp.swift
@@ -187,6 +187,22 @@ struct ViewCommands: Commands {
 
     var body: some Commands {
         CommandGroup(after: .toolbar) {
+            let graph = document?.editingContext.currentGraph
+            let settingsViewModels = graph.map { g in
+                g.selectedNodes.map { g.viewModel(for: $0) }.filter { $0.providesSettingsView() }
+            } ?? []
+            let allOpen = !settingsViewModels.isEmpty && settingsViewModels.allSatisfy(\.showSettings)
+
+            Button(allOpen ? "Hide Node Settings" : "Show Node Settings") {
+                for viewModel in settingsViewModels {
+                    viewModel.showSettings = !allOpen
+                }
+            }
+            .keyboardShortcut("i", modifiers: .command)
+            .disabled(settingsViewModels.isEmpty)
+
+            Divider()
+
             Button("Auto Layout Graph") {
                 // Operate on the graph the user is currently looking
                 // at (a subgraph if they've drilled in), not the

--- a/Fabric Editor/FabricApp.swift
+++ b/Fabric Editor/FabricApp.swift
@@ -78,14 +78,17 @@ struct AboutCommands: Commands {
 struct DocumentCommands:Commands
 {
     @FocusedBinding(\.document) var document: FabricDocument?
-    @FocusedBinding(\.editorInputFocus) var editorInputFocus: FabricEditorInputFocus?
+    @FocusedValue(\.editorFocusTarget) var editorFocusTarget: Binding<FabricEditorFocusTarget?>?
 
     private var activeDocument: FabricDocument? {
         self.document ?? ActiveFabricDocumentStore.shared.activeDocument
     }
 
+    /// Derived from real keyboard focus: false whenever any text field
+    /// (node settings, rename, registry search) is being edited, so the
+    /// pasteboard commands below route to the field editor instead.
     private var isCanvasFocused: Bool {
-        self.editorInputFocus == .canvas
+        self.editorFocusTarget?.wrappedValue == .canvas
     }
 
     var body: some Commands {
@@ -150,7 +153,7 @@ struct DocumentCommands:Commands
 
             Button("Find Nodes")
             {
-                self.editorInputFocus = .registry
+                self.editorFocusTarget?.wrappedValue = .registrySearch
             }
             .keyboardShortcut(.return, modifiers: .command)
             .disabled(self.isCanvasFocused ? (self.document?.editingContext.currentGraph.nodes.isEmpty ?? true) : false)
@@ -202,8 +205,8 @@ struct DocumentFocusedValueKey: FocusedValueKey {
   typealias Value = Binding<FabricDocument>
 }
 
-struct EditorInputFocusValueKey: FocusedValueKey {
-    typealias Value = Binding<FabricEditorInputFocus>
+struct EditorFocusTargetValueKey: FocusedValueKey {
+    typealias Value = Binding<FabricEditorFocusTarget?>
 }
 
 extension FocusedValues
@@ -218,13 +221,15 @@ extension FocusedValues
         }
     }
 
-    var editorInputFocus: EditorInputFocusValueKey.Value?
+    /// A read/write window onto ContentView's `@FocusState` — the editor's
+    /// single keyboard-focus authority.
+    var editorFocusTarget: EditorFocusTargetValueKey.Value?
     {
         get {
-            self[EditorInputFocusValueKey.self]
+            self[EditorFocusTargetValueKey.self]
         }
         set {
-            self[EditorInputFocusValueKey.self] = newValue
+            self[EditorFocusTargetValueKey.self] = newValue
         }
     }
 }

--- a/Fabric Editor/Views/ContentView.swift
+++ b/Fabric Editor/Views/ContentView.swift
@@ -31,7 +31,12 @@ struct ContentView: View {
 
     @State private var columnVisibility = NavigationSplitViewVisibility.doubleColumn
     @State private var inspectorVisibility:Bool = true
-    @State private var inputFocus: FabricEditorInputFocus = .canvas
+
+    // The editor's single keyboard-focus authority. SwiftUI writes it on every
+    // real focus change (canvas, registry search/list — or nil when e.g. a node
+    // settings text field has focus), and views/menu commands read or set it to
+    // route and move focus. Never shadow it with plain @State.
+    @FocusState private var focusTarget: FabricEditorFocusTarget?
 
     init(document: Binding<FabricDocument>) {
         self._document = document
@@ -49,7 +54,7 @@ struct ContentView: View {
         {
             NodeRegisitryView(graphRenderer:self.document.renderer,
                               editingContext: self.document.editingContext,
-                              inputFocus: self.$inputFocus)
+                              focus: self.$focusTarget)
                 .navigationSplitViewColumnWidth(min: 150, ideal: 200, max:250)
 
         } detail: {
@@ -86,9 +91,8 @@ struct ContentView: View {
                     ScrollViewReader { proxy in
                         ScrollView([.horizontal, .vertical])
                         {
-                            GraphCanvas(editingContext: self.document.editingContext, inputFocus: self.$inputFocus)
+                            GraphCanvas(editingContext: self.document.editingContext, focus: self.$focusTarget)
                                 .id("canvas")
-                                .focusedSceneValue(\.editorInputFocus, self.$inputFocus)
                                 .frame(width: self.canvasSize, height: self.canvasSize)
                                 .scaleEffect(finalMagnification * magnifyBy, anchor: magnifyAnchor)
                                 .contextMenu(menuItems: {
@@ -170,9 +174,16 @@ struct ContentView: View {
             }
             .inspector(isPresented: self.$inspectorVisibility)
             {
-                NodeSelectionInspector(editingContext: self.document.editingContext, inputFocus: self.$inputFocus)
+                NodeSelectionInspector(editingContext: self.document.editingContext)
                     .inspectorColumnWidth(min:250, ideal:250, max:300)
             }
+            // Menu commands read and steer real focus through this binding —
+            // e.g. "is the canvas focused?" for Copy/Paste routing, and
+            // Find Nodes writing .registrySearch to focus the search field.
+            .focusedSceneValue(\.editorFocusTarget, Binding(
+                get: { self.focusTarget },
+                set: { self.focusTarget = $0 }
+            ))
             .sheet(
                 isPresented: Binding(
                     get: {

--- a/Fabric/EditorInputFocus.swift
+++ b/Fabric/EditorInputFocus.swift
@@ -2,15 +2,17 @@
 //  EditorInputFocus.swift
 //  Fabric
 //
-//  Created by Codex on 3/9/26.
-//
 
 import Foundation
 
-public enum FabricEditorInputFocus: String, Codable, Hashable
+/// The editor's focusable regions, bound to SwiftUI's focus system via
+/// `@FocusState` / `.focused(_:equals:)`. The value is written by SwiftUI on
+/// every real focus change — when a text field (node settings, rename, search)
+/// holds focus the value is that field's case or nil, so key handlers guarded
+/// on `.canvas` can never intercept keys destined for text editing.
+public enum FabricEditorFocusTarget: Hashable
 {
     case canvas
-    case registry
-    case inspector
-    case nodeSettings
+    case registrySearch
+    case registryList
 }

--- a/Fabric/Views/Graph/GraphCanvas.swift
+++ b/Fabric/Views/Graph/GraphCanvas.swift
@@ -13,12 +13,12 @@ typealias GraphSettingsEntry = (id: UUID, nodeViewModel: NodeViewModel, anchorSi
 public struct GraphCanvas : View
 {
     let editingContext: GraphCanvasContext
-    @Binding var inputFocus: FabricEditorInputFocus
+    let focus: FocusState<FabricEditorFocusTarget?>.Binding
 
-    public init(editingContext: GraphCanvasContext, inputFocus: Binding<FabricEditorInputFocus>)
+    public init(editingContext: GraphCanvasContext, focus: FocusState<FabricEditorFocusTarget?>.Binding)
     {
         self.editingContext = editingContext
-        self._inputFocus = inputFocus
+        self.focus = focus
     }
 
     // Marquee (rubber-band) selection
@@ -43,7 +43,7 @@ public struct GraphCanvas : View
 
                 GraphNodesView(editingContext: editingContext,
                                geom: geom,
-                               inputFocus: $inputFocus,
+                               focus: focus,
                                settingsEntries: $settingsEntries,
                                renamingNodeID: $renamingNodeID)
 
@@ -75,13 +75,14 @@ public struct GraphCanvas : View
                     .opacity(opacity)
             }
             .focusable(true, interactions: .edit)
+            .focused(focus, equals: .canvas)
             .focusEffectDisabled()
             .onKeyPress(keys: self.keys()) { keyPress in
                 return self.handleKeyPress(keyPress: keyPress)
             }
 #if os(macOS)
             .onDeleteCommand {
-                guard self.inputFocus == .canvas else { return }
+                guard self.focus.wrappedValue == .canvas else { return }
 
                 let currentGraph = self.editingContext.currentGraph
                 currentGraph.selectedNodes.forEach { currentGraph.delete(node: $0) }
@@ -99,8 +100,10 @@ public struct GraphCanvas : View
                         self.preMarqueeSelection = []
                     }
             )
+            // No focus write here: the canvas is .focusable(interactions: .edit),
+            // so a click already gives it focus. Writing the FocusState again from
+            // a tap handler triggers a redundant update that can revoke focus.
             .onTapGesture {
-                self.inputFocus = .canvas
                 self.editingContext.currentGraph.deselectAllNodes()
             }
             .onDrop(of: [.nodeRegistryItem, .fileURL], isTargeted: nil) { providers, location in
@@ -117,8 +120,6 @@ public struct GraphCanvas : View
 
     private func calcMarqueeDragChanged(forValue value: DragGesture.Value, currentGraph graph: Graph, canvasSize: CGSize)
     {
-        self.inputFocus = .canvas
-
         if self.marqueeRect == .zero
         {
             if NSEvent.modifierFlags.contains(.shift)
@@ -245,7 +246,10 @@ public struct GraphCanvas : View
 
     private func handleKeyPress(keyPress: KeyPress) -> KeyPress.Result
     {
-        guard self.inputFocus == .canvas else { return .ignored }
+        // Real focus, not a shadow flag: when a text field (settings popover,
+        // rename, search) is being edited this is not .canvas, so arrows and
+        // delete pass through to the field editor.
+        guard self.focus.wrappedValue == .canvas else { return .ignored }
         if renamingNodeID != nil { return .ignored }
 
         switch keyPress.key

--- a/Fabric/Views/Graph/GraphNodesView.swift
+++ b/Fabric/Views/Graph/GraphNodesView.swift
@@ -9,9 +9,17 @@ struct GraphNodesView: View
 {
     let editingContext: GraphCanvasContext
     let geom: GeometryProxy
-    @Binding var inputFocus: FabricEditorInputFocus
+    let focus: FocusState<FabricEditorFocusTarget?>.Binding
     @Binding var settingsEntries: [GraphSettingsEntry]
     @Binding var renamingNodeID: UUID?
+
+    /// Move keyboard focus to the canvas so arrow-key node navigation works
+    /// after interacting with a node. Guarded so an already-focused canvas
+    /// doesn't get a redundant FocusState write (which can revoke focus).
+    private func focusCanvas()
+    {
+        if focus.wrappedValue != .canvas { focus.wrappedValue = .canvas }
+    }
 
     @State private var initialOffsets: [UUID: CGSize] = [:]
     @State private var activeDragAnchor: UUID? = nil
@@ -31,7 +39,7 @@ struct GraphNodesView: View
                     TapGesture(count: 1)
                         .modifiers(.shift)
                         .onEnded {
-                            self.inputFocus = .canvas
+                            self.focusCanvas()
                             nodeViewModel.isSelected.toggle()
                         }
                 )
@@ -51,13 +59,13 @@ struct GraphNodesView: View
                         SimultaneousGesture(
                             TapGesture(count: 1)
                                 .onEnded {
-                                    self.inputFocus = .canvas
+                                    self.focusCanvas()
                                     currentGraph.deselectAllNodes()
                                     nodeViewModel.isSelected.toggle()
                                 },
                             TapGesture(count: 2)
                                 .onEnded {
-                                    self.inputFocus = .canvas
+                                    self.focusCanvas()
                                     if let subgraph = currentNode as? SubgraphNode
                                     {
                                         self.editingContext.enter(subgraph)
@@ -83,7 +91,7 @@ struct GraphNodesView: View
                                   currentGraph: Graph,
                                   currentNodeViewModel: NodeViewModel)
     {
-        self.inputFocus = .canvas
+        self.focusCanvas()
 
         if self.activeDragAnchor == nil
         {
@@ -206,12 +214,13 @@ struct GraphNodesView: View
 
     // MARK: - Node Settings
 
+    // No focus bookkeeping here: the canvas key handlers guard on real focus,
+    // so an open settings panel needs no shadow "nodeSettings" state — clicking
+    // into a panel's field moves focus there, clicking the canvas moves it back.
     private func sychronizeSettingsFor(nodeViewModel: NodeViewModel, show: Bool)
     {
         if show && nodeViewModel.providesSettingsView()
         {
-            self.inputFocus = .nodeSettings
-
             if !settingsEntries.contains(where: { $0.id == nodeViewModel.id })
             {
                 settingsEntries.append((id: nodeViewModel.id, nodeViewModel: nodeViewModel, anchorSize: nodeViewModel.nodeSize))
@@ -220,10 +229,6 @@ struct GraphNodesView: View
         else if !show
         {
             settingsEntries.removeAll { $0.id == nodeViewModel.id }
-            if settingsEntries.isEmpty
-            {
-                self.inputFocus = .canvas
-            }
         }
     }
 }

--- a/Fabric/Views/NodeRegisitryView.swift
+++ b/Fabric/Views/NodeRegisitryView.swift
@@ -12,12 +12,17 @@ public struct NodeRegisitryView: View {
 
     public let graphRenderer: GraphRenderer
     public let editingContext: GraphCanvasContext
-    @Binding private var inputFocus: FabricEditorInputFocus
+
+    /// The editor-wide focus state. The search field binds to `.registrySearch`
+    /// and the list to `.registryList`, so "search focused" is read from real
+    /// focus rather than a locally-shadowed Bool.
+    private let focus: FocusState<FabricEditorFocusTarget?>.Binding
 
     @State private var searchString:String = ""
     @State private var selection = Set<UUID>()
     @State private var headerSelection: Node.NodeTypeGroups = .All
-    @FocusState private var isSearchFocused: Bool
+
+    private var isSearchFocused: Bool { self.focus.wrappedValue == .registrySearch }
 
 
     @State private var filteredNodesForTypes: [Node.NodeType:[NodeClassWrapper]] = [:]
@@ -41,10 +46,10 @@ public struct NodeRegisitryView: View {
 
     private var haveNodesToShow: Bool { self.numNodesToShow > 0 }
 
-    public init(graphRenderer:GraphRenderer, editingContext: GraphCanvasContext, inputFocus: Binding<FabricEditorInputFocus>) {
+    public init(graphRenderer:GraphRenderer, editingContext: GraphCanvasContext, focus: FocusState<FabricEditorFocusTarget?>.Binding) {
         self.graphRenderer = graphRenderer
         self.editingContext = editingContext
-        self._inputFocus = inputFocus
+        self.focus = focus
     }
     
     public var body: some View
@@ -94,7 +99,7 @@ public struct NodeRegisitryView: View {
                         }
                     }
                 }
-                .focused($isSearchFocused, equals:false)
+                .focused(focus, equals: .registryList)
                 .onAppear()
                 {
                     self.updateFilteredNodes()
@@ -117,11 +122,6 @@ public struct NodeRegisitryView: View {
                 } primaryAction: { _ in
                     self.addSelectedNodes()
                 }
-                .simultaneousGesture(
-                    TapGesture().onEnded {
-                        self.inputFocus = .registry
-                    }
-                )
                 .overlay
                 {
                     VStack(spacing:0)
@@ -137,7 +137,6 @@ public struct NodeRegisitryView: View {
                     .opacity( self.haveNodesToShow ? 0.0 : 1.0 )
                 }
                 .onChange(of: self.selection) { _, newSelection in
-                    self.inputFocus = .registry
                     if let id = newSelection.first
                     {
                         withAnimation {
@@ -152,23 +151,15 @@ public struct NodeRegisitryView: View {
 //            Spacer()
         }
         .searchable(text: $searchString, placement: .sidebar)
-        .searchFocused($isSearchFocused)
+        .searchFocused(focus, equals: .registrySearch)
         .searchPresentationToolbarBehavior(.avoidHidingContent)
         .onChange(of: self.searchString) { _, _ in
-            self.inputFocus = .registry
-            
             self.updateFilteredNodes()
             
             let selectionStillValid = self.selection.contains(where: { id in self.filteredNodes.contains(where: { $0.id == id }) })
             if !selectionStillValid
             {
                 self.selectFirstNode()
-            }
-        }
-        .onChange(of: self.inputFocus) { _, newValue in
-            if newValue == .registry
-            {
-                self.isSearchFocused = true
             }
         }
         .onChange(of: self.isSearchFocused) { _, focused in
@@ -209,7 +200,7 @@ public struct NodeRegisitryView: View {
                     .tag(nodeGroup)
                     .help(nodeGroup.rawValue)
                     .onTapGesture {
-                        self.inputFocus = .registry
+                        self.focus.wrappedValue = .registrySearch
                         self.headerSelection = nodeGroup
                     }
             }
@@ -247,8 +238,6 @@ public struct NodeRegisitryView: View {
                      node.startExecution(renderer: self.graphRenderer)
                      
                      self.editingContext.currentGraph.addNode(node)
-                     
-                     self.inputFocus = .canvas
                  }
                  catch
                  {
@@ -256,7 +245,9 @@ public struct NodeRegisitryView: View {
                  }
             }
         }
-        self.inputFocus = .canvas
+        // Hand keyboard focus to the canvas so the freshly added node can be
+        // arrow-key navigated immediately.
+        self.focus.wrappedValue = .canvas
     }
 
     private func selectFirstNode()

--- a/Fabric/Views/NodeSelectionInspector.swift
+++ b/Fabric/Views/NodeSelectionInspector.swift
@@ -12,12 +12,10 @@ import UniformTypeIdentifiers
 public struct NodeSelectionInspector: View
 {
     let editingContext: GraphCanvasContext
-    @Binding private var inputFocus: FabricEditorInputFocus
 
-    public init(editingContext: GraphCanvasContext, inputFocus: Binding<FabricEditorInputFocus>)
+    public init(editingContext: GraphCanvasContext)
     {
         self.editingContext = editingContext
-        self._inputFocus = inputFocus
     }
 
     public var body: some View {


### PR DESCRIPTION
Fixes arrow keys not working in node setting text fields, via a coherence pass on the editor’s focus machinery. Empirically tests good, and the code is more idiomatic.

Adds a View menu item to show/hide node settings, complete with `cmd`-`i` binding.