### PR TITLE
Array input port fixes for virtual port type

### DIFF
--- a/Fabric/Graph/Port/Port.swift
+++ b/Fabric/Graph/Port/Port.swift
@@ -210,7 +210,9 @@ extension UTType
 
     public func canConnect(to other:Port) -> Bool
     {
-        self.portType.canConnect(to: other.portType)
+        if self.kind == .Inlet, self.portType == .Virtual { return true }
+        if other.kind == .Inlet, other.portType == .Virtual { return true }
+        return self.portType.canConnect(to: other.portType)
     }
     
     public func connect(to other: Port) { fatalError("override") }

--- a/Fabric/Graph/Port/PortType+Compatibility.swift
+++ b/Fabric/Graph/Port/PortType+Compatibility.swift
@@ -11,6 +11,11 @@ extension PortType
 {
     func canConnect(to other: PortType) -> Bool
     {
+        if self.isGenericArrayVirtual || other.isGenericArrayVirtual
+        {
+            return self.isArrayType && other.isArrayType
+        }
+
         if self == .NumericVirtual || other == .NumericVirtual
         {
             return self.isNumericVirtualCompatible || other.isNumericVirtualCompatible
@@ -38,6 +43,18 @@ extension PortType
         default:
             return self == other
         }
+    }
+
+    var isGenericArrayVirtual: Bool
+    {
+        if case .Array(portType: .Virtual) = self { return true }
+        return false
+    }
+
+    var isArrayType: Bool
+    {
+        if case .Array = self { return true }
+        return false
     }
 
     var isNumericVirtualCompatible: Bool

--- a/Fabric/Nodes/Parameters/Array/Array Basics/ArrayAppendNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Array Basics/ArrayAppendNode.swift
@@ -23,7 +23,7 @@ public class ArrayAppendNode: TypeAgnosticNode
         super.rebuildPorts(forStrategy: strategy)
         guard let elementType = PortType(rawValue: strategy) else { return }
 
-        let arrayType: PortType = elementType == .Virtual ? .Virtual : .Array(portType: elementType)
+        let arrayType: PortType = .Array(portType: elementType)
 
         for name in ["inputArrayA", "inputArrayB", "outputPort"] {
             if let p: Port = findPort(named: name), p.portType != arrayType { removePort(p) }

--- a/Fabric/Nodes/Parameters/Array/Array Basics/ArrayCountNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Array Basics/ArrayCountNode.swift
@@ -32,7 +32,7 @@ public class ArrayCountNode: TypeAgnosticNode
         super.rebuildPorts(forStrategy: strategy)
         guard let elementType = PortType(rawValue: strategy) else { return }
 
-        let arrayType: PortType = elementType == .Virtual ? .Virtual : .Array(portType: elementType)
+        let arrayType: PortType = .Array(portType: elementType)
 
         if let existing: Port = findPort(named: "inputPort"), existing.portType != arrayType { removePort(existing) }
         if findPort(named: "inputPort") == nil {

--- a/Fabric/Nodes/Parameters/Array/Array Basics/ArrayFirstValueNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Array Basics/ArrayFirstValueNode.swift
@@ -23,7 +23,7 @@ public class ArrayFirstValueNode: TypeAgnosticNode
         super.rebuildPorts(forStrategy: strategy)
         guard let elementType = PortType(rawValue: strategy) else { return }
 
-        let arrayType: PortType = elementType == .Virtual ? .Virtual : .Array(portType: elementType)
+        let arrayType: PortType = .Array(portType: elementType)
 
         if let existing: Port = findPort(named: "inputPort"),  existing.portType != arrayType   { removePort(existing) }
         if let existing: Port = findPort(named: "outputPort"), existing.portType != elementType { removePort(existing) }

--- a/Fabric/Nodes/Parameters/Array/Array Basics/ArrayIndexValueNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Array Basics/ArrayIndexValueNode.swift
@@ -32,7 +32,7 @@ public class ArrayIndexValueNode: TypeAgnosticNode
         super.rebuildPorts(forStrategy: strategy)
         guard let elementType = PortType(rawValue: strategy) else { return }
 
-        let arrayType: PortType = elementType == .Virtual ? .Virtual : .Array(portType: elementType)
+        let arrayType: PortType = .Array(portType: elementType)
 
         if let existing: Port = findPort(named: "inputPort"),  existing.portType != arrayType   { removePort(existing) }
         if let existing: Port = findPort(named: "outputPort"), existing.portType != elementType { removePort(existing) }

--- a/Fabric/Nodes/Parameters/Array/Array Basics/ArrayLastValueNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Array Basics/ArrayLastValueNode.swift
@@ -23,7 +23,7 @@ public class ArrayLastValueNode: TypeAgnosticNode
         super.rebuildPorts(forStrategy: strategy)
         guard let elementType = PortType(rawValue: strategy) else { return }
 
-        let arrayType: PortType = elementType == .Virtual ? .Virtual : .Array(portType: elementType)
+        let arrayType: PortType = .Array(portType: elementType)
 
         if let existing: Port = findPort(named: "inputPort"),  existing.portType != arrayType   { removePort(existing) }
         if let existing: Port = findPort(named: "outputPort"), existing.portType != elementType { removePort(existing) }

--- a/Fabric/Nodes/Parameters/Array/Array Basics/ArrayQueueNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Array Basics/ArrayQueueNode.swift
@@ -41,7 +41,7 @@ public class ArrayQueueNode: TypeAgnosticNode
         super.rebuildPorts(forStrategy: strategy)
         guard let elementType = PortType(rawValue: strategy) else { return }
 
-        let arrayType: PortType = elementType == .Virtual ? .Virtual : .Array(portType: elementType)
+        let arrayType: PortType = .Array(portType: elementType)
 
         // Replace inputPort only when the element type changes
         if let existing: Port = findPort(named: "inputPort"), existing.portType != elementType {

--- a/Fabric/Nodes/Parameters/Array/Array Basics/ArrayReplaceValueAtIndexNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Array Basics/ArrayReplaceValueAtIndexNode.swift
@@ -32,7 +32,7 @@ public class ArrayReplaceValueAtIndexNode: TypeAgnosticNode
         super.rebuildPorts(forStrategy: strategy)
         guard let elementType = PortType(rawValue: strategy) else { return }
 
-        let arrayType: PortType = elementType == .Virtual ? .Virtual : .Array(portType: elementType)
+        let arrayType: PortType = .Array(portType: elementType)
 
         if let existing: Port = findPort(named: "inputPort"),  existing.portType != arrayType   { removePort(existing) }
         if let existing: Port = findPort(named: "inputValue"), existing.portType != elementType { removePort(existing) }

--- a/Fabric/Nodes/Parameters/Array/Array Basics/ArrayReverseNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Array Basics/ArrayReverseNode.swift
@@ -23,7 +23,7 @@ public class ArrayReverseNode: TypeAgnosticNode
         super.rebuildPorts(forStrategy: strategy)
         guard let elementType = PortType(rawValue: strategy) else { return }
 
-        let arrayType: PortType = elementType == .Virtual ? .Virtual : .Array(portType: elementType)
+        let arrayType: PortType = .Array(portType: elementType)
 
         for name in ["inputPort", "outputPort"] {
             if let p: Port = findPort(named: name), p.portType != arrayType { removePort(p) }

--- a/Fabric/Nodes/Parameters/Array/Array Basics/ArrayShuffleNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Array Basics/ArrayShuffleNode.swift
@@ -32,7 +32,7 @@ public class ArrayShuffleNode: TypeAgnosticNode
         super.rebuildPorts(forStrategy: strategy)
         guard let elementType = PortType(rawValue: strategy) else { return }
 
-        let arrayType: PortType = elementType == .Virtual ? .Virtual : .Array(portType: elementType)
+        let arrayType: PortType = .Array(portType: elementType)
 
         for name in ["inputPort", "outputPort"] {
             if let p: Port = findPort(named: name), p.portType != arrayType { removePort(p) }

--- a/Fabric/Nodes/Parameters/Array/Array Basics/ArraySplitAtIndexNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Array Basics/ArraySplitAtIndexNode.swift
@@ -32,7 +32,7 @@ public class ArraySplitAtIndexNode: TypeAgnosticNode
         super.rebuildPorts(forStrategy: strategy)
         guard let elementType = PortType(rawValue: strategy) else { return }
 
-        let arrayType: PortType = elementType == .Virtual ? .Virtual : .Array(portType: elementType)
+        let arrayType: PortType = .Array(portType: elementType)
 
         for name in ["inputPort", "outputBefore", "outputFrom"] {
             if let p: Port = findPort(named: name), p.portType != arrayType { removePort(p) }

--- a/Fabric/Nodes/Parameters/Array/Array Basics/ArraySubarrayNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Array Basics/ArraySubarrayNode.swift
@@ -34,7 +34,7 @@ public class ArraySubarrayNode: TypeAgnosticNode
         super.rebuildPorts(forStrategy: strategy)
         guard let elementType = PortType(rawValue: strategy) else { return }
 
-        let arrayType: PortType = elementType == .Virtual ? .Virtual : .Array(portType: elementType)
+        let arrayType: PortType = .Array(portType: elementType)
 
         for name in ["inputPort", "outputPort"] {
             if let p: Port = findPort(named: name), p.portType != arrayType { removePort(p) }

--- a/Tests/PortConnectionTests.swift
+++ b/Tests/PortConnectionTests.swift
@@ -75,4 +75,60 @@ struct PortConnectionTests {
         )
         #expect(decodedSource.outputNumber.connections.count == 1)
     }
+
+    @Test("Generic array virtual type compatibility is array scoped")
+    func genericArrayVirtualTypeCompatibilityIsArrayScoped() {
+        let genericArray = PortType.Array(portType: .Virtual)
+
+        #expect(genericArray.canConnect(to: .Array(portType: .Float)))
+        #expect(genericArray.canConnect(to: .Array(portType: .String)))
+        #expect(genericArray.canConnect(to: genericArray))
+
+        #expect(!genericArray.canConnect(to: .Float))
+        #expect(!genericArray.canConnect(to: .String))
+        #expect(!genericArray.canConnect(to: .Virtual))
+    }
+
+    @Test("Generic array virtual inlets reject scalar outlets")
+    func genericArrayVirtualInletsRejectScalarOutlets() {
+        let arrayInlet = PortType.Array(portType: .Virtual).makeFreshPort(name: "Array", kind: .Inlet)
+        let scalarOutlet = PortType.Float.makeFreshPort(name: "Float", kind: .Outlet)
+        let virtualOutlet = PortType.Virtual.makeFreshPort(name: "Value", kind: .Outlet)
+        let concreteArrayOutlet = PortType.Array(portType: .Float).makeFreshPort(name: "Array", kind: .Outlet)
+
+        #expect(!arrayInlet.canConnect(to: scalarOutlet))
+        #expect(!arrayInlet.canConnect(to: virtualOutlet))
+        #expect(arrayInlet.canConnect(to: concreteArrayOutlet))
+    }
+
+    @Test("Pure virtual inlets remain universal")
+    func pureVirtualInletsRemainUniversal() {
+        let virtualInlet = PortType.Virtual.makeFreshPort(name: "Value", kind: .Inlet)
+        let concreteArrayOutlet = PortType.Array(portType: .Float).makeFreshPort(name: "Array", kind: .Outlet)
+        let genericArrayOutlet = PortType.Array(portType: .Virtual).makeFreshPort(name: "Array", kind: .Outlet)
+
+        #expect(virtualInlet.canConnect(to: concreteArrayOutlet))
+        #expect(virtualInlet.canConnect(to: genericArrayOutlet))
+    }
+
+    @Test("Virtual strategy array nodes expose generic array ports")
+    func virtualStrategyArrayNodesExposeGenericArrayPorts() throws {
+        guard let context = makeContext() else { return }
+
+        let arrayCount = ArrayCountNode(context: context, portType: .Virtual)
+        let countInput: Fabric.Port = arrayCount.port(named: "inputPort")
+        #expect(countInput.portType == .Array(portType: .Virtual))
+
+        let firstValue = ArrayFirstValueNode(context: context, portType: .Virtual)
+        let firstInput: Fabric.Port = firstValue.port(named: "inputPort")
+        let firstOutput: Fabric.Port = firstValue.port(named: "outputPort")
+        #expect(firstInput.portType == .Array(portType: .Virtual))
+        #expect(firstOutput.portType == .Virtual)
+
+        let queue = ArrayQueueNode(context: context, portType: .Virtual)
+        let queueInput: Fabric.Port = queue.port(named: "inputPort")
+        let queueOutput: Fabric.Port = queue.port(named: "outputPort")
+        #expect(queueInput.portType == .Virtual)
+        #expect(queueOutput.portType == .Array(portType: .Virtual))
+    }
 }


### PR DESCRIPTION
Fix an issue with how Array nodes used virtual vs .Array(.virtual) as a port type, causing an issue where nodes that take an array input can also take scalar inputs due to being a fully virtualized port.

Not fully vetted but passes initial smell test and compile run noodle for a bit test. 