### PR TITLE
Feature/satin 2.0 graph scroll perf

### DIFF
--- a/Fabric Editor/Views/ContentView.swift
+++ b/Fabric Editor/Views/ContentView.swift
@@ -10,24 +10,23 @@ import Fabric
 
 struct ContentView: View {
 
-    struct ScrollGeomHelper : Equatable
+    private struct ScrollMetrics : Equatable
     {
-        let offset:CGPoint
-        let geometry:ScrollGeometry
-        
-        static func == (lhs: ScrollGeomHelper, rhs: ScrollGeomHelper) -> Bool
-        {
-            lhs.offset == rhs.offset && lhs.geometry == rhs.geometry
-        }
+        let graphOffset: CGPoint
+        let contentOffset: CGPoint
+        let containerSize: CGSize
+        let radialGradientEndRadius: CGFloat
     }
     
     @Binding var document: FabricDocument
     @Environment(\.undoManager) private var undoManager
 
+    @State private var canvasHitTestingEnabled = true
+    
     @GestureState private var magnifyBy = 1.0
     @State private var finalMagnification = 1.0
     @State private var magnifyAnchor: UnitPoint = .center
-    @State private var scrollGeometry: ScrollGeometry = ScrollGeometry(contentOffset: .zero, contentSize: .zero, contentInsets: .init(top: 0, leading: 0, bottom: 0, trailing: 0), containerSize: .zero)
+    @State private var radialGradientEndRadius: CGFloat = .zero
 
     @State private var columnVisibility = NavigationSplitViewVisibility.doubleColumn
     @State private var inspectorVisibility:Bool = true
@@ -86,12 +85,14 @@ struct ContentView: View {
 
                 ZStack
                 {
-                    RadialGradient(colors: [.clear, .black.opacity(0.75)], center: .center, startRadius: 0, endRadius: self.scrollGeometry.containerSize.width * 1.5)
+                    RadialGradient(colors: [.clear, .black.opacity(0.75)], center: .center, startRadius: 0, endRadius: self.radialGradientEndRadius)
 
                     ScrollViewReader { proxy in
                         ScrollView([.horizontal, .vertical])
                         {
-                            GraphCanvas(editingContext: self.document.editingContext, focus: self.$focusTarget)
+                            GraphCanvas(editingContext: self.document.editingContext,
+                                        focus: self.$focusTarget,
+                                        canvasSize: CGSize(width: self.canvasSize, height: self.canvasSize))
                                 .id("canvas")
                                 .frame(width: self.canvasSize, height: self.canvasSize)
                                 .scaleEffect(finalMagnification * magnifyBy, anchor: magnifyAnchor)
@@ -106,6 +107,8 @@ struct ContentView: View {
                                     MagnifyGesture()
                                         .updating($magnifyBy, body: { value, state, _ in
 
+                                            self.canvasHitTestingEnabled = false
+                                            
                                             let proposedScale = finalMagnification * value.magnification
 
                                             guard (self.zoomMin ..< self.zoomMax).contains(proposedScale)
@@ -121,8 +124,8 @@ struct ContentView: View {
                                             let u = value.startAnchor.x
                                             let v = value.startAnchor.y
 
-                                            let containerSize = self.scrollGeometry.containerSize
-                                            let contentOffset = self.scrollGeometry.contentOffset
+                                            let containerSize = self.document.editingContext.currentScrollContainerSize
+                                            let contentOffset = self.document.editingContext.currentScrollContentOffset
 
                                             let visibleWidthInCanvas  = containerSize.width  / scale
                                             let visibleHeightInCanvas = containerSize.height / scale
@@ -139,9 +142,11 @@ struct ContentView: View {
                                             magnifyAnchor = UnitPoint(x: newX, y: newY)
                                         })
                                         .onEnded { value in
+                                            self.canvasHitTestingEnabled = true
                                             finalMagnification = min(max(finalMagnification * value.magnification, self.zoomMin), self.zoomMax)
                                         }
                                 )
+                                .allowsHitTesting(self.canvasHitTestingEnabled)
                                 .onAppear {
                                     self.document.editingContext.rootGraph.undoManager = undoManager
 
@@ -157,18 +162,29 @@ struct ContentView: View {
 
                         }
                         .defaultScrollAnchor(.center)
+                        .onScrollPhaseChange { _, newPhase in
+                            self.canvasHitTestingEnabled = !newPhase.isScrolling
+                        }
                     }
-                    .onScrollGeometryChange(for: ScrollGeomHelper.self) { geometry in
-
+                    .onScrollGeometryChange(for: ScrollMetrics.self) { geometry in
                         let center = CGPoint(x: geometry.contentSize.width / 2,
                                              y: geometry.contentSize.height / 2)
                         let offset = (geometry.contentOffset - center) + (geometry.containerSize / 2)
 
-                        return ScrollGeomHelper(offset: offset, geometry: geometry)
+                        return ScrollMetrics(graphOffset: offset,
+                                             contentOffset: geometry.contentOffset,
+                                             containerSize: geometry.containerSize,
+                                             radialGradientEndRadius: geometry.containerSize.width * 1.5)
 
-                    } action: { _, newScrollOffset in
-                        scrollGeometry = newScrollOffset.geometry
-                        self.document.editingContext.currentScrollOffset = newScrollOffset.offset
+                    } action: { _, newScrollMetrics in
+                        self.document.editingContext.currentScrollOffset = newScrollMetrics.graphOffset
+                        self.document.editingContext.currentScrollContentOffset = newScrollMetrics.contentOffset
+                        self.document.editingContext.currentScrollContainerSize = newScrollMetrics.containerSize
+
+                        if self.radialGradientEndRadius != newScrollMetrics.radialGradientEndRadius
+                        {
+                            self.radialGradientEndRadius = newScrollMetrics.radialGradientEndRadius
+                        }
                     }
                 }
             }

--- a/Fabric Editor/Views/ContentView.swift
+++ b/Fabric Editor/Views/ContentView.swift
@@ -92,7 +92,8 @@ struct ContentView: View {
                         {
                             GraphCanvas(editingContext: self.document.editingContext,
                                         focus: self.$focusTarget,
-                                        canvasSize: CGSize(width: self.canvasSize, height: self.canvasSize))
+                                        canvasSize: CGSize(width: self.canvasSize, height: self.canvasSize),
+                                        connectionsHitTestingEnabled: self.canvasHitTestingEnabled)
                                 .id("canvas")
                                 .frame(width: self.canvasSize, height: self.canvasSize)
                                 .scaleEffect(finalMagnification * magnifyBy, anchor: magnifyAnchor)

--- a/Fabric.xcodeproj/xcuserdata/vade.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Fabric.xcodeproj/xcuserdata/vade.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -9,6 +9,11 @@
 			<key>orderHint</key>
 			<integer>4</integer>
 		</dict>
+		<key>CodeEditor (Playground).xcscheme</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>3</integer>
+		</dict>
 		<key>Fabric Editor.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>

--- a/Fabric/EditorInputFocus.swift
+++ b/Fabric/EditorInputFocus.swift
@@ -13,7 +13,7 @@ import Foundation
 public enum FabricEditorFocusTarget: Hashable
 {
     case canvas
-    case nodeSettings
+    case nodeSettings(UUID)
     case registrySearch
     case registryList
 }

--- a/Fabric/EditorInputFocus.swift
+++ b/Fabric/EditorInputFocus.swift
@@ -13,6 +13,7 @@ import Foundation
 public enum FabricEditorFocusTarget: Hashable
 {
     case canvas
+    case nodeSettings
     case registrySearch
     case registryList
 }

--- a/Fabric/Graph/Graph.swift
+++ b/Fabric/Graph/Graph.swift
@@ -357,6 +357,13 @@ internal import AnyCodable
     {
         nodeViewModels[node.id]!
     }
+
+    /// Returns the NodeViewModel when SwiftUI is evaluating transient stale
+    /// references, such as connection rows from the same transaction as delete.
+    public func viewModelIfPresent(for node: Node) -> NodeViewModel?
+    {
+        nodeViewModels[node.id]
+    }
     
     public func delete(node:Node, disconnect:Bool = true)
     {
@@ -389,6 +396,12 @@ internal import AnyCodable
             for (port, connectedPort) in savedConnections {
                 port.connect(to: connectedPort)
             }
+
+            node.markDirty()
+            graph.updateRenderingNodes()
+            graph.rebuildPublishedParameterGroup()
+            graph.syncNodesToScene()
+            graph.markConnectionsChanged()
         }
 
         self.undoManager?.setActionName("Delete Node")

--- a/Fabric/Graph/Graph.swift
+++ b/Fabric/Graph/Graph.swift
@@ -66,9 +66,16 @@ internal import AnyCodable
     
     // Fix for #103 - this now triggers syncNodesToScene() inside of `GraphRenderer`
     public var shouldUpdateConnections = false
+    public private(set) var connectionRevision = 0
   
 
     @ObservationIgnored weak var lastNode:(Node)? = nil
+
+    public func markConnectionsChanged()
+    {
+        connectionRevision += 1
+        shouldUpdateConnections = true
+    }
 
     public let publishedParameterGroup:ParameterGroup = ParameterGroup("Published")
 

--- a/Fabric/Graph/Graph.swift
+++ b/Fabric/Graph/Graph.swift
@@ -64,8 +64,8 @@ internal import AnyCodable
         return renderableNodes.compactMap { $0.getObject() as? Satin.Renderable }
     }
     
-    // Fix for #103 - this now triggers syncNodesToScene() inside of `GraphRenderer`
-    public var shouldUpdateConnections = false
+    // Fix for #103 - connection/topology changes trigger syncNodesToScene() inside of `GraphRenderer`.
+    @ObservationIgnored private var pendingConnectionSceneSync = false
     public private(set) var connectionRevision = 0
   
 
@@ -74,7 +74,14 @@ internal import AnyCodable
     public func markConnectionsChanged()
     {
         connectionRevision += 1
-        shouldUpdateConnections = true
+        pendingConnectionSceneSync = true
+    }
+
+    func consumePendingConnectionSceneSync() -> Bool
+    {
+        let shouldSyncScene = pendingConnectionSceneSync
+        pendingConnectionSceneSync = false
+        return shouldSyncScene
     }
 
     public let publishedParameterGroup:ParameterGroup = ParameterGroup("Published")
@@ -338,7 +345,7 @@ internal import AnyCodable
         }
 
         self.undoManager?.setActionName("Add Node")
-        self.shouldUpdateConnections = true
+        self.markConnectionsChanged()
 
         self.updateRenderingNodes()
         self.rebuildPublishedParameterGroup()
@@ -377,7 +384,7 @@ internal import AnyCodable
             graph.nodes.append(node)
             node.graph = graph
             graph.maybeAddNodeToScene(node)
-            graph.shouldUpdateConnections = true
+            graph.markConnectionsChanged()
 
             for (port, connectedPort) in savedConnections {
                 port.connect(to: connectedPort)
@@ -385,7 +392,7 @@ internal import AnyCodable
         }
 
         self.undoManager?.setActionName("Delete Node")
-        self.shouldUpdateConnections = true
+        self.markConnectionsChanged()
 
         self.updateRenderingNodes()
         self.rebuildPublishedParameterGroup()
@@ -421,7 +428,7 @@ internal import AnyCodable
         }
 
         self.publishedParameterGroup.append( publishedParams )
-        self.shouldUpdateConnections = true
+        self.markConnectionsChanged()
         self.onPublishedPortsChanged?()
     }
 
@@ -968,7 +975,7 @@ internal import AnyCodable
         self.deselectAllNodes()
         for newNode in newNodes { nodeViewModels[newNode.id]?.isSelected = true }
 
-        self.shouldUpdateConnections = true
+        self.markConnectionsChanged()
 
         return newNodes
     }
@@ -1118,7 +1125,7 @@ extension Graph
             self.deselectAllNodes()
             for newNode in newNodes { nodeViewModels[newNode.id]?.isSelected = true }
 
-            self.shouldUpdateConnections = true
+            self.markConnectionsChanged()
 
             return newNodes
         }

--- a/Fabric/Graph/GraphCanvasContext.swift
+++ b/Fabric/Graph/GraphCanvasContext.swift
@@ -7,6 +7,23 @@
 
 import SwiftUI
 
+struct GraphConnectionPair: Identifiable
+{
+    struct ID: Hashable
+    {
+        let outletID: UUID
+        let inletID: UUID
+    }
+
+    let outlet: Port
+    let inlet: Port
+
+    var id: ID
+    {
+        ID(outletID: outlet.id, inletID: inlet.id)
+    }
+}
+
 /// Owns all editor session state for a node canvas: subgraph navigation,
 /// scroll position, drag preview, port hit-testing, selection tracking,
 /// and auto-layout timing for rapid node adds.
@@ -32,14 +49,132 @@ public class GraphCanvasContext
     /// Canvas scroll position; used to calculate initial offset for newly added nodes.
     @ObservationIgnored public var currentScrollOffset: CGPoint = .zero
 
+    /// Raw scroll view content offset; used by editor gestures without invalidating SwiftUI views.
+    @ObservationIgnored public var currentScrollContentOffset: CGPoint = .zero
+
+    /// Current scroll view container size; used by editor gestures without invalidating SwiftUI views.
+    @ObservationIgnored public var currentScrollContainerSize: CGSize = .zero
+
+    /// Fixed graph canvas size; used to translate model-space node positions into canvas coordinates.
+    @ObservationIgnored public var canvasSize: CGSize = .zero
+
     /// Port currently being dragged (for preview line rendering).
     var dragPreviewSourcePortID: UUID? = nil
 
     /// Current endpoint of the drag preview line.
     var dragPreviewTargetPosition: CGPoint? = nil
 
-    /// Cached screen positions of all ports, maintained by views during render for hit-testing.
-    @ObservationIgnored var portPositions: [UUID: CGPoint] = [:]
+    @ObservationIgnored private let titleHeight: CGFloat = 30
+    @ObservationIgnored private let portVStackSpacing: CGFloat = 10
+    @ObservationIgnored private let portRowHeight: CGFloat = 15
+    @ObservationIgnored private let outletTopSpacerHeight: CGFloat = 25
+    @ObservationIgnored private var cachedConnectionGraphID: UUID?
+    @ObservationIgnored private var cachedConnectionRevision: Int = 0
+    @ObservationIgnored private var cachedConnectionNodeCount: Int = 0
+    @ObservationIgnored private var cachedConnectionPairs: [GraphConnectionPair] = []
+
+    func connectionPairs(for graph: Graph) -> [GraphConnectionPair]
+    {
+        if cachedConnectionGraphID == graph.id,
+           cachedConnectionRevision == graph.connectionRevision,
+           cachedConnectionNodeCount == graph.nodes.count
+        {
+            return cachedConnectionPairs
+        }
+
+        let outlets = graph.nodes.flatMap(\.ports).filter { $0.kind == .Outlet }
+        cachedConnectionPairs = outlets.flatMap { outlet in
+            outlet.connections
+                .filter { $0.kind == .Inlet }
+                .map { GraphConnectionPair(outlet: outlet, inlet: $0) }
+        }
+        cachedConnectionGraphID = graph.id
+        cachedConnectionRevision = graph.connectionRevision
+        cachedConnectionNodeCount = graph.nodes.count
+
+        return cachedConnectionPairs
+    }
+
+    public func graphPosition(for port: Port) -> CGPoint?
+    {
+        guard let node = port.node else { return nil }
+
+        return self.graphPosition(for: port, nodeOffset: node.offset, nodeSize: node.nodeSize)
+    }
+
+    public func graphPosition(for port: Port, nodeOffset: CGSize, nodeSize: CGSize) -> CGPoint?
+    {
+        guard let node = port.node else { return nil }
+
+        let xOffset: CGFloat
+        let yFromTop: CGFloat
+        let sameKindPorts = node.ports.filter { $0.kind == port.kind }
+        let portIndex = sameKindPorts.firstIndex(where: { $0.id == port.id }) ?? 0
+
+        switch port.kind
+        {
+        case .Inlet:
+            xOffset = -nodeSize.width / 2
+            yFromTop = titleHeight + portVStackSpacing + CGFloat(portIndex) * (portRowHeight + portVStackSpacing) + portRowHeight / 2
+
+        case .Outlet:
+            xOffset = nodeSize.width / 2
+            yFromTop = outletTopSpacerHeight + portVStackSpacing + CGFloat(portIndex) * (portRowHeight + portVStackSpacing) + portRowHeight / 2
+        }
+
+        return CGPoint(x: nodeOffset.width + xOffset,
+                       y: nodeOffset.height + yFromTop - nodeSize.height / 2)
+    }
+
+    public func canvasPosition(for port: Port) -> CGPoint?
+    {
+        guard let graphPosition = self.graphPosition(for: port) else { return nil }
+
+        return self.canvasPosition(forGraphPosition: graphPosition)
+    }
+
+    public func canvasPosition(for port: Port, nodeOffset: CGSize, nodeSize: CGSize) -> CGPoint?
+    {
+        guard let graphPosition = self.graphPosition(for: port, nodeOffset: nodeOffset, nodeSize: nodeSize) else { return nil }
+
+        return self.canvasPosition(forGraphPosition: graphPosition)
+    }
+
+    private func canvasPosition(forGraphPosition graphPosition: CGPoint) -> CGPoint
+    {
+        return CGPoint(x: graphPosition.x + canvasSize.width / 2,
+                       y: graphPosition.y + canvasSize.height / 2)
+    }
+
+    public func nearestPortID(to graphPosition: CGPoint, maximumDistance: CGFloat = 25) -> UUID?
+    {
+        var closestPort: (id: UUID, distance: CGFloat)? = nil
+
+        for node in currentGraph.nodes
+        {
+            for port in node.ports
+            {
+                guard let portPosition = self.canvasPosition(for: port) else { continue }
+
+                let distance = hypot(graphPosition.x - portPosition.x, graphPosition.y - portPosition.y)
+                guard distance < maximumDistance else { continue }
+
+                if let currentClosest = closestPort
+                {
+                    if distance < currentClosest.distance
+                    {
+                        closestPort = (id: port.id, distance: distance)
+                    }
+                }
+                else
+                {
+                    closestPort = (id: port.id, distance: distance)
+                }
+            }
+        }
+
+        return closestPort?.id
+    }
 
     // MARK: - Auto-Layout Timing
 

--- a/Fabric/Graph/GraphCanvasContext.swift
+++ b/Fabric/Graph/GraphCanvasContext.swift
@@ -115,7 +115,7 @@ public class GraphCanvasContext
         {
         case .Inlet:
             xOffset = -nodeSize.width / 2
-            yFromTop = titleHeight + portVStackSpacing + CGFloat(portIndex) * (portRowHeight + portVStackSpacing) + portRowHeight / 2
+            yFromTop = outletTopSpacerHeight + portVStackSpacing + CGFloat(portIndex) * (portRowHeight + portVStackSpacing) +  portRowHeight / 2
 
         case .Outlet:
             xOffset = nodeSize.width / 2

--- a/Fabric/Graph/GraphRenderer.swift
+++ b/Fabric/Graph/GraphRenderer.swift
@@ -176,8 +176,7 @@ public class GraphRenderer : ViewRenderer
         let feedbackCache = self.feedbackCache(for: graph.id)
         feedbackCache.resetCacheFor(executionInfo: currentExecutionInfo)
 
-        pendingSceneSync = graph.shouldUpdateConnections
-        graph.shouldUpdateConnections = false
+        pendingSceneSync = graph.consumePendingConnectionSceneSync()
         if pendingSceneSync {
             feedbackCache.invalidateTopologyCaches()
         }
@@ -230,8 +229,7 @@ public class GraphRenderer : ViewRenderer
 
     public func executeAndDraw(graph: Graph, executionInfo: GraphExecutionInfo, renderPassDescriptor: MTLRenderPassDescriptor, commandBuffer: MTLCommandBuffer)
     {
-        let needsSceneSync = graph.shouldUpdateConnections
-        graph.shouldUpdateConnections = false
+        let needsSceneSync = graph.consumePendingConnectionSceneSync()
         if needsSceneSync {
             invalidateFeedbackTopologyCaches(for: graph)
         }

--- a/Fabric/Graph/Node/Node.swift
+++ b/Fabric/Graph/Node/Node.swift
@@ -272,7 +272,7 @@ public class Node : Codable, Equatable, Identifiable, Hashable, Copyable
             self.parameterGroup.append(param)
         }
 
-        self.graph?.shouldUpdateConnections = true
+        self.graph?.markConnectionsChanged()
         self.portsChangedSubject.send()
     }
 
@@ -285,7 +285,7 @@ public class Node : Codable, Equatable, Identifiable, Hashable, Copyable
             self.parameterGroup.remove(param)
         }
 
-        self.graph?.shouldUpdateConnections = true
+        self.graph?.markConnectionsChanged()
         self.portsChangedSubject.send()
     }
 

--- a/Fabric/Graph/Port/NodePort.swift
+++ b/Fabric/Graph/Port/NodePort.swift
@@ -171,7 +171,7 @@ public class NodePort<Value : PortValueRepresentable>: Port
             port.connect(to: other)
         }
         self.node?.graph?.undoManager?.setActionName("Disconnect Ports")
-        self.node?.graph?.shouldUpdateConnections = true
+        self.node?.graph?.markConnectionsChanged()
     }
 
     override public func connect(to other: Port)
@@ -274,7 +274,7 @@ public class NodePort<Value : PortValueRepresentable>: Port
             port.disconnect(from: other)
         }
         self.node?.graph?.undoManager?.setActionName("Connect Ports")
-        self.node?.graph?.shouldUpdateConnections = true
+        self.node?.graph?.markConnectionsChanged()
     }
 
     public func send(_ v: Value?, force:Bool = false)

--- a/Fabric/Nodes/Object/SubGraph/Iterator/IteratorNode.swift
+++ b/Fabric/Nodes/Object/SubGraph/Iterator/IteratorNode.swift
@@ -94,8 +94,7 @@ public class IteratorNode: SubgraphNode
             executionInfo.iterationInfo = iterationInfo
 
             
-            let needsSceneSync = subGraph.shouldUpdateConnections
-            subGraph.shouldUpdateConnections = false
+            let needsSceneSync = subGraph.consumePendingConnectionSceneSync()
             if needsSceneSync {
                 renderer.invalidateFeedbackTopologyCaches(for: subGraph)
             }

--- a/Fabric/Nodes/Object/SubGraph/SubgraphNode.swift
+++ b/Fabric/Nodes/Object/SubGraph/SubgraphNode.swift
@@ -68,7 +68,7 @@ public class SubgraphNode: BaseObjectNode
         self.synchronizeParameters()
 
         self.invalidatePortCaches()
-        self.graph?.shouldUpdateConnections = true
+        self.graph?.markConnectionsChanged()
         self.portsChangedSubject.send()
     }
 

--- a/Fabric/Views/Graph/GraphBackground.swift
+++ b/Fabric/Views/Graph/GraphBackground.swift
@@ -7,12 +7,9 @@ import SwiftUI
 
 struct GraphBackground: View
 {
-    let geom: GeometryProxy
-
     var body: some View
     {
         Image("background")
             .resizable(resizingMode: .tile)
-            .offset(-geom.size / 2)
     }
 }

--- a/Fabric/Views/Graph/GraphCanvas.swift
+++ b/Fabric/Views/Graph/GraphCanvas.swift
@@ -14,11 +14,16 @@ public struct GraphCanvas : View
 {
     let editingContext: GraphCanvasContext
     let focus: FocusState<FabricEditorFocusTarget?>.Binding
+    let canvasSize: CGSize
 
-    public init(editingContext: GraphCanvasContext, focus: FocusState<FabricEditorFocusTarget?>.Binding)
+    public init(editingContext: GraphCanvasContext,
+                focus: FocusState<FabricEditorFocusTarget?>.Binding,
+                canvasSize: CGSize)
     {
         self.editingContext = editingContext
         self.focus = focus
+        self.canvasSize = canvasSize
+        self.editingContext.canvasSize = canvasSize
     }
 
     // Marquee (rubber-band) selection
@@ -33,86 +38,81 @@ public struct GraphCanvas : View
 
     public var body: some View
     {
-        GeometryReader { geom in
+        ZStack
+        {
+            GraphBackground()
+                .offset(-canvasSize / 2)
 
-            ZStack
-            {
-                GraphBackground(geom: geom)
+            GraphNotesView(editingContext: editingContext)
+                .offset(-canvasSize / 2)
 
-                GraphNotesView(editingContext: editingContext, geom: geom)
+            GraphNodesView(editingContext: editingContext,
+                           focus: focus,
+                           settingsEntries: $settingsEntries,
+                           renamingNodeID: $renamingNodeID)
+                .offset(-canvasSize / 2)
 
-                GraphNodesView(editingContext: editingContext,
-                               geom: geom,
-                               focus: focus,
-                               settingsEntries: $settingsEntries,
-                               renamingNodeID: $renamingNodeID)
-
-                GraphNodeSettingsView(settingsEntries: $settingsEntries, geom: geom)
-            }
-            .offset(geom.size / 2)
-            .clipShape(Rectangle())
-            .contentShape(Rectangle())
-            .coordinateSpace(name: "graph")
-            .onPreferenceChange(PortAnchorKey.self) { portAnchors in
-                self.calcPortAnchors(portAnchors, geometryProxy: geom)
-            }
-            .overlayPreferenceValue(PortAnchorKey.self) { portAnchors in
-                GraphConnectionsView(editingContext: editingContext,
-                                     portAnchors: portAnchors,
-                                     geom: geom)
-                .id(editingContext.currentGraph.shouldUpdateConnections)
-            }
-            .overlay
-            {
-                let opacity = self.marqueeRect == .zero ? 0.0 : 1.0
-
-                Rectangle()
-                    .fill(Color.accentColor.opacity(0.1))
-                    .overlay(Rectangle().strokeBorder(Color.accentColor, lineWidth: 1))
-                    .frame(width: self.marqueeRect.width, height: self.marqueeRect.height)
-                    .position(x: self.marqueeRect.midX, y: self.marqueeRect.midY)
-                    .allowsHitTesting(false)
-                    .opacity(opacity)
-            }
-            .focusable(true, interactions: .edit)
-            .focused(focus, equals: .canvas)
-            .focusEffectDisabled()
-            .onKeyPress(keys: self.keys()) { keyPress in
-                return self.handleKeyPress(keyPress: keyPress)
-            }
+            GraphNodeSettingsView(settingsEntries: $settingsEntries)
+                .offset(-canvasSize / 2)
+        }
+        .offset(canvasSize / 2)
+        .clipShape(Rectangle())
+        .contentShape(Rectangle())
+        .coordinateSpace(name: "graph")
+        .overlay {
+            GraphConnectionsView(editingContext: editingContext)
+                .id(editingContext.currentGraph.connectionRevision)
+        }
+//        .overlay
+//        {
+//            let opacity = self.marqueeRect == .zero ? 0.0 : 1.0
+//            
+//            Rectangle()
+//                .position(x: self.marqueeRect.midX, y: self.marqueeRect.midY)
+//                .frame(width: self.marqueeRect.width, height: self.marqueeRect.height)
+//                .opacity(opacity)
+//                .fill(Color.accentColor.opacity(0.1))
+//                .overlay(Rectangle().strokeBorder(Color.accentColor, lineWidth: 1))
+//                .allowsHitTesting(false)
+//        }
+        .focusable(true, interactions: .edit)
+        .focused(focus, equals: .canvas)
+        .focusEffectDisabled()
+        .onKeyPress(keys: self.keys()) { keyPress in
+            return self.handleKeyPress(keyPress: keyPress)
+        }
 #if os(macOS)
-            .onDeleteCommand {
-                guard self.focus.wrappedValue == .canvas else { return }
-
-                let currentGraph = self.editingContext.currentGraph
-                currentGraph.selectedNodes.forEach { currentGraph.delete(node: $0) }
-            }
+        .onDeleteCommand {
+            guard self.focus.wrappedValue == .canvas else { return }
+            
+            let currentGraph = self.editingContext.currentGraph
+            currentGraph.selectedNodes.forEach { currentGraph.delete(node: $0) }
+        }
 #endif
-            .gesture(
-                DragGesture(minimumDistance: 3)
-                    .onChanged { value in
-                        self.calcMarqueeDragChanged(forValue: value,
-                                                    currentGraph: self.editingContext.currentGraph,
-                                                    canvasSize: geom.size)
-                    }
-                    .onEnded { _ in
-                        self.marqueeRect = .zero
-                        self.preMarqueeSelection = []
-                    }
-            )
-            // No focus write here: the canvas is .focusable(interactions: .edit),
-            // so a click already gives it focus. Writing the FocusState again from
-            // a tap handler triggers a redundant update that can revoke focus.
-            .onTapGesture {
-                self.editingContext.currentGraph.deselectAllNodes()
-            }
-            .onDrop(of: [.nodeRegistryItem, .fileURL], isTargeted: nil) { providers, location in
-                self.handleDrop(providers: providers, location: location, canvasSize: geom.size)
-            }
-            .onChange(of: editingContext.currentGraph.nodes.count) { _, _ in
-                let nodeIDs = Set(editingContext.currentGraph.nodes.map(\.id))
-                settingsEntries.removeAll { !nodeIDs.contains($0.id) }
-            }
+        .gesture(
+            DragGesture(minimumDistance: 3)
+                .onChanged { value in
+                    self.calcMarqueeDragChanged(forValue: value,
+                                                currentGraph: self.editingContext.currentGraph,
+                                                canvasSize: canvasSize)
+                }
+                .onEnded { _ in
+                    self.marqueeRect = .zero
+                    self.preMarqueeSelection = []
+                }
+        )
+        // No focus write here: the canvas is .focusable(interactions: .edit),
+        // so a click already gives it focus. Writing the FocusState again from
+        // a tap handler triggers a redundant update that can revoke focus.
+        .onTapGesture {
+            self.editingContext.currentGraph.deselectAllNodes()
+        }
+        .onDrop(of: [.nodeRegistryItem, .fileURL], isTargeted: nil) { providers, location in
+            self.handleDrop(providers: providers, location: location, canvasSize: canvasSize)
+        }
+        .onChange(of: editingContext.currentGraph.nodes.count) { _, _ in
+            let nodeIDs = Set(editingContext.currentGraph.nodes.map(\.id))
+            settingsEntries.removeAll { !nodeIDs.contains($0.id) }
         }
     }
 
@@ -280,14 +280,4 @@ public struct GraphCanvas : View
         return .handled
     }
 
-    // MARK: - Port / Connection Helpers
-
-    private func calcPortAnchors(_ portAnchors: PortAnchorKey.Value, geometryProxy geom: GeometryProxy)
-    {
-        var positions: [UUID: CGPoint] = [:]
-        for (portID, anchor) in portAnchors {
-            positions[portID] = geom[anchor]
-        }
-        self.editingContext.portPositions = positions
-    }
 }

--- a/Fabric/Views/Graph/GraphCanvas.swift
+++ b/Fabric/Views/Graph/GraphCanvas.swift
@@ -15,14 +15,17 @@ public struct GraphCanvas : View
     let editingContext: GraphCanvasContext
     let focus: FocusState<FabricEditorFocusTarget?>.Binding
     let canvasSize: CGSize
+    let connectionsHitTestingEnabled: Bool
 
     public init(editingContext: GraphCanvasContext,
                 focus: FocusState<FabricEditorFocusTarget?>.Binding,
-                canvasSize: CGSize)
+                canvasSize: CGSize,
+                connectionsHitTestingEnabled: Bool = true)
     {
         self.editingContext = editingContext
         self.focus = focus
         self.canvasSize = canvasSize
+        self.connectionsHitTestingEnabled = connectionsHitTestingEnabled
         self.editingContext.canvasSize = canvasSize
     }
 
@@ -60,21 +63,11 @@ public struct GraphCanvas : View
         .contentShape(Rectangle())
         .coordinateSpace(name: "graph")
         .overlay {
-            GraphConnectionsView(editingContext: editingContext)
-                .id(editingContext.currentGraph.connectionRevision)
+            GraphConnectionsView(editingContext: editingContext,
+                                 allowsConnectionHitTesting: connectionsHitTestingEnabled,
+                                 marqueeRect: marqueeRect)
+            .id(editingContext.currentGraph.connectionRevision)
         }
-//        .overlay
-//        {
-//            let opacity = self.marqueeRect == .zero ? 0.0 : 1.0
-//            
-//            Rectangle()
-//                .position(x: self.marqueeRect.midX, y: self.marqueeRect.midY)
-//                .frame(width: self.marqueeRect.width, height: self.marqueeRect.height)
-//                .opacity(opacity)
-//                .fill(Color.accentColor.opacity(0.1))
-//                .overlay(Rectangle().strokeBorder(Color.accentColor, lineWidth: 1))
-//                .allowsHitTesting(false)
-//        }
         .focusable(true, interactions: .edit)
         .focused(focus, equals: .canvas)
         .focusEffectDisabled()
@@ -279,5 +272,4 @@ public struct GraphCanvas : View
 
         return .handled
     }
-
 }

--- a/Fabric/Views/Graph/GraphCanvas.swift
+++ b/Fabric/Views/Graph/GraphCanvas.swift
@@ -55,7 +55,8 @@ public struct GraphCanvas : View
                            renamingNodeID: $renamingNodeID)
                 .offset(-canvasSize / 2)
 
-            GraphNodeSettingsView(settingsEntries: $settingsEntries)
+            GraphNodeSettingsView(settingsEntries: $settingsEntries,
+                                  focus: focus)
                 .offset(-canvasSize / 2)
         }
         .offset(canvasSize / 2)

--- a/Fabric/Views/Graph/GraphConnectionsView.swift
+++ b/Fabric/Views/Graph/GraphConnectionsView.swift
@@ -68,8 +68,8 @@ struct GraphConnectionsView: View
     private func canvasPosition(for port: Port, in graph: Graph) -> CGPoint?
     {
         guard let node = port.node else { return nil }
+        guard let nodeViewModel = graph.viewModelIfPresent(for: node) else { return nil }
 
-        let nodeViewModel = graph.viewModel(for: node)
         return editingContext.canvasPosition(for: port,
                                              nodeOffset: nodeViewModel.offset,
                                              nodeSize: nodeViewModel.nodeSize)

--- a/Fabric/Views/Graph/GraphConnectionsView.swift
+++ b/Fabric/Views/Graph/GraphConnectionsView.swift
@@ -8,6 +8,8 @@ import SwiftUI
 struct GraphConnectionsView: View
 {
     let editingContext: GraphCanvasContext
+    let allowsConnectionHitTesting: Bool
+    let marqueeRect: CGRect
 
     var body: some View
     {
@@ -23,13 +25,20 @@ struct GraphConnectionsView: View
             {
                 let path = calcPathUsing(port: outlet, start: start, end: end)
 
-                path.stroke(outlet.backgroundColor, lineWidth: 2)
-                    .contentShape(
-                        path.stroke(style: StrokeStyle(lineWidth: 5))
-                    )
-                    .onTapGesture(count: 2) {
-                        outlet.disconnect(from: inlet)
-                    }
+                if allowsConnectionHitTesting
+                {
+                    path.stroke(outlet.backgroundColor, lineWidth: 2)
+                        .contentShape(
+                            path.stroke(style: StrokeStyle(lineWidth: 5))
+                        )
+                        .onTapGesture(count: 2) {
+                            outlet.disconnect(from: inlet)
+                        }
+                }
+                else
+                {
+                    path.stroke(outlet.backgroundColor, lineWidth: 2)
+                }
             }
         }
 
@@ -42,6 +51,17 @@ struct GraphConnectionsView: View
 
             path.stroke(sourcePort.backgroundColor.opacity(0.6), style: StrokeStyle(lineWidth: 2, dash: [5, 3]))
                 .animation(.spring(response: 0.3, dampingFraction: 0.7), value: targetPosition)
+        }
+
+        if marqueeRect != .zero
+        {
+            Path(marqueeRect)
+                .fill(Color.accentColor.opacity(0.1))
+                .allowsHitTesting(false)
+
+            Path(marqueeRect)
+                .stroke(Color.accentColor, lineWidth: 1)
+                .allowsHitTesting(false)
         }
     }
 

--- a/Fabric/Views/Graph/GraphConnectionsView.swift
+++ b/Fabric/Views/Graph/GraphConnectionsView.swift
@@ -8,48 +8,51 @@ import SwiftUI
 struct GraphConnectionsView: View
 {
     let editingContext: GraphCanvasContext
-    let portAnchors: PortAnchorKey.Value
-    let geom: GeometryProxy
 
     var body: some View
     {
         let currentGraph = editingContext.currentGraph
-        let outlets = currentGraph.nodes.flatMap(\.ports).filter({ $0.kind == .Outlet })
+        let connectionPairs = editingContext.connectionPairs(for: currentGraph)
 
-        ForEach(outlets) { port in
-            let connectedPorts: [Port] = port.connections.filter({ $0.kind == .Inlet })
+        ForEach(connectionPairs) { connectionPair in
+            let outlet = connectionPair.outlet
+            let inlet = connectionPair.inlet
 
-            ForEach(connectedPorts) { connectedPort in
-                if let sourceAnchor = portAnchors[port.id],
-                   let destAnchor = portAnchors[connectedPort.id]
-                {
-                    let start = geom[sourceAnchor]
-                    let end = geom[destAnchor]
-                    let path = calcPathUsing(port: port, start: start, end: end)
+            if let start = self.canvasPosition(for: outlet, in: currentGraph),
+               let end = self.canvasPosition(for: inlet, in: currentGraph)
+            {
+                let path = calcPathUsing(port: outlet, start: start, end: end)
 
-                    path.stroke(port.backgroundColor, lineWidth: 2)
-                        .contentShape(
-                            path.stroke(style: StrokeStyle(lineWidth: 5))
-                        )
-                        .onTapGesture(count: 2) {
-                            port.disconnect(from: connectedPort)
-                            currentGraph.shouldUpdateConnections.toggle()
-                        }
-                }
+                path.stroke(outlet.backgroundColor, lineWidth: 2)
+                    .contentShape(
+                        path.stroke(style: StrokeStyle(lineWidth: 5))
+                    )
+                    .onTapGesture(count: 2) {
+                        outlet.disconnect(from: inlet)
+                    }
             }
         }
 
         if let sourcePortID = editingContext.dragPreviewSourcePortID,
            let targetPosition = editingContext.dragPreviewTargetPosition,
-           let sourceAnchor = portAnchors[sourcePortID],
-           let sourcePort = currentGraph.nodePort(forID: sourcePortID)
+           let sourcePort = currentGraph.nodePort(forID: sourcePortID),
+           let start = self.canvasPosition(for: sourcePort, in: currentGraph)
         {
-            let start = geom[sourceAnchor]
             let path = calcPathUsing(port: sourcePort, start: start, end: targetPosition)
 
             path.stroke(sourcePort.backgroundColor.opacity(0.6), style: StrokeStyle(lineWidth: 2, dash: [5, 3]))
                 .animation(.spring(response: 0.3, dampingFraction: 0.7), value: targetPosition)
         }
+    }
+
+    private func canvasPosition(for port: Port, in graph: Graph) -> CGPoint?
+    {
+        guard let node = port.node else { return nil }
+
+        let nodeViewModel = graph.viewModel(for: node)
+        return editingContext.canvasPosition(for: port,
+                                             nodeOffset: nodeViewModel.offset,
+                                             nodeSize: nodeViewModel.nodeSize)
     }
 
     private func calcPathUsing(port: Port, start: CGPoint, end: CGPoint) -> Path

--- a/Fabric/Views/Graph/GraphNodeSettingsView.swift
+++ b/Fabric/Views/Graph/GraphNodeSettingsView.swift
@@ -43,13 +43,16 @@ struct GraphNodeSettingsView: View
                     NodeSettingView(nodeViewModel: nodeViewModel)
                         .interactiveDismissDisabled(true)
                         .focusable(true, interactions: .edit)
-                        .focused(focus, equals: .nodeSettings)
+                        .focused(focus, equals: .nodeSettings(nodeViewModel.id))
                         .focusEffectDisabled()
                         .onAppear {
-                            focus.wrappedValue = .nodeSettings
+                            focus.wrappedValue = .nodeSettings(nodeViewModel.id)
                         }
                         .onDisappear {
-                            focus.wrappedValue = .canvas
+                            if focus.wrappedValue == .nodeSettings(nodeViewModel.id)
+                            {
+                                focus.wrappedValue = .canvas
+                            }
                         }
                 }
                 .onChange(of: isPresented) { _, newValue in

--- a/Fabric/Views/Graph/GraphNodeSettingsView.swift
+++ b/Fabric/Views/Graph/GraphNodeSettingsView.swift
@@ -8,7 +8,6 @@ import SwiftUI
 struct GraphNodeSettingsView: View
 {
     @Binding var settingsEntries: [GraphSettingsEntry]
-    let geom: GeometryProxy
 
     var body: some View
     {
@@ -18,7 +17,6 @@ struct GraphNodeSettingsView: View
                                       onClose: {
                 entry.nodeViewModel.showSettings = false
             })
-            .offset(-geom.size / 2)
             .offset(entry.nodeViewModel.offset)
         }
     }

--- a/Fabric/Views/Graph/GraphNodeSettingsView.swift
+++ b/Fabric/Views/Graph/GraphNodeSettingsView.swift
@@ -8,12 +8,14 @@ import SwiftUI
 struct GraphNodeSettingsView: View
 {
     @Binding var settingsEntries: [GraphSettingsEntry]
+    let focus: FocusState<FabricEditorFocusTarget?>.Binding
 
     var body: some View
     {
         ForEach(settingsEntries, id: \.id) { entry in
             NodeSettingsPopoverAnchor(nodeViewModel: entry.nodeViewModel,
                                       anchorSize: entry.anchorSize,
+                                      focus: focus,
                                       onClose: {
                 entry.nodeViewModel.showSettings = false
             })
@@ -28,6 +30,7 @@ struct GraphNodeSettingsView: View
     {
         let nodeViewModel: NodeViewModel
         let anchorSize: CGSize
+        let focus: FocusState<FabricEditorFocusTarget?>.Binding
         let onClose: () -> Void
         @State private var isPresented: Bool = true
 
@@ -39,6 +42,15 @@ struct GraphNodeSettingsView: View
                 .popover(isPresented: $isPresented) {
                     NodeSettingView(nodeViewModel: nodeViewModel)
                         .interactiveDismissDisabled(true)
+                        .focusable(true, interactions: .edit)
+                        .focused(focus, equals: .nodeSettings)
+                        .focusEffectDisabled()
+                        .onAppear {
+                            focus.wrappedValue = .nodeSettings
+                        }
+                        .onDisappear {
+                            focus.wrappedValue = .canvas
+                        }
                 }
                 .onChange(of: isPresented) { _, newValue in
                     if !newValue { onClose() }

--- a/Fabric/Views/Graph/GraphNodeSettingsView.swift
+++ b/Fabric/Views/Graph/GraphNodeSettingsView.swift
@@ -48,16 +48,40 @@ struct GraphNodeSettingsView: View
                         .onAppear {
                             focus.wrappedValue = .nodeSettings(nodeViewModel.id)
                         }
+                        // Return-to-invoker: closing the panel that holds
+                        // keyboard focus hands focus back to the canvas.
+                        // FocusState cannot see focus inside a popover's
+                        // window (its bindings never update when a field in
+                        // the panel is being edited), so containment can't be
+                        // read here. Instead, one runloop turn after teardown,
+                        // detect *dangling* focus: if the focus enum doesn't
+                        // know where focus is and no text editor survived as
+                        // first responder, focus died with this panel —
+                        // return it to the canvas. If typing continues in
+                        // another panel's field (a live NSText first
+                        // responder) or the enum names a live region, leave
+                        // focus alone.
                         .onDisappear {
-                            if focus.wrappedValue == .nodeSettings(nodeViewModel.id)
-                            {
-                                focus.wrappedValue = .canvas
-                            }
+                            restoreCanvasFocusIfDangling()
                         }
                 }
                 .onChange(of: isPresented) { _, newValue in
                     if !newValue { onClose() }
                 }
+        }
+
+        private func restoreCanvasFocusIfDangling()
+        {
+#if os(macOS)
+            DispatchQueue.main.async {
+                guard focus.wrappedValue == nil else { return }
+
+                let window = NSApp.keyWindow ?? NSApp.mainWindow ?? NSApp.windows.first(where: \.isVisible)
+                guard !(window?.firstResponder is NSText) else { return }
+
+                focus.wrappedValue = .canvas
+            }
+#endif
         }
     }
 }

--- a/Fabric/Views/Graph/GraphNodesView.swift
+++ b/Fabric/Views/Graph/GraphNodesView.swift
@@ -8,7 +8,6 @@ import SwiftUI
 struct GraphNodesView: View
 {
     let editingContext: GraphCanvasContext
-    let geom: GeometryProxy
     let focus: FocusState<FabricEditorFocusTarget?>.Binding
     @Binding var settingsEntries: [GraphSettingsEntry]
     @Binding var renamingNodeID: UUID?
@@ -32,7 +31,6 @@ struct GraphNodesView: View
             let nodeViewModel = currentGraph.viewModel(for: currentNode)
 
             NodeView(nodeViewModel: nodeViewModel, editingContext: editingContext)
-                .offset(-geom.size / 2)
                 .offset(nodeViewModel.offset)
 #if os(macOS)
                 .highPriorityGesture(

--- a/Fabric/Views/Graph/GraphNodesView.swift
+++ b/Fabric/Views/Graph/GraphNodesView.swift
@@ -212,9 +212,8 @@ struct GraphNodesView: View
 
     // MARK: - Node Settings
 
-    // No focus bookkeeping here: the canvas key handlers guard on real focus,
-    // so an open settings panel needs no shadow "nodeSettings" state — clicking
-    // into a panel's field moves focus there, clicking the canvas moves it back.
+    // Settings popover focus is handled by GraphNodeSettingsView so canvas and
+    // registry key handlers do not steal keys while settings controls are active.
     private func sychronizeSettingsFor(nodeViewModel: NodeViewModel, show: Bool)
     {
         if show && nodeViewModel.providesSettingsView()

--- a/Fabric/Views/Graph/GraphNotesView.swift
+++ b/Fabric/Views/Graph/GraphNotesView.swift
@@ -8,7 +8,6 @@ import SwiftUI
 struct GraphNotesView: View
 {
     let editingContext: GraphCanvasContext
-    let geom: GeometryProxy
 
     var body: some View
     {
@@ -16,7 +15,6 @@ struct GraphNotesView: View
 
         ForEach(currentGraph.notes) { currentNote in
             NoteView(note: currentNote)
-                .offset(-geom.size / 2)
                 .offset(x: currentNote.rect.midX, y: currentNote.rect.midY)
                 .contextMenu {
                     Button("Delete Note") {

--- a/Fabric/Views/NodeSelectionInspector.swift
+++ b/Fabric/Views/NodeSelectionInspector.swift
@@ -44,7 +44,7 @@ public struct NodeSelectionInspector: View
             }
         }
         .listStyle(.sidebar)
-        .id(currentGraph.shouldUpdateConnections)
+        .id(currentGraph.connectionRevision)
 
     }
 

--- a/Fabric/Views/Nodes/NodeInletView.swift
+++ b/Fabric/Views/Nodes/NodeInletView.swift
@@ -38,7 +38,7 @@ struct NodeInletView: View
                                 self.editingContext.dragPreviewTargetPosition = nil
                             }
                             
-                            guard let targetPortID = self.findPortAt(position: value.location, in: value.location),
+                            guard let targetPortID = self.editingContext.nearestPortID(to: value.location),
                                   let targetPort = self.editingContext.currentGraph.nodePort(forID: targetPortID),
                                   targetPort.id != self.port.id,
                                   targetPort.kind == .Outlet,
@@ -52,15 +52,6 @@ struct NodeInletView: View
                             self.port.connect(to: targetPort)
                         }
                 )
-                .anchorPreference(
-                    key: PortAnchorKey.self,
-                    value: .center,
-                    transform: {  anchor in
-
-                        [ port.id : anchor ]
-                    }
-                )
-               
                 .help("\(port.name): \(port.portType.rawValue) - \(port.parameter?.description ?? "" )")
 
             Text(port.displayName)
@@ -75,26 +66,5 @@ struct NodeInletView: View
         // priority for connection dragging.
         .contentShape(.interaction, Rectangle())
         .modifier(PortRenameAlert(port: port, graph: graph))
-    }
-
-    private func findPortAt(position: CGPoint, in geometryPosition: CGPoint) -> UUID? {
-        let hitRadius: CGFloat = 25
-        var closestPort: (UUID, CGFloat)? = nil
-
-        for (portID, portPosition) in self.editingContext.portPositions {
-            let distance = hypot(position.x - portPosition.x, position.y - portPosition.y)
-
-            if distance < hitRadius {
-                if let (_, currentClosest) = closestPort {
-                    if distance < currentClosest {
-                        closestPort = (portID, distance)
-                    }
-                } else {
-                    closestPort = (portID, distance)
-                }
-            }
-        }
-
-        return closestPort?.0
     }
 }

--- a/Fabric/Views/Nodes/NodeOutletView.swift
+++ b/Fabric/Views/Nodes/NodeOutletView.swift
@@ -42,7 +42,7 @@ struct NodeOutletView: View
                                 self.editingContext.dragPreviewTargetPosition = nil
                             }
 
-                            guard let targetPortID = self.findPortAt(position: value.location, in: value.location),
+                            guard let targetPortID = self.editingContext.nearestPortID(to: value.location),
                                   let targetPort = self.editingContext.currentGraph.nodePort(forID: targetPortID),
                                   targetPort.id != self.port.id,
                                   targetPort.kind == .Inlet,
@@ -57,39 +57,11 @@ struct NodeOutletView: View
                             self.port.connect(to: targetPort)
                         }
                 )
-                .anchorPreference(
-                    key: PortAnchorKey.self,
-                    value: .center,
-                    transform: {  anchor in
-
-                        [  port.id : anchor ]
-                    })
                 .help("\(port.name): \(port.portType.rawValue) - \(port.parameter?.description ?? "" )")
 
         }
         .frame(height: 15)
         .contentShape(.interaction, Rectangle())
         .modifier(PortRenameAlert(port: port, graph: graph))
-    }
-
-    private func findPortAt(position: CGPoint, in geometryPosition: CGPoint) -> UUID? {
-        let hitRadius: CGFloat = 25
-        var closestPort: (UUID, CGFloat)? = nil
-
-        for (portID, portPosition) in self.editingContext.portPositions {
-            let distance = hypot(position.x - portPosition.x, position.y - portPosition.y)
-
-            if distance < hitRadius {
-                if let (_, currentClosest) = closestPort {
-                    if distance < currentClosest {
-                        closestPort = (portID, distance)
-                    }
-                } else {
-                    closestPort = (portID, distance)
-                }
-            }
-        }
-
-        return closestPort?.0
     }
 }

--- a/Fabric/Views/Nodes/PortContextMenu.swift
+++ b/Fabric/Views/Nodes/PortContextMenu.swift
@@ -65,6 +65,6 @@ struct PortContextMenu: View
     private func disconnect()
     {
         port.disconnectAll()
-        graph.shouldUpdateConnections.toggle()
+        graph.markConnectionsChanged()
     }
 }

--- a/Fabric/Views/Nodes/PortRenameAlert.swift
+++ b/Fabric/Views/Nodes/PortRenameAlert.swift
@@ -44,13 +44,13 @@ struct PortRenameAlert: ViewModifier
         let trimmed = renameText.trimmingCharacters(in: .whitespacesAndNewlines)
         port.publishedName = trimmed.isEmpty ? nil : trimmed
         graph.rebuildPublishedParameterGroup()
-        graph.shouldUpdateConnections.toggle()
+        graph.markConnectionsChanged()
     }
 
     private func clearName()
     {
         port.publishedName = nil
         graph.rebuildPublishedParameterGroup()
-        graph.shouldUpdateConnections.toggle()
+        graph.markConnectionsChanged()
     }
 }


### PR DESCRIPTION
 PR Notes

  This improves graph canvas scrolling and connection responsiveness by reducing unnecessary SwiftUI invalidation work during scroll and pan interactions.

  Changes include:

  - Avoid storing full scroll geometry in view state during graph scrolling.
  - Keep scroll-derived state narrower and mostly outside observation-driven redraw paths.
  - Disable expensive canvas/connection hit testing while scrolling.
  - Replace port anchor preferences with model-based port position calculation.
  - Cache graph connection pairs instead of rediscovering topology every redraw.
  - Move marquee drawing into the connection overlay path to avoid an extra overlay view.

  The main user-visible result is smoother graph scrolling/panning.