### PR TITLE
Add configurable String Split modes

### DIFF
--- a/Fabric/Nodes/Parameters/String/BaseFormatStringNode.swift
+++ b/Fabric/Nodes/Parameters/String/BaseFormatStringNode.swift
@@ -1,0 +1,207 @@
+//
+//  BaseFormatStringNode.swift
+//  Fabric
+//
+//  Shared base for the nodes driven by a `{name:spec}` format string — String
+//  Formatter, which substitutes values into it, and String Scanner, which reads
+//  values back out. Everything the two share lives here: the format string and
+//  its serialization, the Settings pane, and the dynamic ports the placeholders
+//  build. A subclass says what a placeholder's port looks like and what to do
+//  once the ports have been rebuilt; the rest is not its business.
+//
+//  The format string is Settings-view state, never a port: it decides how many
+//  ports the node has and of what type, so a graph-driven edit would churn ports
+//  and drop wires on every change.
+//
+
+import Foundation
+import Satin
+import SwiftUI
+
+// MARK: - Settings View
+
+/// The format-string field with the guidance its node supplies. The syntax is
+/// shared, so the field is too; only the wording above it differs.
+struct FormatStringSettingsView: View {
+    @Bindable var model: BaseFormatStringNode.SettingsModel
+    let guidance: String
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            // As a LocalizedStringKey, so the guidance keeps the markdown
+            // styling it had when it was written inline.
+            Text(.init(guidance))
+
+            Spacer()
+
+            TextField("Format String", text: $model.formatString)
+                .lineLimit(1)
+                .font(.system(size: 10))
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+        }
+    }
+}
+
+// MARK: - Base Format String Node
+
+public class BaseFormatStringNode: Node {
+
+    // MARK: - Subclass contract
+
+    /// The format string a node of this type starts with.
+    public class var defaultFormatString: String { "" }
+
+    /// Which side of the node the placeholders build their ports on: inlets for
+    /// a node reading values in, outlets for one handing values out.
+    public class var placeholderPortKind: PortKind { .Inlet }
+
+    /// Ports on that side the format string does not own, so the placeholder
+    /// diff leaves them alone.
+    public class var staticPortNames: Set<String> { [] }
+
+    /// Markdown shown above the format-string field in the Settings pane.
+    public class var settingsGuidance: String { "" }
+
+    /// The port one placeholder builds. Subclasses must override.
+    func makePlaceholderPort(for placeholder: FormatPlaceholder) -> Port {
+        fatalError("\(Self.self) must override makePlaceholderPort(for:)")
+    }
+
+    /// Called after every format-string edit, once the ports match the new
+    /// parse. The node is already marked dirty — this is for whatever else the
+    /// subclass derives from the format string.
+    func formatStringDidChange() { }
+
+    // MARK: - Format string
+
+    public fileprivate(set) var formatString: String {
+        didSet {
+            self.updatePorts()
+            self.nameSubject.send()
+        }
+    }
+
+    /// Sets the format string from outside the Settings view — the procedural
+    /// equivalent of typing in the inspector.
+    public func setFormatString(_ formatString: String) {
+        guard formatString != self.formatString else { return }
+        self.formatString = formatString
+    }
+
+    /// The current format string, parsed. Rebuilt only when it changes.
+    private(set) var parsedFormatString = ParsedFormatString(tokens: [])
+
+    override public var displayName: String? { formatString.isEmpty ? nil : formatString }
+
+    // MARK: - Init
+
+    private enum CodingKeys: String, CodingKey {
+        case formatString
+    }
+
+    public required init(context: Context) {
+        self.formatString = Self.defaultFormatString
+        super.init(context: context)
+        self.updatePorts()
+    }
+
+    /// Procedural construction with a specific format string — the Settings-view
+    /// state that shapes this node's ports, so graph building never has to go
+    /// through the inspector to reach it.
+    public init(context: Context, formatString: String) {
+        self.formatString = formatString
+        super.init(context: context)
+        self.updatePorts()
+    }
+
+    public required init(from decoder: any Decoder) throws {
+        self.formatString = Self.defaultFormatString
+
+        try super.init(from: decoder)
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        // Assigning runs didSet, which rebuilds the ports against the restored
+        // format string; the decoded ports it matches by name and type are kept,
+        // UUIDs and all, so the graph's connection restore still finds them.
+        self.formatString = try container.decodeIfPresent(String.self, forKey: .formatString)
+            ?? Self.defaultFormatString
+    }
+
+    public override func encode(to encoder: Encoder) throws {
+        try super.encode(to: encoder)
+
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.formatString, forKey: .formatString)
+    }
+
+    // MARK: - Settings
+
+    override public func providesSettingsView() -> Bool { true }
+
+    override public func settingsView() -> AnyView {
+        AnyView(FormatStringSettingsView(model: _settingsModel, guidance: Self.settingsGuidance))
+    }
+
+    @Observable final class SettingsModel
+    {
+        var formatString: String
+        {
+            didSet
+            {
+                guard formatString != node?.formatString else { return }
+                node?.formatString = formatString
+            }
+        }
+        private weak var node: BaseFormatStringNode?
+
+        init(node: BaseFormatStringNode)
+        {
+            self.node = node
+            self.formatString = node.formatString
+        }
+    }
+
+    private lazy var _settingsModel = SettingsModel(node: self)
+
+    // MARK: - Dynamic Port Management
+
+    /// Diffs the ports the placeholders ask for against the ones already there:
+    /// a name that has gone, or that has changed type, loses its port; a name
+    /// with no port gets one. A placeholder whose name and type are unchanged
+    /// keeps its port, and so keeps its wire and its value, across an edit.
+    private func updatePorts() {
+        let newParse = parseFormatString(formatString)
+        let newNames = Set(newParse.placeholders.map(\.name))
+
+        let existingNames = Set(
+            self.ports
+                .filter { $0.kind == Self.placeholderPortKind && !Self.staticPortNames.contains($0.name) }
+                .map(\.name)
+        )
+
+        for portName in existingNames.subtracting(newNames) {
+            if let port: Port = self.findPort(named: portName) {
+                self.removePort(port)
+            }
+        }
+
+        for placeholder in newParse.placeholders {
+            if let existingPort: Port = self.findPort(named: placeholder.name),
+               existingPort.portType != placeholder.portType {
+                self.removePort(existingPort)
+            }
+        }
+
+        for placeholder in newParse.placeholders
+        where (self.findPort(named: placeholder.name) as Port?) == nil {
+            self.addDynamicPort(self.makePlaceholderPort(for: placeholder), name: placeholder.name)
+        }
+
+        self.parsedFormatString = newParse
+
+        // A format edit reshapes the result even when it reshapes no port, and
+        // the renderer skips a node that is not dirty.
+        self.markDirty()
+        self.formatStringDidChange()
+    }
+}

--- a/Fabric/Nodes/Parameters/String/StringEscapeSequences.swift
+++ b/Fabric/Nodes/Parameters/String/StringEscapeSequences.swift
@@ -5,17 +5,60 @@
 
 import Foundation
 
-/// Decodes the escape sequences the String nodes accept wherever a user types a
-/// pattern — String Split's and String Join's separators today. One vocabulary
-/// across all of them, so a separator typed into one node means the same thing
-/// in another: `\n`, `\r` and `\t` name the invisible characters, and `\\` is a
-/// literal backslash.
+/// The escape sequences a pattern may use. One vocabulary shared across the
+/// String nodes, so a sequence typed into one means the same thing in another;
+/// each node opts in to the part of it that its syntax calls for.
+struct EscapeSequences: OptionSet
+{
+    let rawValue: Int
+
+    /// `\n`, `\r` and `\t` — the characters that cannot be typed into a
+    /// single-line field. Wanted wherever a user writes a pattern.
+    static let invisibleCharacters = EscapeSequences(rawValue: 1 << 0)
+
+    /// `\{` and `\}` — a literal brace. Only meaningful where braces are syntax,
+    /// as in the String Formatter and String Scanner format strings; elsewhere a
+    /// brace needs no escaping and `\{` is better left as typed.
+    static let braces = EscapeSequences(rawValue: 1 << 1)
+
+    /// The character an escape stands for, or nil when this set does not
+    /// recognize it. `\\` is always recognized and so has no option of its own:
+    /// without it, no sequence could be written out literally.
+    func substitution(forEscaped character: Character) -> Character?
+    {
+        switch character
+        {
+        case "\\":
+            return "\\"
+        case "n" where contains(.invisibleCharacters):
+            return "\n"
+        case "r" where contains(.invisibleCharacters):
+            return "\r"
+        case "t" where contains(.invisibleCharacters):
+            return "\t"
+        case "{" where contains(.braces):
+            return "{"
+        case "}" where contains(.braces):
+            return "}"
+        default:
+            return nil
+        }
+    }
+}
+
+/// Decodes the escape sequences in a user-typed pattern — String Split's and
+/// String Join's separators, the String Formatter and String Scanner format
+/// strings.
 ///
-/// Deliberately lenient. An unrecognized escape (`\q`) and a trailing lone
-/// backslash are both preserved verbatim rather than swallowed or flagged, so a
-/// pattern mid-typing never silently loses characters, and adding a sequence to
-/// the vocabulary later is the only way a pattern's meaning can change.
-func decodeEscapeSequences(_ pattern: String) -> String
+/// Deliberately lenient. An escape this set does not recognize (`\q`, or `\{`
+/// where braces are not syntax) and a trailing lone backslash are preserved
+/// verbatim rather than swallowed or flagged, so a pattern mid-typing never
+/// silently loses characters, and widening the set is the only way a pattern's
+/// meaning can change.
+func decodeEscapeSequences(
+    _ pattern: String,
+    including sequences: EscapeSequences = .invisibleCharacters
+) -> String
 {
     var decoded = ""
     var currentIndex = pattern.startIndex
@@ -37,19 +80,16 @@ func decodeEscapeSequences(_ pattern: String) -> String
             break
         }
 
-        switch pattern[escapedCharacterIndex]
+        let escapedCharacter = pattern[escapedCharacterIndex]
+
+        if let substitution = sequences.substitution(forEscaped: escapedCharacter)
         {
-        case "n":
-            decoded.append("\n")
-        case "r":
-            decoded.append("\r")
-        case "t":
-            decoded.append("\t")
-        case "\\":
-            decoded.append("\\")
-        default:
+            decoded.append(substitution)
+        }
+        else
+        {
             decoded.append(character)
-            decoded.append(pattern[escapedCharacterIndex])
+            decoded.append(escapedCharacter)
         }
 
         currentIndex = pattern.index(after: escapedCharacterIndex)

--- a/Fabric/Nodes/Parameters/String/StringEscapeSequences.swift
+++ b/Fabric/Nodes/Parameters/String/StringEscapeSequences.swift
@@ -1,0 +1,59 @@
+//
+//  StringEscapeSequences.swift
+//  Fabric
+//
+
+import Foundation
+
+/// Decodes the escape sequences the String nodes accept wherever a user types a
+/// pattern — String Split's and String Join's separators today. One vocabulary
+/// across all of them, so a separator typed into one node means the same thing
+/// in another: `\n`, `\r` and `\t` name the invisible characters, and `\\` is a
+/// literal backslash.
+///
+/// Deliberately lenient. An unrecognized escape (`\q`) and a trailing lone
+/// backslash are both preserved verbatim rather than swallowed or flagged, so a
+/// pattern mid-typing never silently loses characters, and adding a sequence to
+/// the vocabulary later is the only way a pattern's meaning can change.
+func decodeEscapeSequences(_ pattern: String) -> String
+{
+    var decoded = ""
+    var currentIndex = pattern.startIndex
+
+    while currentIndex < pattern.endIndex
+    {
+        let character = pattern[currentIndex]
+        guard character == "\\" else
+        {
+            decoded.append(character)
+            currentIndex = pattern.index(after: currentIndex)
+            continue
+        }
+
+        let escapedCharacterIndex = pattern.index(after: currentIndex)
+        guard escapedCharacterIndex < pattern.endIndex else
+        {
+            decoded.append(character)
+            break
+        }
+
+        switch pattern[escapedCharacterIndex]
+        {
+        case "n":
+            decoded.append("\n")
+        case "r":
+            decoded.append("\r")
+        case "t":
+            decoded.append("\t")
+        case "\\":
+            decoded.append("\\")
+        default:
+            decoded.append(character)
+            decoded.append(pattern[escapedCharacterIndex])
+        }
+
+        currentIndex = pattern.index(after: escapedCharacterIndex)
+    }
+
+    return decoded
+}

--- a/Fabric/Nodes/Parameters/String/StringFormatterNode.swift
+++ b/Fabric/Nodes/Parameters/String/StringFormatterNode.swift
@@ -74,13 +74,15 @@ struct ParsedFormatString: Equatable {
     }
 }
 
+/// What a format string's literal text may escape: the shared invisible
+/// characters — the only way to write one into the single-line Settings field —
+/// plus the braces this format claims as syntax.
+private let formatStringEscapeSequences: EscapeSequences = [.invisibleCharacters, .braces]
+
 /// Parse a format string into literal text and placeholder occurrences.
 ///
-/// Literals accept the same escape sequences as the String Split and String Join
-/// separators (`\n`, `\r`, `\t`, `\\`) — the only way to put an invisible
-/// character in a format string, since the Settings field is single-line. Braces
-/// are this format's own syntax, so `\{` and `\}` are resolved here too, giving a
-/// literal brace that neither opens nor closes a placeholder.
+/// Literals accept `formatStringEscapeSequences`, so an escaped brace is literal
+/// text that neither opens nor closes a placeholder.
 func parseFormatString(_ formatString: String) -> ParsedFormatString {
     var tokens: [ParsedFormatString.Token] = []
     var literal = ""
@@ -88,7 +90,7 @@ func parseFormatString(_ formatString: String) -> ParsedFormatString {
 
     func flushLiteral() {
         guard !literal.isEmpty else { return }
-        tokens.append(.literal(decodeEscapeSequences(literal)))
+        tokens.append(.literal(decodeEscapeSequences(literal, including: formatStringEscapeSequences)))
         literal = ""
     }
 
@@ -103,19 +105,12 @@ func parseFormatString(_ formatString: String) -> ParsedFormatString {
                 break
             }
 
-            let escapedCharacter = formatString[escapedCharacterIndex]
-
-            if escapedCharacter == "{" || escapedCharacter == "}" {
-                // Resolved here rather than by the shared decoder: an escaped
-                // brace must not reach the placeholder scan below.
-                literal.append(escapedCharacter)
-            } else {
-                // Left intact for the shared decoder, so `\\{` still reads as a
-                // literal backslash followed by a placeholder.
-                literal.append(character)
-                literal.append(escapedCharacter)
-            }
-
+            // A backslash shields the character after it from being read as
+            // syntax; what the pair stands for is the decoder's business at
+            // flush time. So `\{` never opens a placeholder, while `\\{` — a
+            // shielded backslash, then a brace — still does.
+            literal.append(character)
+            literal.append(formatString[escapedCharacterIndex])
             currentIndex = formatString.index(after: escapedCharacterIndex)
             continue
         }

--- a/Fabric/Nodes/Parameters/String/StringFormatterNode.swift
+++ b/Fabric/Nodes/Parameters/String/StringFormatterNode.swift
@@ -10,35 +10,88 @@ import SwiftUI
 
 // MARK: - Shared format string parsing
 
+/// What a placeholder's specifier asks for: the type of the port it builds and,
+/// for the numeric kinds, how to render the value.
+///
+/// The specifier is user-typed and reaches `String(format:)`, whose conversions
+/// are read positionally against a single argument — so a specifier is only
+/// honoured once it has been parsed whole and found to hold exactly one
+/// conversion. Anything else falls back to `.string`, printing the value as
+/// written rather than reading a vararg that was never supplied.
+enum FormatSpecifier: Equatable {
+    case string
+    case bool
+    /// printf format for a Swift Int, with the `l` length modifier its 64 bits need.
+    case integer(printfFormat: String)
+    case floatingPoint(printfFormat: String)
+
+    /// printf flags this accepts before the width; all are argument-free.
+    private static let flagCharacters: Set<Character> = ["-", "+", " ", "0", "#"]
+
+    init(_ specifier: String?) {
+        guard let specifier else { self = .string; return }
+
+        let trimmed = specifier.trimmingCharacters(in: .whitespaces)
+        guard trimmed != "s" else { self = .string; return }
+        guard trimmed != "b" else { self = .bool; return }
+
+        // <flags><width>.<precision><conversion>, and nothing else.
+        var remainder = Substring(trimmed)
+
+        let flags = remainder.prefix { Self.flagCharacters.contains($0) }
+        remainder = remainder.dropFirst(flags.count)
+
+        let width = remainder.prefix(while: \.isNumber)
+        remainder = remainder.dropFirst(width.count)
+
+        var precision = Substring()
+        if remainder.first == "." {
+            let digits = remainder.dropFirst().prefix(while: \.isNumber)
+            precision = remainder.prefix(1 + digits.count)
+            remainder = remainder.dropFirst(precision.count)
+        }
+
+        guard let conversion = remainder.first, remainder.count == 1 else { self = .string; return }
+
+        switch conversion {
+        case "d", "i":
+            self = .integer(printfFormat: "%\(flags)\(width)\(precision)ld")
+        case "f", "e", "g", "E", "G":
+            self = .floatingPoint(printfFormat: "%\(flags)\(width)\(precision)\(conversion)")
+        default:
+            self = .string
+        }
+    }
+
+    var portType: PortType {
+        switch self {
+        case .string: return .String
+        case .bool: return .Bool
+        case .integer: return .Int
+        case .floatingPoint: return .Float
+        }
+    }
+}
+
 /// A parsed placeholder from a format string like "Hello {name:.2f}"
 struct FormatPlaceholder: Equatable {
     let name: String
     let formatSpecifier: String?  // e.g. ".2f", "d", "s", "b" — nil means default (String)
 
+    /// What the specifier asks for, or `.string` if it asks for nothing legible.
+    var specifier: FormatSpecifier { FormatSpecifier(formatSpecifier) }
+
     /// The port type implied by the format specifier
-    var portType: PortType {
-        guard let spec = formatSpecifier else { return .String }
-        let trimmed = spec.trimmingCharacters(in: .whitespaces)
-        if trimmed == "b" { return .Bool }
-        if trimmed == "d" || trimmed == "i" { return .Int }
-        if trimmed == "s" { return .String }
-        // Anything containing 'f', 'e', 'g' (printf float specifiers) → Float
-        let lastChar = trimmed.last
-        if lastChar == "f" || lastChar == "e" || lastChar == "g" { return .Float }
-        return .String
-    }
+    var portType: PortType { specifier.portType }
 
     /// The printf format string to use with String(format:), or nil for plain string conversion
     var printfFormat: String? {
-        guard let spec = formatSpecifier else { return nil }
-        let trimmed = spec.trimmingCharacters(in: .whitespaces)
-        if trimmed == "s" || trimmed == "b" { return nil }
-        if trimmed == "d" || trimmed == "i" { return "%d" }
-        let lastChar = trimmed.last
-        if lastChar == "f" || lastChar == "e" || lastChar == "g" {
-            return "%\(trimmed)"
+        switch specifier {
+        case .integer(let printfFormat), .floatingPoint(let printfFormat):
+            return printfFormat
+        case .string, .bool:
+            return nil
         }
-        return nil
     }
 }
 

--- a/Fabric/Nodes/Parameters/String/StringFormatterNode.swift
+++ b/Fabric/Nodes/Parameters/String/StringFormatterNode.swift
@@ -112,18 +112,30 @@ struct ParsedFormatString: Equatable {
     /// Placeholders in first-appearance order, one entry per name — the set of
     /// ports the node exposes. A repeated name keeps its first specifier, so the
     /// port type stays put no matter how a later occurrence is written.
-    var placeholders: [FormatPlaceholder] {
-        var seen = Set<String>()
-        return tokens.compactMap { token in
-            guard case .placeholder(let placeholder) = token,
-                  seen.insert(placeholder.name).inserted else { return nil }
-            return placeholder
+    let placeholders: [FormatPlaceholder]
+
+    /// Resolved once here rather than per lookup: both nodes ask for a
+    /// placeholder by name for every occurrence they walk, on every execute.
+    private let placeholdersByName: [String: FormatPlaceholder]
+
+    init(tokens: [Token]) {
+        var placeholders: [FormatPlaceholder] = []
+        var placeholdersByName: [String: FormatPlaceholder] = [:]
+
+        for case .placeholder(let placeholder) in tokens
+        where placeholdersByName[placeholder.name] == nil {
+            placeholders.append(placeholder)
+            placeholdersByName[placeholder.name] = placeholder
         }
+
+        self.tokens = tokens
+        self.placeholders = placeholders
+        self.placeholdersByName = placeholdersByName
     }
 
     /// The placeholder a name resolves to, i.e. the one that owns the port.
     func placeholder(named name: String) -> FormatPlaceholder? {
-        placeholders.first { $0.name == name }
+        placeholdersByName[name]
     }
 }
 

--- a/Fabric/Nodes/Parameters/String/StringFormatterNode.swift
+++ b/Fabric/Nodes/Parameters/String/StringFormatterNode.swift
@@ -42,20 +42,140 @@ struct FormatPlaceholder: Equatable {
     }
 }
 
-/// Parse placeholders from a format string. Matches `{name}` and `{name:spec}`.
-func parseFormatPlaceholders(_ formatString: String) -> [FormatPlaceholder] {
-    let pattern = #/\{(\w+)(?::([^}]+))?\}/#
-    var placeholders: [FormatPlaceholder] = []
-    var seen = Set<String>()
-
-    for match in formatString.matches(of: pattern) {
-        let name = String(match.1)
-        if seen.contains(name) { continue }
-        seen.insert(name)
-        let spec = match.2.map { String($0) }
-        placeholders.append(FormatPlaceholder(name: name, formatSpecifier: spec))
+/// A format string broken into the literal text and the `{name}` / `{name:spec}`
+/// occurrences it is made of, in source order. Both String Formatter and String
+/// Scanner walk this: one substitutes values into the placeholders, the other
+/// builds a regex that captures them back out.
+struct ParsedFormatString: Equatable {
+    enum Token: Equatable {
+        /// Literal text, escape sequences already decoded.
+        case literal(String)
+        /// One placeholder occurrence — a name may occur more than once.
+        case placeholder(FormatPlaceholder)
     }
-    return placeholders
+
+    let tokens: [Token]
+
+    /// Placeholders in first-appearance order, one entry per name — the set of
+    /// ports the node exposes. A repeated name keeps its first specifier, so the
+    /// port type stays put no matter how a later occurrence is written.
+    var placeholders: [FormatPlaceholder] {
+        var seen = Set<String>()
+        return tokens.compactMap { token in
+            guard case .placeholder(let placeholder) = token,
+                  seen.insert(placeholder.name).inserted else { return nil }
+            return placeholder
+        }
+    }
+
+    /// The placeholder a name resolves to, i.e. the one that owns the port.
+    func placeholder(named name: String) -> FormatPlaceholder? {
+        placeholders.first { $0.name == name }
+    }
+}
+
+/// Parse a format string into literal text and placeholder occurrences.
+///
+/// Literals accept the same escape sequences as the String Split and String Join
+/// separators (`\n`, `\r`, `\t`, `\\`) — the only way to put an invisible
+/// character in a format string, since the Settings field is single-line. Braces
+/// are this format's own syntax, so `\{` and `\}` are resolved here too, giving a
+/// literal brace that neither opens nor closes a placeholder.
+func parseFormatString(_ formatString: String) -> ParsedFormatString {
+    var tokens: [ParsedFormatString.Token] = []
+    var literal = ""
+    var currentIndex = formatString.startIndex
+
+    func flushLiteral() {
+        guard !literal.isEmpty else { return }
+        tokens.append(.literal(decodeEscapeSequences(literal)))
+        literal = ""
+    }
+
+    while currentIndex < formatString.endIndex {
+        let character = formatString[currentIndex]
+
+        if character == "\\" {
+            let escapedCharacterIndex = formatString.index(after: currentIndex)
+
+            guard escapedCharacterIndex < formatString.endIndex else {
+                literal.append(character)
+                break
+            }
+
+            let escapedCharacter = formatString[escapedCharacterIndex]
+
+            if escapedCharacter == "{" || escapedCharacter == "}" {
+                // Resolved here rather than by the shared decoder: an escaped
+                // brace must not reach the placeholder scan below.
+                literal.append(escapedCharacter)
+            } else {
+                // Left intact for the shared decoder, so `\\{` still reads as a
+                // literal backslash followed by a placeholder.
+                literal.append(character)
+                literal.append(escapedCharacter)
+            }
+
+            currentIndex = formatString.index(after: escapedCharacterIndex)
+            continue
+        }
+
+        if character == "{",
+           let (placeholder, endIndex) = parsePlaceholder(in: formatString, from: currentIndex) {
+            flushLiteral()
+            tokens.append(.placeholder(placeholder))
+            currentIndex = endIndex
+            continue
+        }
+
+        literal.append(character)
+        currentIndex = formatString.index(after: currentIndex)
+    }
+
+    flushLiteral()
+
+    return ParsedFormatString(tokens: tokens)
+}
+
+/// Reads one `{name}` / `{name:spec}` starting at `startIndex`, returning it with
+/// the index just past its closing brace. Nil for anything else — an unmatched or
+/// empty brace is literal text, as it was before placeholders were escapable.
+private func parsePlaceholder(
+    in formatString: String,
+    from startIndex: String.Index
+) -> (placeholder: FormatPlaceholder, endIndex: String.Index)? {
+    var currentIndex = formatString.index(after: startIndex)
+
+    var name = ""
+    while currentIndex < formatString.endIndex {
+        let character = formatString[currentIndex]
+        guard character.isLetter || character.isNumber || character == "_" else { break }
+        name.append(character)
+        currentIndex = formatString.index(after: currentIndex)
+    }
+
+    guard !name.isEmpty, currentIndex < formatString.endIndex else { return nil }
+
+    var formatSpecifier: String? = nil
+    if formatString[currentIndex] == ":" {
+        currentIndex = formatString.index(after: currentIndex)
+
+        var specifier = ""
+        while currentIndex < formatString.endIndex, formatString[currentIndex] != "}" {
+            specifier.append(formatString[currentIndex])
+            currentIndex = formatString.index(after: currentIndex)
+        }
+
+        guard !specifier.isEmpty else { return nil }
+        formatSpecifier = specifier
+    }
+
+    guard currentIndex < formatString.endIndex, formatString[currentIndex] == "}" else { return nil }
+
+    return (
+        FormatPlaceholder(name: name, formatSpecifier: formatSpecifier),
+        formatString.index(after: currentIndex)
+    )
 }
 
 // MARK: - Settings View
@@ -65,7 +185,7 @@ struct StringFormatSettingsView: View {
 
     var body: some View {
         VStack(alignment: .leading) {
-            Text("Use `{name}` for String, `{name:s}` String, `{name:d}` or `{name:i}` Int, `{name:b}` Bool, `{name:f}` or `{name:.2f}` Float.\n\nExample: `Position: {x:.2f}, {y:.2f}`")
+            Text("Use `{name}` for String, `{name:s}` String, `{name:d}` or `{name:i}` Int, `{name:b}` Bool, `{name:f}` or `{name:.2f}` Float.\n\nExample: `Position: {x:.2f}, {y:.2f}`\n\nEscapes: `\\n`, `\\r`, `\\t`, `\\\\`, and `\\{` `\\}` for literal braces.")
 
             Spacer()
 
@@ -113,16 +233,25 @@ public class StringFormatterNode: Node {
         self.updatePorts()
     }
 
+    /// Procedural construction with a specific format string — the Settings-view
+    /// state that shapes this node's ports, so graph building never has to go
+    /// through the inspector to reach it.
+    public init(context: Context, formatString: String) {
+        self.formatString = formatString
+        super.init(context: context)
+        self.updatePorts()
+    }
+
     // MARK: - Properties
 
-    fileprivate var formatString: String = "Hello {name}" {
+    public fileprivate(set) var formatString: String = "Hello {name}" {
         didSet {
             self.updatePorts()
             self.nameSubject.send()
         }
     }
 
-    private var placeholders: [FormatPlaceholder] = []
+    private var parsedFormatString = ParsedFormatString(tokens: [])
 
     // MARK: - Ports
 
@@ -177,63 +306,57 @@ public class StringFormatterNode: Node {
 
         guard anyChanged else { return }
 
-        var result = formatString
-        let pattern = #/\{(\w+)(?::([^}]+))?\}/#
+        // Assembled by walking the parse, so a value that happens to look like a
+        // placeholder is never substituted into a second time.
+        var result = ""
 
-        for match in formatString.matches(of: pattern) {
-            let name = String(match.1)
-            let placeholder = placeholders.first(where: { $0.name == name })
-
-            let replacement: String
-            switch placeholder?.portType ?? .String {
-            case .Float:
-                if let port = self.findPort(named: name) as? NodePort<Float>,
-                   let value = port.value {
-                    if let fmt = placeholder?.printfFormat {
-                        replacement = String(format: fmt, value)
-                    } else {
-                        replacement = String(value)
-                    }
-                } else {
-                    replacement = ""
-                }
-            case .Int:
-                if let port = self.findPort(named: name) as? NodePort<Int>,
-                   let value = port.value {
-                    if let fmt = placeholder?.printfFormat {
-                        replacement = String(format: fmt, value)
-                    } else {
-                        replacement = String(value)
-                    }
-                } else {
-                    replacement = ""
-                }
-            case .Bool:
-                if let port = self.findPort(named: name) as? NodePort<Bool>,
-                   let value = port.value {
-                    replacement = String(value)
-                } else {
-                    replacement = ""
-                }
-            default: // .String
-                if let port = self.findPort(named: name) as? NodePort<String>,
-                   let value = port.value {
-                    replacement = value
-                } else {
-                    replacement = ""
-                }
+        for token in parsedFormatString.tokens {
+            switch token {
+            case .literal(let text):
+                result += text
+            case .placeholder(let placeholder):
+                result += formattedValue(named: placeholder.name)
             }
-
-            result = result.replacingOccurrences(of: String(match.0), with: replacement)
         }
 
         outputString.send(result)
     }
 
+    /// The value on the port `name` owns, rendered with the specifier that built
+    /// that port. Empty when the port is missing or holds no value.
+    private func formattedValue(named name: String) -> String {
+        guard let placeholder = parsedFormatString.placeholder(named: name) else { return "" }
+
+        switch placeholder.portType {
+        case .Float:
+            guard let port = self.findPort(named: name) as? NodePort<Float>,
+                  let value = port.value else { return "" }
+            guard let printfFormat = placeholder.printfFormat else { return String(value) }
+            return String(format: printfFormat, value)
+
+        case .Int:
+            guard let port = self.findPort(named: name) as? NodePort<Int>,
+                  let value = port.value else { return "" }
+            guard let printfFormat = placeholder.printfFormat else { return String(value) }
+            return String(format: printfFormat, value)
+
+        case .Bool:
+            guard let port = self.findPort(named: name) as? NodePort<Bool>,
+                  let value = port.value else { return "" }
+            return String(value)
+
+        default: // .String
+            guard let port = self.findPort(named: name) as? NodePort<String>,
+                  let value = port.value else { return "" }
+            return value
+        }
+    }
+
     // MARK: - Dynamic Port Management
 
     private func updatePorts() {
-        let newPlaceholders = parseFormatPlaceholders(formatString)
+        let newParse = parseFormatString(formatString)
+        let newPlaceholders = newParse.placeholders
 
         let existingNames = Set(self.inputPorts().map { $0.name })
         let newNames = Set(newPlaceholders.map { $0.name })
@@ -262,7 +385,7 @@ public class StringFormatterNode: Node {
             }
         }
 
-        self.placeholders = newPlaceholders
+        self.parsedFormatString = newParse
     }
 
     private func makeInputPort(for placeholder: FormatPlaceholder) -> Port {

--- a/Fabric/Nodes/Parameters/String/StringFormatterNode.swift
+++ b/Fabric/Nodes/Parameters/String/StringFormatterNode.swift
@@ -238,87 +238,23 @@ private func parsePlaceholder(
     )
 }
 
-// MARK: - Settings View
-
-struct StringFormatSettingsView: View {
-    @Bindable var model: StringFormatterNode.SettingsModel
-
-    var body: some View {
-        VStack(alignment: .leading) {
-            Text("Use `{name}` for String, `{name:s}` String, `{name:d}` or `{name:i}` Int, `{name:b}` Bool, `{name:f}` or `{name:.2f}` Float.\n\nExample: `Position: {x:.2f}, {y:.2f}`\n\nEscapes: `\\n`, `\\r`, `\\t`, `\\\\`, and `\\{` `\\}` for literal braces.")
-
-            Spacer()
-
-            TextField("Format String", text: $model.formatString)
-                .lineLimit(1)
-                .font(.system(size: 10))
-                .textFieldStyle(RoundedBorderTextFieldStyle())
-        }
-    }
-}
-
 // MARK: - String Formatter Node
 
-public class StringFormatterNode: Node {
+public class StringFormatterNode: BaseFormatStringNode {
     override public class var name: String { "String Formatter" }
     override public class var nodeType: Node.NodeType { .Parameter(parameterType: .String) }
     override public class var nodeExecutionMode: Node.ExecutionMode { .Processor }
     override public class var nodeTimeMode: Node.TimeMode { .None }
     override public class var nodeDescription: String { "Format values into a string using named placeholders. Inverse of String Scanner." }
 
-    override public var displayName: String? { formatString.isEmpty ? nil : formatString }
+    override public class var defaultFormatString: String { "Hello {name}" }
 
-    // MARK: - Codable
+    /// Placeholders are the values to substitute, so each builds an inlet.
+    override public class var placeholderPortKind: PortKind { .Inlet }
 
-    private enum CodingKeys: String, CodingKey {
-        case formatString
+    override public class var settingsGuidance: String {
+        "Use `{name}` for String, `{name:s}` String, `{name:d}` or `{name:i}` Int, `{name:b}` Bool, `{name:f}` or `{name:.2f}` Float.\n\nExample: `Position: {x:.2f}, {y:.2f}`\n\nEscapes: `\\n`, `\\r`, `\\t`, `\\\\`, and `\\{` `\\}` for literal braces."
     }
-
-    public required init(from decoder: any Decoder) throws {
-        try super.init(from: decoder)
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        let decoded = try container.decodeIfPresent(String.self, forKey: .formatString)
-        self.formatString = decoded ?? "Hello {name}"
-        self.updatePorts()
-    }
-
-    public override func encode(to encoder: Encoder) throws {
-        try super.encode(to: encoder)
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(self.formatString, forKey: .formatString)
-    }
-
-    public required init(context: Context) {
-        super.init(context: context)
-        self.updatePorts()
-    }
-
-    /// Procedural construction with a specific format string — the Settings-view
-    /// state that shapes this node's ports, so graph building never has to go
-    /// through the inspector to reach it.
-    public init(context: Context, formatString: String) {
-        self.formatString = formatString
-        super.init(context: context)
-        self.updatePorts()
-    }
-
-    // MARK: - Properties
-
-    public fileprivate(set) var formatString: String = "Hello {name}" {
-        didSet {
-            self.updatePorts()
-            self.nameSubject.send()
-        }
-    }
-
-    /// Sets the format string from outside the Settings view — the procedural
-    /// equivalent of typing in the inspector.
-    public func setFormatString(_ formatString: String) {
-        guard formatString != self.formatString else { return }
-        self.formatString = formatString
-    }
-
-    private var parsedFormatString = ParsedFormatString(tokens: [])
 
     /// Forces one evaluation after a format-string edit, even when no input
     /// changed: a new format produces a different string from the same values,
@@ -335,35 +271,6 @@ public class StringFormatterNode: Node {
     }
 
     public var outputString: NodePort<String> { port(named: "outputString") }
-
-    override public func providesSettingsView() -> Bool { true }
-
-    override public func settingsView() -> AnyView {
-        AnyView(StringFormatSettingsView(model: _settingsModel))
-    }
-
-    // MARK: - Settings Model
-
-    @Observable final class SettingsModel
-    {
-        var formatString: String
-        {
-            didSet
-            {
-                guard formatString != node?.formatString else { return }
-                node?.formatString = formatString
-            }
-        }
-        private weak var node: StringFormatterNode?
-
-        init(node: StringFormatterNode)
-        {
-            self.node = node
-            self.formatString = node.formatString
-        }
-    }
-
-    private lazy var _settingsModel = SettingsModel(node: self)
 
     // MARK: - Execution
 
@@ -426,46 +333,8 @@ public class StringFormatterNode: Node {
 
     // MARK: - Dynamic Port Management
 
-    private func updatePorts() {
-        let newParse = parseFormatString(formatString)
-        let newPlaceholders = newParse.placeholders
-
-        let existingNames = Set(self.inputPorts().map { $0.name })
-        let newNames = Set(newPlaceholders.map { $0.name })
-
-        // Remove ports no longer in the format string
-        let toRemove = existingNames.subtracting(newNames)
-        for portName in toRemove {
-            if let port: Port = self.findPort(named: portName) {
-                self.removePort(port)
-            }
-        }
-
-        // Remove ports whose type has changed
-        for placeholder in newPlaceholders {
-            if let existingPort: Port = self.findPort(named: placeholder.name),
-               existingPort.portType != placeholder.portType {
-                self.removePort(existingPort)
-            }
-        }
-
-        // Add ports for new placeholders
-        for placeholder in newPlaceholders {
-            if (self.findPort(named: placeholder.name) as Port?) == nil {
-                let port = makeInputPort(for: placeholder)
-                self.addDynamicPort(port, name: placeholder.name)
-            }
-        }
-
-        self.parsedFormatString = newParse
-
-        // A format edit reshapes the output even when it reshapes no port, and
-        // the renderer skips a node that is not dirty.
-        self.needsEvaluation = true
-        self.markDirty()
-    }
-
-    private func makeInputPort(for placeholder: FormatPlaceholder) -> Port {
+    /// A placeholder's value arrives on an editable inlet of its type.
+    override func makePlaceholderPort(for placeholder: FormatPlaceholder) -> Port {
         switch placeholder.portType {
         case .Float:
             return ParameterPort(parameter: FloatParameter(placeholder.name, 0.0, .inputfield))
@@ -476,5 +345,11 @@ public class StringFormatterNode: Node {
         default:
             return ParameterPort(parameter: StringParameter(placeholder.name, "", .inputfield))
         }
+    }
+
+    override func formatStringDidChange() {
+        // A new format produces a different string from the same values — and a
+        // format with no placeholders has no input whose change could say so.
+        self.needsEvaluation = true
     }
 }

--- a/Fabric/Nodes/Parameters/String/StringFormatterNode.swift
+++ b/Fabric/Nodes/Parameters/String/StringFormatterNode.swift
@@ -246,7 +246,19 @@ public class StringFormatterNode: Node {
         }
     }
 
+    /// Sets the format string from outside the Settings view — the procedural
+    /// equivalent of typing in the inspector.
+    public func setFormatString(_ formatString: String) {
+        guard formatString != self.formatString else { return }
+        self.formatString = formatString
+    }
+
     private var parsedFormatString = ParsedFormatString(tokens: [])
+
+    /// Forces one evaluation after a format-string edit, even when no input
+    /// changed: a new format produces a different string from the same values,
+    /// and a format with no placeholders at all has no input to change.
+    private var needsEvaluation = true
 
     // MARK: - Ports
 
@@ -296,10 +308,10 @@ public class StringFormatterNode: Node {
                                  commandBuffer: MTLCommandBuffer)
     throws
     {
-        let inputs = self.inputPorts()
-        let anyChanged = inputs.compactMap(\.valueDidChange).contains(true)
+        let inputsChanged = self.inputPorts().contains { $0.valueDidChange }
 
-        guard anyChanged else { return }
+        guard inputsChanged || self.needsEvaluation else { return }
+        self.needsEvaluation = false
 
         // Assembled by walking the parse, so a value that happens to look like a
         // placeholder is never substituted into a second time.
@@ -381,6 +393,11 @@ public class StringFormatterNode: Node {
         }
 
         self.parsedFormatString = newParse
+
+        // A format edit reshapes the output even when it reshapes no port, and
+        // the renderer skips a node that is not dirty.
+        self.needsEvaluation = true
+        self.markDirty()
     }
 
     private func makeInputPort(for placeholder: FormatPlaceholder) -> Port {

--- a/Fabric/Nodes/Parameters/String/StringJoinNode.swift
+++ b/Fabric/Nodes/Parameters/String/StringJoinNode.swift
@@ -26,7 +26,7 @@ public class StringJoinNode : Node
         return ports +
         [
             ("inputPort",       NodePort<ContiguousArray<String>>(name: "Strings", kind: .Inlet, description: "Array of strings to join")),
-            ("separatorPort",   ParameterPort(parameter: StringParameter("Separator", ", ", .inputfield, "Separator to place between each string"))),
+            ("separatorPort",   ParameterPort(parameter: StringParameter("Separator", ", ", .inputfield, #"Separator to place between each string. Supports \n, \r, \t, and \\ escape sequences"#))),
             ("outputPort",      NodePort<String>(name: "String", kind: .Outlet, description: "Joined string result")),
         ]
     }
@@ -47,7 +47,9 @@ public class StringJoinNode : Node
             if let strings = self.inputPort.value,
                let separator = self.separatorPort.value
             {
-                self.outputPort.send( strings.joined(separator: separator) )
+                // Same escape vocabulary as String Split's separator, so a
+                // separator that splits a string joins it back together.
+                self.outputPort.send( strings.joined(separator: decodeEscapeSequences(separator)) )
             }
         }
     }

--- a/Fabric/Nodes/Parameters/String/StringScannerNode.swift
+++ b/Fabric/Nodes/Parameters/String/StringScannerNode.swift
@@ -147,31 +147,41 @@ public class StringScannerNode: Node {
 
         outputMatched.send(true)
 
-        // Extract captured values and send to output ports
-        for (index, placeholder) in parsedFormatString.placeholders.enumerated() {
-            let captureIndex = index + 1  // Index 0 is the whole match
+        // Extract captured values and send to output ports. buildRegex emits one
+        // capture group per placeholder *occurrence*, so the groups are walked in
+        // that same order — a name written twice captures twice, independently,
+        // and its port takes the last of them.
+        var captureIndex = 0  // Index 0 is the whole match
+
+        for token in parsedFormatString.tokens {
+            guard case .placeholder(let occurrence) = token else { continue }
+
+            captureIndex += 1
             guard captureIndex < match.output.count else { continue }
 
-            let captured = String(match.output[captureIndex].substring ?? "")
+            send(String(match.output[captureIndex].substring ?? ""), toPortNamed: occurrence.name)
+        }
+    }
 
-            switch placeholder.portType {
-            case .Float:
-                if let port = self.findPort(named: placeholder.name) as? NodePort<Float> {
-                    port.send(Float(captured) ?? 0.0)
-                }
-            case .Int:
-                if let port = self.findPort(named: placeholder.name) as? NodePort<Int> {
-                    port.send(Int(captured) ?? 0)
-                }
-            case .Bool:
-                if let port = self.findPort(named: placeholder.name) as? NodePort<Bool> {
-                    let value = captured == "true" || captured == "1" || captured == "yes"
-                    port.send(value)
-                }
-            default: // .String
-                if let port = self.findPort(named: placeholder.name) as? NodePort<String> {
-                    port.send(captured)
-                }
+    /// Sends captured text to the port `name` owns, converted to that port's type.
+    private func send(_ captured: String, toPortNamed name: String) {
+        switch parsedFormatString.placeholder(named: name)?.portType ?? .String {
+        case .Float:
+            if let port = self.findPort(named: name) as? NodePort<Float> {
+                port.send(Float(captured) ?? 0.0)
+            }
+        case .Int:
+            if let port = self.findPort(named: name) as? NodePort<Int> {
+                port.send(Int(captured) ?? 0)
+            }
+        case .Bool:
+            if let port = self.findPort(named: name) as? NodePort<Bool> {
+                let value = captured == "true" || captured == "1" || captured == "yes"
+                port.send(value)
+            }
+        default: // .String
+            if let port = self.findPort(named: name) as? NodePort<String> {
+                port.send(captured)
             }
         }
     }

--- a/Fabric/Nodes/Parameters/String/StringScannerNode.swift
+++ b/Fabric/Nodes/Parameters/String/StringScannerNode.swift
@@ -8,87 +8,26 @@ import Satin
 import Metal
 import SwiftUI
 
-// MARK: - Settings View
-
-struct StringScannerSettingsView: View {
-    @Bindable var model: StringScannerNode.SettingsModel
-
-    var body: some View {
-        VStack(alignment: .leading) {
-            Text("Use `{name}` for String, `{name:s}` String, `{name:d}` or `{name:i}` Int, `{name:b}` Bool, `{name:f}` Float.\n\nExample: `Frame {n:d} at {t:f}s`\n\nEscapes: `\\n`, `\\r`, `\\t`, `\\\\`, and `\\{` `\\}` for literal braces.\n\nThe format string is converted to a regex that captures values from the input string.")
-
-            Spacer()
-
-            TextField("Format String", text: $model.formatString)
-                .lineLimit(1)
-                .font(.system(size: 10))
-                .textFieldStyle(RoundedBorderTextFieldStyle())
-        }
-    }
-}
-
 // MARK: - String Scanner Node
 
-public class StringScannerNode: Node {
+public class StringScannerNode: BaseFormatStringNode {
     override public class var name: String { "String Scanner" }
     override public class var nodeType: Node.NodeType { .Parameter(parameterType: .String) }
     override public class var nodeExecutionMode: Node.ExecutionMode { .Processor }
     override public class var nodeTimeMode: Node.TimeMode { .None }
     override public class var nodeDescription: String { "Extract values from a string using named placeholders. Inverse of String Formatter." }
 
-    override public var displayName: String? { formatString.isEmpty ? nil : formatString }
+    override public class var defaultFormatString: String { "Frame {n:d} at {t:f}s" }
 
-    // MARK: - Codable
+    /// Placeholders are what the scan captures, so each builds an outlet —
+    /// alongside Matched, which the format string does not own.
+    override public class var placeholderPortKind: PortKind { .Outlet }
+    override public class var staticPortNames: Set<String> { ["Matched"] }
 
-    private enum CodingKeys: String, CodingKey {
-        case formatString
+    override public class var settingsGuidance: String {
+        "Use `{name}` for String, `{name:s}` String, `{name:d}` or `{name:i}` Int, `{name:b}` Bool, `{name:f}` Float.\n\nExample: `Frame {n:d} at {t:f}s`\n\nEscapes: `\\n`, `\\r`, `\\t`, `\\\\`, and `\\{` `\\}` for literal braces.\n\nThe format string is converted to a regex that captures values from the input string."
     }
 
-    public required init(from decoder: any Decoder) throws {
-        try super.init(from: decoder)
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        let decoded = try container.decodeIfPresent(String.self, forKey: .formatString)
-        self.formatString = decoded ?? "Frame {n:d} at {t:f}s"
-        self.updatePorts()
-    }
-
-    public override func encode(to encoder: Encoder) throws {
-        try super.encode(to: encoder)
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(self.formatString, forKey: .formatString)
-    }
-
-    public required init(context: Context) {
-        super.init(context: context)
-        self.updatePorts()
-    }
-
-    /// Procedural construction with a specific format string — the Settings-view
-    /// state that shapes this node's ports, so graph building never has to go
-    /// through the inspector to reach it.
-    public init(context: Context, formatString: String) {
-        self.formatString = formatString
-        super.init(context: context)
-        self.updatePorts()
-    }
-
-    // MARK: - Properties
-
-    public fileprivate(set) var formatString: String = "Frame {n:d} at {t:f}s" {
-        didSet {
-            self.updatePorts()
-            self.nameSubject.send()
-        }
-    }
-
-    /// Sets the format string from outside the Settings view — the procedural
-    /// equivalent of typing in the inspector.
-    public func setFormatString(_ formatString: String) {
-        guard formatString != self.formatString else { return }
-        self.formatString = formatString
-    }
-
-    private var parsedFormatString = ParsedFormatString(tokens: [])
     private var scanRegex: Regex<AnyRegexOutput>? = nil
 
     // MARK: - Ports
@@ -103,35 +42,6 @@ public class StringScannerNode: Node {
 
     public var inputString: ParameterPort<String> { port(named: "inputString") }
     public var outputMatched: NodePort<Bool> { port(named: "outputMatched") }
-
-    override public func providesSettingsView() -> Bool { true }
-
-    override public func settingsView() -> AnyView {
-        AnyView(StringScannerSettingsView(model: _settingsModel))
-    }
-
-    // MARK: - Settings Model
-
-    @Observable final class SettingsModel
-    {
-        var formatString: String
-        {
-            didSet
-            {
-                guard formatString != node?.formatString else { return }
-                node?.formatString = formatString
-            }
-        }
-        private weak var node: StringScannerNode?
-
-        init(node: StringScannerNode)
-        {
-            self.node = node
-            self.formatString = node.formatString
-        }
-    }
-
-    private lazy var _settingsModel = SettingsModel(node: self)
 
     // MARK: - Execution
 
@@ -195,45 +105,26 @@ public class StringScannerNode: Node {
 
     // MARK: - Dynamic Port Management
 
-    private func updatePorts() {
-        let newParse = parseFormatString(formatString)
-        let newPlaceholders = newParse.placeholders
-
-        let staticPortNames: Set<String> = ["Matched"]
-        let existingNames = Set(self.outputPorts().filter { !staticPortNames.contains($0.name) }.map { $0.name })
-        let newNames = Set(newPlaceholders.map { $0.name })
-
-        // Remove ports no longer in the format string
-        let toRemove = existingNames.subtracting(newNames)
-        for portName in toRemove {
-            if let port: Port = self.findPort(named: portName) {
-                self.removePort(port)
-            }
+    /// A placeholder's capture leaves on an outlet of its type.
+    override func makePlaceholderPort(for placeholder: FormatPlaceholder) -> Port {
+        switch placeholder.portType {
+        case .Float:
+            return NodePort<Float>(name: placeholder.name, kind: .Outlet, description: "Captured float value")
+        case .Int:
+            return NodePort<Int>(name: placeholder.name, kind: .Outlet, description: "Captured integer value")
+        case .Bool:
+            return NodePort<Bool>(name: placeholder.name, kind: .Outlet, description: "Captured boolean value")
+        default:
+            return NodePort<String>(name: placeholder.name, kind: .Outlet, description: "Captured string value")
         }
+    }
 
-        // Remove ports whose type has changed
-        for placeholder in newPlaceholders {
-            if let existingPort: Port = self.findPort(named: placeholder.name),
-               existingPort.portType != placeholder.portType {
-                self.removePort(existingPort)
-            }
-        }
-
-        // Add ports for new placeholders
-        for placeholder in newPlaceholders {
-            if (self.findPort(named: placeholder.name) as Port?) == nil {
-                let port = makeOutputPort(for: placeholder)
-                self.addDynamicPort(port, name: placeholder.name)
-            }
-        }
-
-        self.parsedFormatString = newParse
+    override func formatStringDidChange() {
         self.buildRegex()
 
-        // The input is unchanged but the regex reading it is not, and the
-        // renderer skips a node that is not dirty — so re-scan what is there.
+        // The input is unchanged but the regex reading it is not, so re-scan
+        // what is already there.
         self.inputString.valueDidChange = true
-        self.markDirty()
     }
 
     private func buildRegex() {
@@ -264,20 +155,7 @@ public class StringScannerNode: Node {
         regexString += "$"
 
         // Newlines are ordinary characters here: a `\n` in the format string is
-        // now matchable, so a String capture must be able to span one too.
+        // matchable, so a String capture must be able to span one too.
         self.scanRegex = try? Regex(regexString).dotMatchesNewlines()
-    }
-
-    private func makeOutputPort(for placeholder: FormatPlaceholder) -> Port {
-        switch placeholder.portType {
-        case .Float:
-            return NodePort<Float>(name: placeholder.name, kind: .Outlet, description: "Captured float value")
-        case .Int:
-            return NodePort<Int>(name: placeholder.name, kind: .Outlet, description: "Captured integer value")
-        case .Bool:
-            return NodePort<Bool>(name: placeholder.name, kind: .Outlet, description: "Captured boolean value")
-        default:
-            return NodePort<String>(name: placeholder.name, kind: .Outlet, description: "Captured string value")
-        }
     }
 }

--- a/Fabric/Nodes/Parameters/String/StringScannerNode.swift
+++ b/Fabric/Nodes/Parameters/String/StringScannerNode.swift
@@ -15,7 +15,7 @@ struct StringScannerSettingsView: View {
 
     var body: some View {
         VStack(alignment: .leading) {
-            Text("Use `{name}` for String, `{name:s}` String, `{name:d}` or `{name:i}` Int, `{name:b}` Bool, `{name:f}` Float.\n\nExample: `Frame {n:d} at {t:f}s`\n\nThe format string is converted to a regex that captures values from the input string.")
+            Text("Use `{name}` for String, `{name:s}` String, `{name:d}` or `{name:i}` Int, `{name:b}` Bool, `{name:f}` Float.\n\nExample: `Frame {n:d} at {t:f}s`\n\nEscapes: `\\n`, `\\r`, `\\t`, `\\\\`, and `\\{` `\\}` for literal braces.\n\nThe format string is converted to a regex that captures values from the input string.")
 
             Spacer()
 
@@ -63,16 +63,25 @@ public class StringScannerNode: Node {
         self.updatePorts()
     }
 
+    /// Procedural construction with a specific format string — the Settings-view
+    /// state that shapes this node's ports, so graph building never has to go
+    /// through the inspector to reach it.
+    public init(context: Context, formatString: String) {
+        self.formatString = formatString
+        super.init(context: context)
+        self.updatePorts()
+    }
+
     // MARK: - Properties
 
-    fileprivate var formatString: String = "Frame {n:d} at {t:f}s" {
+    public fileprivate(set) var formatString: String = "Frame {n:d} at {t:f}s" {
         didSet {
             self.updatePorts()
             self.nameSubject.send()
         }
     }
 
-    private var placeholders: [FormatPlaceholder] = []
+    private var parsedFormatString = ParsedFormatString(tokens: [])
     private var scanRegex: Regex<AnyRegexOutput>? = nil
 
     // MARK: - Ports
@@ -139,7 +148,7 @@ public class StringScannerNode: Node {
         outputMatched.send(true)
 
         // Extract captured values and send to output ports
-        for (index, placeholder) in placeholders.enumerated() {
+        for (index, placeholder) in parsedFormatString.placeholders.enumerated() {
             let captureIndex = index + 1  // Index 0 is the whole match
             guard captureIndex < match.output.count else { continue }
 
@@ -170,7 +179,8 @@ public class StringScannerNode: Node {
     // MARK: - Dynamic Port Management
 
     private func updatePorts() {
-        let newPlaceholders = parseFormatPlaceholders(formatString)
+        let newParse = parseFormatString(formatString)
+        let newPlaceholders = newParse.placeholders
 
         let staticPortNames: Set<String> = ["Matched"]
         let existingNames = Set(self.outputPorts().filter { !staticPortNames.contains($0.name) }.map { $0.name })
@@ -200,27 +210,24 @@ public class StringScannerNode: Node {
             }
         }
 
-        self.placeholders = newPlaceholders
+        self.parsedFormatString = newParse
         self.buildRegex()
         self.inputString.valueDidChange = true
     }
 
     private func buildRegex() {
-        let placeholderPattern = #/\{(\w+)(?::([^}]+))?\}/#
-
         var regexString = "^"
-        var lastEnd = formatString.startIndex
 
-        for match in formatString.matches(of: placeholderPattern) {
-            // Escape the literal text between placeholders
-            let literalRange = lastEnd..<match.range.lowerBound
-            let literal = String(formatString[literalRange])
-            regexString += NSRegularExpression.escapedPattern(for: literal)
+        for token in parsedFormatString.tokens {
+            switch token {
+            case .literal(let text):
+                // Decoded literal text, taken as-is: whatever the user typed
+                // matches itself, regex metacharacters included.
+                regexString += NSRegularExpression.escapedPattern(for: text)
 
-            // Add a capture group appropriate to the type
-            let name = String(match.1)
-            if let placeholder = placeholders.first(where: { $0.name == name }) {
-                switch placeholder.portType {
+            case .placeholder(let placeholder):
+                // A capture group appropriate to the type owning the port.
+                switch parsedFormatString.placeholder(named: placeholder.name)?.portType ?? .String {
                 case .Float:
                     regexString += "([+-]?(?:\\d+\\.?\\d*|\\.\\d+)(?:[eE][+-]?\\d+)?)"
                 case .Int:
@@ -230,19 +237,14 @@ public class StringScannerNode: Node {
                 default:
                     regexString += "(.+?)"
                 }
-            } else {
-                regexString += "(.+?)"
             }
-
-            lastEnd = match.range.upperBound
         }
 
-        // Append any trailing literal text
-        let trailing = String(formatString[lastEnd...])
-        regexString += NSRegularExpression.escapedPattern(for: trailing)
         regexString += "$"
 
-        self.scanRegex = try? Regex(regexString)
+        // Newlines are ordinary characters here: a `\n` in the format string is
+        // now matchable, so a String capture must be able to span one too.
+        self.scanRegex = try? Regex(regexString).dotMatchesNewlines()
     }
 
     private func makeOutputPort(for placeholder: FormatPlaceholder) -> Port {

--- a/Fabric/Nodes/Parameters/String/StringScannerNode.swift
+++ b/Fabric/Nodes/Parameters/String/StringScannerNode.swift
@@ -81,6 +81,13 @@ public class StringScannerNode: Node {
         }
     }
 
+    /// Sets the format string from outside the Settings view — the procedural
+    /// equivalent of typing in the inspector.
+    public func setFormatString(_ formatString: String) {
+        guard formatString != self.formatString else { return }
+        self.formatString = formatString
+    }
+
     private var parsedFormatString = ParsedFormatString(tokens: [])
     private var scanRegex: Regex<AnyRegexOutput>? = nil
 
@@ -222,7 +229,11 @@ public class StringScannerNode: Node {
 
         self.parsedFormatString = newParse
         self.buildRegex()
+
+        // The input is unchanged but the regex reading it is not, and the
+        // renderer skips a node that is not dirty — so re-scan what is there.
         self.inputString.valueDidChange = true
+        self.markDirty()
     }
 
     private func buildRegex() {

--- a/Fabric/Nodes/Parameters/String/StringSplitNode.swift
+++ b/Fabric/Nodes/Parameters/String/StringSplitNode.swift
@@ -8,160 +8,120 @@ import Satin
 import Metal
 import SwiftUI
 
-public enum StringSplitMode: String, Codable, CaseIterable, Sendable
+/// How a String Split node divides its input. Custom is the only mode that takes
+/// a Separator inlet, so the mode lives on the Settings picker (a StrategyNode
+/// strategy) rather than a wired port.
+public enum StringSplitMode: String, NodeStrategyOption, CaseIterable
 {
-    case exactSeparator = "Exact Separator"
-    case words = "Words"
-    case commas = "Commas"
-    case lines = "Lines"
+    /// Splits on the exact text supplied by the Separator inlet.
+    case custom = "Custom"
+    /// Splits on commas.
+    case comma = "Comma"
+    /// Splits on any whitespace.
+    case space = "Space"
+    /// Splits on any recognized newline character.
+    case newline = "Newline"
 
-    var description: String
+    /// One or two sentences shown in the Settings pane to explain the mode.
+    public var usageGuidance: String
     {
         switch self
         {
-        case .exactSeparator:
-            "Splits on the exact value supplied by the Separator inlet."
-        case .words:
-            "Splits on any whitespace."
-        case .commas:
-            "Splits on commas, trims whitespace, and removes empty values."
-        case .lines:
-            "Splits on recognized newline characters, trims whitespace, and removes empty values."
+        case .custom:
+            return #"Splits on the exact value supplied by the Separator inlet, which understands the \n, \r, \t and \\ escape sequences. Empty and untrimmed components are kept, so joining the result back together reproduces the input."#
+        case .comma:
+            return "Splits on commas, trims whitespace, and removes empty values. For comma-separated lists written for people to read."
+        case .space:
+            return "Splits on any whitespace — spaces, tabs and newlines alike — and removes empty values. For splitting prose into words."
+        case .newline:
+            return "Splits on recognized newline characters, trims whitespace, and removes empty values. For loaded text files, whichever line endings they use."
         }
     }
 }
 
-private struct StringSplitSettingsView: View
+public class StringSplitNode: StrategyNode
 {
-    let node: StringSplitNode
-    @State private var splitMode: StringSplitMode
-
-    init(node: StringSplitNode)
-    {
-        self.node = node
-        _splitMode = State(initialValue: node.splitMode)
-    }
-
-    var body: some View
-    {
-        VStack(alignment: .leading)
-        {
-            Picker("Split Mode", selection: $splitMode)
-            {
-                ForEach(StringSplitMode.allCases, id: \.self)
-                {
-                    splitMode in
-                    Text(splitMode.rawValue).tag(splitMode)
-                }
-            }
-            .pickerStyle(.menu)
-            .controlSize(.small)
-            .onChange(of: splitMode)
-            {
-                _, newSplitMode in
-                node.splitMode = newSplitMode
-            }
-
-            Text(splitMode.description)
-                .foregroundStyle(.secondary)
-        }
-    }
-}
-
-public class StringSplitNode: Node {
     override public class var name: String { "String Split" }
     override public class var nodeType: Node.NodeType { .Parameter(parameterType: .String) }
     override public class var nodeExecutionMode: Node.ExecutionMode { .Processor }
     override public class var nodeTimeMode: Node.TimeMode { .None }
-    override public class var nodeDescription: String { "Split a String into an Array of Strings using an exact separator, whitespace, commas, or lines. Inverse of String Join." }
+    override public class var nodeDescription: String { "Split a String into an Array of Strings. Mode (in Settings): a Custom separator, or commas, whitespace, or lines. Inverse of String Join." }
 
-    // MARK: - Settings
+    override public class var strategyOptions: [any NodeStrategyOption] { StringSplitMode.allCases }
 
-    public fileprivate(set) var splitMode: StringSplitMode
+    // Title leads with the active mode (StrategyNode default), e.g. "Newline String Split".
+
+    /// The active mode, or nil if the serialized strategy names no known mode.
+    public var splitMode: StringSplitMode? { strategyOption() }
+
+    // Settings pane: the strategy picker plus usage guidance for the selected mode.
+    override public var settingsSize: SettingsViewSize { .Small }
+
+    override public func settingsView() -> AnyView
     {
-        didSet
+        AnyView(StrategyGuidanceView(model: strategySettingsModel) { StringSplitMode(rawValue: $0)?.usageGuidance ?? "" })
+    }
+
+    // Ports
+    override public class func registerPorts(context: Context) -> [(name: String, port: Port)] {
+        let ports = super.registerPorts(context: context)
+
+        return ports + [
+            ("inputPort", ParameterPort(parameter: StringParameter("String", "", .inputfield, "Input string to split"))),
+            ("outputPort", NodePort<ContiguousArray<String>>(name: "Strings", kind: .Outlet, description: "Array of string components")),
+        ]
+    }
+
+    // Port proxies
+    public var inputPort: ParameterPort<String> { port(named: "inputPort") }
+    public var outputPort: NodePort<ContiguousArray<String>> { port(named: "outputPort") }
+    /// Present only in Custom mode.
+    public var inputSeparator: ParameterPort<String>? { findPort(named: "inputSeparator") }
+
+    /// The Separator inlet belongs to Custom alone; the other modes carry their
+    /// separator in the mode itself.
+    override public func rebuildPorts(forStrategy strategy: String)
+    {
+        let wantsSeparator = strategy == StringSplitMode.custom.rawValue
+        let existingSeparator: ParameterPort<String>? = findPort(named: "inputSeparator")
+
+        switch (wantsSeparator, existingSeparator)
         {
-            guard splitMode != oldValue else { return }
+        case (true, nil):
+            addDynamicPort(
+                ParameterPort(parameter: StringParameter("Separator", ", ", .inputfield, #"Separator string to split on. Supports \n, \r, \t, and \\ escape sequences"#)),
+                name: "inputSeparator"
+            )
+        case (false, let separatorPort?):
+            removePort(separatorPort)
+        default:
+            break
+        }
+
+        // The String inlet survives a mode change, so nothing else would mark
+        // this node dirty — re-split what's already there the new way.
+        if let inputPort: ParameterPort<String> = findPort(named: "inputPort")
+        {
             inputPort.valueDidChange = true
             markDirty()
         }
     }
 
-    private enum CodingKeys: String, CodingKey
-    {
-        case splitMode
-    }
-
-    public required init(context: Context)
-    {
-        splitMode = .exactSeparator
-        super.init(context: context)
-    }
-
-    public init(context: Context, splitMode: StringSplitMode)
-    {
-        self.splitMode = splitMode
-        super.init(context: context)
-    }
-
-    public required init(from decoder: any Decoder) throws
-    {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        splitMode = try container.decodeIfPresent(StringSplitMode.self, forKey: .splitMode)
-            ?? .exactSeparator
-        try super.init(from: decoder)
-    }
-
-    public override func encode(to encoder: any Encoder) throws
-    {
-        try super.encode(to: encoder)
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(splitMode, forKey: .splitMode)
-    }
-
-    override public func providesSettingsView() -> Bool { true }
-
-    override public var settingsSize: SettingsViewSize { .Small }
-
-    override public func settingsView() -> AnyView
-    {
-        AnyView(StringSplitSettingsView(node: self))
-    }
-    
-    // Ports
-    override public class func registerPorts(context: Context) -> [(name: String, port: Port)] {
-        let ports = super.registerPorts(context: context)
-        
-        return ports + [
-            ("inputPort", ParameterPort(parameter: StringParameter("String", "", .inputfield, "Input string to split"))),
-            ("inputSeparator", ParameterPort(parameter: StringParameter("Separator", ", ", .inputfield, #"Separator string to split on. Supports \n, \r, \t, and \\ escape sequences"#))),
-            ("outputPort", NodePort<ContiguousArray<String>>(name: "Strings", kind: .Outlet, description: "Array of string components")),
-        ]
-    }
-    
-    // Port proxies
-    public var inputPort: ParameterPort<String> { port(named: "inputPort") }
-    public var inputSeparator: ParameterPort<String> { port(named: "inputSeparator") }
-    public var outputPort: NodePort<ContiguousArray<String>> { port(named: "outputPort") }
-
     override public func respondToPull(requestedOutputPort: Port?) -> PullResponse
     {
-        switch splitMode
-        {
-        case .exactSeparator:
-            return .evaluate(pulling: [inputPort, inputSeparator])
-        case .words, .commas, .lines:
-            return .evaluate(pulling: [inputPort])
-        }
+        guard let inputSeparator else { return .evaluate(pulling: [inputPort]) }
+        return .evaluate(pulling: [inputPort, inputSeparator])
     }
-    
+
     override public func execute(renderer:GraphRenderer,
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
     throws
     {
-        let separatorDidChange = splitMode == .exactSeparator && inputSeparator.valueDidChange
+        guard let splitMode else { return }
+
+        let separatorDidChange = inputSeparator?.valueDidChange ?? false
         guard inputPort.valueDidChange || separatorDidChange,
               let string = inputPort.value else
         {
@@ -169,9 +129,9 @@ public class StringSplitNode: Node {
         }
 
         let separator: String
-        if splitMode == .exactSeparator
+        if splitMode == .custom
         {
-            guard let inputSeparatorValue = inputSeparator.value else { return }
+            guard let inputSeparatorValue = inputSeparator?.value else { return }
             separator = inputSeparatorValue
         }
         else
@@ -185,20 +145,20 @@ public class StringSplitNode: Node {
     static func split(
         _ string: String,
         separator: String,
-        mode: StringSplitMode = .exactSeparator
+        mode: StringSplitMode = .custom
     ) -> ContiguousArray<String>
     {
         switch mode
         {
-        case .exactSeparator:
+        case .custom:
             return ContiguousArray(
                 string.components(separatedBy: decodedSeparator(separator))
             )
-        case .words:
-            return ContiguousArray(string.split(whereSeparator: \.isWhitespace).map(String.init))
-        case .commas:
+        case .comma:
             return splitAndTrim(string.components(separatedBy: ","))
-        case .lines:
+        case .space:
+            return ContiguousArray(string.split(whereSeparator: \.isWhitespace).map(String.init))
+        case .newline:
             return splitAndTrim(string.components(separatedBy: .newlines))
         }
     }

--- a/Fabric/Nodes/Parameters/String/StringSplitNode.swift
+++ b/Fabric/Nodes/Parameters/String/StringSplitNode.swift
@@ -54,6 +54,50 @@ public class StringSplitNode: StrategyNode
     /// The active mode, or nil if the serialized strategy names no known mode.
     public var splitMode: StringSplitMode? { strategyOption() }
 
+    /// The separator Custom mode uses, kept while another mode is selected.
+    /// Switching mode tears the inlet down — the wire goes with it, as it does
+    /// for every strategy node — but what the user typed is theirs, so it is
+    /// parked here and seeds the inlet when Custom comes back.
+    public private(set) var customSeparator: String = ", "
+
+    private enum CodingKeys: String, CodingKey
+    {
+        case customSeparator
+    }
+
+    public required init(context: Context)
+    {
+        super.init(context: context)
+    }
+
+    // Declaring the two above stops the strategy initializers being inherited;
+    // overriding this one brings them, and StrategyNode's typed convenience
+    // initializer, back.
+    public override init(context: Context, initialStrategy: String)
+    {
+        super.init(context: context, initialStrategy: initialStrategy)
+    }
+
+    public required init(from decoder: any Decoder) throws
+    {
+        // Decoded before super.init, which rebuilds the ports: in Custom mode the
+        // inlet is restored from the document, in any other mode this is all that
+        // is left of the separator.
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        customSeparator = try container.decodeIfPresent(String.self, forKey: .customSeparator) ?? ", "
+
+        try super.init(from: decoder)
+    }
+
+    public override func encode(to encoder: any Encoder) throws
+    {
+        try super.encode(to: encoder)
+
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        // The live inlet is the truth while Custom is selected.
+        try container.encode(inputSeparator?.value ?? customSeparator, forKey: .customSeparator)
+    }
+
     // Settings pane: the strategy picker plus usage guidance for the selected mode.
     override public var settingsSize: SettingsViewSize { .Small }
 
@@ -89,10 +133,11 @@ public class StringSplitNode: StrategyNode
         {
         case (true, nil):
             addDynamicPort(
-                ParameterPort(parameter: StringParameter("Separator", ", ", .inputfield, #"Separator string to split on. Supports \n, \r, \t, and \\ escape sequences"#)),
+                ParameterPort(parameter: StringParameter("Separator", customSeparator, .inputfield, #"Separator string to split on. Supports \n, \r, \t, and \\ escape sequences"#)),
                 name: "inputSeparator"
             )
         case (false, let separatorPort?):
+            customSeparator = separatorPort.value ?? customSeparator
             removePort(separatorPort)
         default:
             break

--- a/Fabric/Nodes/Parameters/String/StringSplitNode.swift
+++ b/Fabric/Nodes/Parameters/String/StringSplitNode.swift
@@ -152,7 +152,7 @@ public class StringSplitNode: StrategyNode
         {
         case .custom:
             return ContiguousArray(
-                string.components(separatedBy: decodedSeparator(separator))
+                string.components(separatedBy: decodeEscapeSequences(separator))
             )
         case .comma:
             return splitAndTrim(string.components(separatedBy: ","))
@@ -173,48 +173,5 @@ public class StringSplitNode: StrategyNode
                 return trimmedValue.isEmpty ? nil : trimmedValue
             }
         )
-    }
-
-    static func decodedSeparator(_ separator: String) -> String
-    {
-        var decodedSeparator = ""
-        var currentIndex = separator.startIndex
-
-        while currentIndex < separator.endIndex
-        {
-            let character = separator[currentIndex]
-            guard character == "\\" else
-            {
-                decodedSeparator.append(character)
-                currentIndex = separator.index(after: currentIndex)
-                continue
-            }
-
-            let escapedCharacterIndex = separator.index(after: currentIndex)
-            guard escapedCharacterIndex < separator.endIndex else
-            {
-                decodedSeparator.append(character)
-                break
-            }
-
-            switch separator[escapedCharacterIndex]
-            {
-            case "n":
-                decodedSeparator.append("\n")
-            case "r":
-                decodedSeparator.append("\r")
-            case "t":
-                decodedSeparator.append("\t")
-            case "\\":
-                decodedSeparator.append("\\")
-            default:
-                decodedSeparator.append(character)
-                decodedSeparator.append(separator[escapedCharacterIndex])
-            }
-
-            currentIndex = separator.index(after: escapedCharacterIndex)
-        }
-
-        return decodedSeparator
     }
 }

--- a/Fabric/Nodes/Parameters/String/StringSplitNode.swift
+++ b/Fabric/Nodes/Parameters/String/StringSplitNode.swift
@@ -6,13 +6,127 @@
 import Foundation
 import Satin
 import Metal
+import SwiftUI
+
+public enum StringSplitMode: String, Codable, CaseIterable, Sendable
+{
+    case exactSeparator = "Exact Separator"
+    case words = "Words"
+    case commas = "Commas"
+    case lines = "Lines"
+
+    var description: String
+    {
+        switch self
+        {
+        case .exactSeparator:
+            "Splits on the exact value supplied by the Separator inlet."
+        case .words:
+            "Splits on any whitespace."
+        case .commas:
+            "Splits on commas, trims whitespace, and removes empty values."
+        case .lines:
+            "Splits on recognized newline characters, trims whitespace, and removes empty values."
+        }
+    }
+}
+
+private struct StringSplitSettingsView: View
+{
+    let node: StringSplitNode
+    @State private var splitMode: StringSplitMode
+
+    init(node: StringSplitNode)
+    {
+        self.node = node
+        _splitMode = State(initialValue: node.splitMode)
+    }
+
+    var body: some View
+    {
+        VStack(alignment: .leading)
+        {
+            Picker("Split Mode", selection: $splitMode)
+            {
+                ForEach(StringSplitMode.allCases, id: \.self)
+                {
+                    splitMode in
+                    Text(splitMode.rawValue).tag(splitMode)
+                }
+            }
+            .pickerStyle(.menu)
+            .controlSize(.small)
+            .onChange(of: splitMode)
+            {
+                _, newSplitMode in
+                node.splitMode = newSplitMode
+            }
+
+            Text(splitMode.description)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
 
 public class StringSplitNode: Node {
     override public class var name: String { "String Split" }
     override public class var nodeType: Node.NodeType { .Parameter(parameterType: .String) }
     override public class var nodeExecutionMode: Node.ExecutionMode { .Processor }
     override public class var nodeTimeMode: Node.TimeMode { .None }
-    override public class var nodeDescription: String { "Split a String into an Array of Strings using a separator. Inverse of String Join." }
+    override public class var nodeDescription: String { "Split a String into an Array of Strings using an exact separator, whitespace, commas, or lines. Inverse of String Join." }
+
+    // MARK: - Settings
+
+    public fileprivate(set) var splitMode: StringSplitMode
+    {
+        didSet
+        {
+            guard splitMode != oldValue else { return }
+            inputPort.valueDidChange = true
+            markDirty()
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey
+    {
+        case splitMode
+    }
+
+    public required init(context: Context)
+    {
+        splitMode = .exactSeparator
+        super.init(context: context)
+    }
+
+    public init(context: Context, splitMode: StringSplitMode)
+    {
+        self.splitMode = splitMode
+        super.init(context: context)
+    }
+
+    public required init(from decoder: any Decoder) throws
+    {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        splitMode = try container.decodeIfPresent(StringSplitMode.self, forKey: .splitMode)
+            ?? .exactSeparator
+        try super.init(from: decoder)
+    }
+
+    public override func encode(to encoder: any Encoder) throws
+    {
+        try super.encode(to: encoder)
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(splitMode, forKey: .splitMode)
+    }
+
+    override public func providesSettingsView() -> Bool { true }
+
+    override public var settingsSize: SettingsViewSize { .Small }
+
+    override public func settingsView() -> AnyView
+    {
+        AnyView(StringSplitSettingsView(node: self))
+    }
     
     // Ports
     override public class func registerPorts(context: Context) -> [(name: String, port: Port)] {
@@ -29,22 +143,75 @@ public class StringSplitNode: Node {
     public var inputPort: ParameterPort<String> { port(named: "inputPort") }
     public var inputSeparator: ParameterPort<String> { port(named: "inputSeparator") }
     public var outputPort: NodePort<ContiguousArray<String>> { port(named: "outputPort") }
+
+    override public func respondToPull(requestedOutputPort: Port?) -> PullResponse
+    {
+        switch splitMode
+        {
+        case .exactSeparator:
+            return .evaluate(pulling: [inputPort, inputSeparator])
+        case .words, .commas, .lines:
+            return .evaluate(pulling: [inputPort])
+        }
+    }
     
     override public func execute(renderer:GraphRenderer,
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
     {
-        if inputPort.valueDidChange || inputSeparator.valueDidChange,
-           let string = inputPort.value,
-           let separator = inputSeparator.value {
-            outputPort.send(Self.split(string, separator: separator))
+        let separatorDidChange = splitMode == .exactSeparator && inputSeparator.valueDidChange
+        guard inputPort.valueDidChange || separatorDidChange,
+              let string = inputPort.value else
+        {
+            return
+        }
+
+        let separator: String
+        if splitMode == .exactSeparator
+        {
+            guard let inputSeparatorValue = inputSeparator.value else { return }
+            separator = inputSeparatorValue
+        }
+        else
+        {
+            separator = ""
+        }
+
+        outputPort.send(Self.split(string, separator: separator, mode: splitMode))
+    }
+
+    static func split(
+        _ string: String,
+        separator: String,
+        mode: StringSplitMode = .exactSeparator
+    ) -> ContiguousArray<String>
+    {
+        switch mode
+        {
+        case .exactSeparator:
+            return ContiguousArray(
+                string.components(separatedBy: decodedSeparator(separator))
+            )
+        case .words:
+            return ContiguousArray(string.split(whereSeparator: \.isWhitespace).map(String.init))
+        case .commas:
+            return splitAndTrim(string.components(separatedBy: ","))
+        case .lines:
+            return splitAndTrim(string.components(separatedBy: .newlines))
         }
     }
 
-    static func split(_ string: String, separator: String) -> ContiguousArray<String>
+    private static func splitAndTrim(_ values: [String]) -> ContiguousArray<String>
     {
-        ContiguousArray(string.components(separatedBy: decodedSeparator(separator)))
+        ContiguousArray(
+            values.compactMap
+            {
+                value in
+                let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
+                return trimmedValue.isEmpty ? nil : trimmedValue
+            }
+        )
     }
 
     static func decodedSeparator(_ separator: String) -> String

--- a/Tests/StringEscapeSequenceTests.swift
+++ b/Tests/StringEscapeSequenceTests.swift
@@ -28,6 +28,28 @@ struct StringEscapeSequenceTests
         #expect(decodeEscapeSequences(#"ends\"#) == #"ends\"#)
     }
 
+    @Test("Braces decode only where they are syntax")
+    func bracesAreOptedInto()
+    {
+        #expect(decodeEscapeSequences(#"\{n\}"#) == #"\{n\}"#)
+        #expect(decodeEscapeSequences(#"\{n\}"#, including: [.invisibleCharacters, .braces]) == "{n}")
+    }
+
+    @Test("An unwanted sequence is left as typed")
+    func unwantedSequencesRemainLiteral()
+    {
+        #expect(decodeEscapeSequences(#"\n"#, including: []) == #"\n"#)
+        #expect(decodeEscapeSequences(#"\{"#, including: .braces) == "{")
+        #expect(decodeEscapeSequences(#"\t"#, including: .braces) == #"\t"#)
+    }
+
+    @Test("The backslash escape holds regardless of the sequences wanted")
+    func backslashIsAlwaysDecoded()
+    {
+        #expect(decodeEscapeSequences(#"\\"#, including: []) == "\\")
+        #expect(decodeEscapeSequences(#"\\n"#, including: []) == #"\n"#)
+    }
+
     @Test("Text without escapes passes through untouched")
     func plainTextIsUntouched()
     {

--- a/Tests/StringEscapeSequenceTests.swift
+++ b/Tests/StringEscapeSequenceTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Testing
+@testable import Fabric
+
+@Suite("String Escape Sequences")
+struct StringEscapeSequenceTests
+{
+    @Test("Invisible characters are expressible")
+    func invisibleCharacters()
+    {
+        #expect(decodeEscapeSequences(#"\n"#) == "\n")
+        #expect(decodeEscapeSequences(#"\r"#) == "\r")
+        #expect(decodeEscapeSequences(#"\t"#) == "\t")
+        #expect(decodeEscapeSequences(#"\r\n"#) == "\r\n")
+    }
+
+    @Test("Escaped backslash yields a literal backslash, and shields the next character")
+    func escapedBackslash()
+    {
+        #expect(decodeEscapeSequences(#"\\"#) == "\\")
+        #expect(decodeEscapeSequences(#"\\n"#) == #"\n"#)
+    }
+
+    @Test("Unknown and trailing escapes are preserved literally")
+    func unknownEscapesRemainLiteral()
+    {
+        #expect(decodeEscapeSequences(#"\q"#) == #"\q"#)
+        #expect(decodeEscapeSequences(#"ends\"#) == #"ends\"#)
+    }
+
+    @Test("Text without escapes passes through untouched")
+    func plainTextIsUntouched()
+    {
+        #expect(decodeEscapeSequences(", ") == ", ")
+        #expect(decodeEscapeSequences("") == "")
+    }
+
+    @Test("String Join reverses a String Split on the same separator")
+    func splitAndJoinRoundTrip() throws
+    {
+        guard let harness = GraphExecutionTestHarness(renderWidth: 64, renderHeight: 64) else { return }
+
+        let separator = #"\n"#
+        let input = "first\nsecond\nthird"
+
+        let join = StringJoinNode(context: harness.context)
+        join.inputPort.value = StringSplitNode.split(input, separator: separator, mode: .custom)
+        join.separatorPort.value = separator
+
+        try harness.execute(join)
+
+        #expect(join.outputPort.value == input)
+    }
+}

--- a/Tests/StringFormatStringTests.swift
+++ b/Tests/StringFormatStringTests.swift
@@ -126,6 +126,41 @@ struct StringFormatStringTests
         #expect(formatter.outputString.value == "{b} second")
     }
 
+    @Test("A format string of pure literal text still emits")
+    func formatterEmitsWithoutPlaceholders() throws
+    {
+        guard let harness = GraphExecutionTestHarness(renderWidth: 64, renderHeight: 64) else { return }
+
+        let formatter = StringFormatterNode(context: harness.context, formatString: #"Line one\nLine two"#)
+
+        try harness.execute(formatter)
+
+        #expect(formatter.outputString.value == "Line one\nLine two")
+    }
+
+    @Test("Editing the format string re-emits from unchanged inputs")
+    func formatterReEmitsAfterFormatEdit() throws
+    {
+        guard let harness = GraphExecutionTestHarness(renderWidth: 64, renderHeight: 64) else { return }
+
+        let formatter = StringFormatterNode(context: harness.context, formatString: "Hello {name}")
+
+        let name = try #require(formatter.findPort(named: "name", as: ParameterPort<String>.self))
+        name.value = "Bob"
+
+        try harness.execute(formatter)
+        #expect(formatter.outputString.value == "Hello Bob")
+
+        // What a pass through the renderer would leave behind.
+        formatter.markClean()
+
+        formatter.setFormatString("Goodbye {name}")
+        #expect(formatter.isDirty)
+
+        try harness.execute(formatter)
+        #expect(formatter.outputString.value == "Goodbye Bob")
+    }
+
     // MARK: - String Scanner
 
     @Test("Scanner matches across an escaped newline")
@@ -176,6 +211,33 @@ struct StringFormatStringTests
 
         #expect(scanner.outputMatched.value == true)
         #expect(number.value == 7)
+    }
+
+    @Test("Editing the format string re-scans the unchanged input")
+    func scannerReScansAfterFormatEdit() throws
+    {
+        guard let harness = GraphExecutionTestHarness(renderWidth: 64, renderHeight: 64) else { return }
+
+        let scanner = StringScannerNode(context: harness.context, formatString: "Frame {n:d}")
+        scanner.inputString.value = "Frame 12 at 1.5s"
+
+        try harness.execute(scanner)
+        #expect(scanner.outputMatched.value == false)
+
+        // What a pass through the renderer would leave behind.
+        scanner.markClean()
+
+        scanner.setFormatString("Frame {n:d} at {t:f}s")
+        #expect(scanner.isDirty)
+
+        try harness.execute(scanner)
+
+        let frameNumber = try #require(scanner.findPort(named: "n", as: NodePort<Int>.self))
+        let time = try #require(scanner.findPort(named: "t", as: NodePort<Float>.self))
+
+        #expect(scanner.outputMatched.value == true)
+        #expect(frameNumber.value == 12)
+        #expect(time.value == 1.5)
     }
 
     @Test("A repeated name does not shift the captures that follow it")

--- a/Tests/StringFormatStringTests.swift
+++ b/Tests/StringFormatStringTests.swift
@@ -72,6 +72,7 @@ struct StringFormatStringTests
         let parsed = parseFormatString("{n:d} {n:s}")
 
         #expect(parsed.placeholders == [FormatPlaceholder(name: "n", formatSpecifier: "d")])
+        #expect(parsed.placeholder(named: "n") == FormatPlaceholder(name: "n", formatSpecifier: "d"))
         #expect(parsed.tokens.count == 3)
     }
 

--- a/Tests/StringFormatStringTests.swift
+++ b/Tests/StringFormatStringTests.swift
@@ -1,0 +1,196 @@
+import Foundation
+import Testing
+@testable import Fabric
+
+@Suite("String Format Strings")
+struct StringFormatStringTests
+{
+    // MARK: - Parsing
+
+    @Test("Literal text and placeholders are parsed in source order")
+    func literalAndPlaceholderOrder()
+    {
+        let parsed = parseFormatString("Frame {n:d} at {t:f}s")
+
+        #expect(parsed.tokens == [
+            .literal("Frame "),
+            .placeholder(FormatPlaceholder(name: "n", formatSpecifier: "d")),
+            .literal(" at "),
+            .placeholder(FormatPlaceholder(name: "t", formatSpecifier: "f")),
+            .literal("s"),
+        ])
+    }
+
+    @Test("Literals decode the shared escape sequences")
+    func literalsDecodeEscapes()
+    {
+        let parsed = parseFormatString(#"{a}\n{b}\tend"#)
+
+        #expect(parsed.tokens == [
+            .placeholder(FormatPlaceholder(name: "a", formatSpecifier: nil)),
+            .literal("\n"),
+            .placeholder(FormatPlaceholder(name: "b", formatSpecifier: nil)),
+            .literal("\tend"),
+        ])
+    }
+
+    @Test("Escaped braces are literal text, not a placeholder")
+    func escapedBracesAreLiteral()
+    {
+        let parsed = parseFormatString(#"\{n:d\} is {n:d}"#)
+
+        #expect(parsed.tokens == [
+            .literal("{n:d} is "),
+            .placeholder(FormatPlaceholder(name: "n", formatSpecifier: "d")),
+        ])
+        #expect(parsed.placeholders.map(\.name) == ["n"])
+    }
+
+    @Test("An escaped backslash still leaves the next brace as a placeholder")
+    func escapedBackslashBeforePlaceholder()
+    {
+        let parsed = parseFormatString(#"\\{n}"#)
+
+        #expect(parsed.tokens == [
+            .literal("\\"),
+            .placeholder(FormatPlaceholder(name: "n", formatSpecifier: nil)),
+        ])
+    }
+
+    @Test("Malformed braces stay literal")
+    func malformedBracesStayLiteral()
+    {
+        #expect(parseFormatString("{}").tokens == [.literal("{}")])
+        #expect(parseFormatString("{ n }").tokens == [.literal("{ n }")])
+        #expect(parseFormatString("{n").tokens == [.literal("{n")])
+        #expect(parseFormatString("{n:}").tokens == [.literal("{n:}")])
+    }
+
+    @Test("A repeated name yields one placeholder, keeping its first specifier")
+    func repeatedNameKeepsFirstSpecifier()
+    {
+        let parsed = parseFormatString("{n:d} {n:s}")
+
+        #expect(parsed.placeholders == [FormatPlaceholder(name: "n", formatSpecifier: "d")])
+        #expect(parsed.tokens.count == 3)
+    }
+
+    // MARK: - String Formatter
+
+    @Test("Formatter writes escape sequences into its output")
+    func formatterDecodesEscapes() throws
+    {
+        guard let harness = GraphExecutionTestHarness(renderWidth: 64, renderHeight: 64) else { return }
+
+        let formatter = StringFormatterNode(context: harness.context, formatString: #"{a}\n{b}"#)
+
+        let inputA = try #require(formatter.findPort(named: "a", as: ParameterPort<String>.self))
+        let inputB = try #require(formatter.findPort(named: "b", as: ParameterPort<String>.self))
+        inputA.value = "first"
+        inputB.value = "second"
+
+        try harness.execute(formatter)
+
+        #expect(formatter.outputString.value == "first\nsecond")
+    }
+
+    @Test("Formatter emits literal braces for an escaped placeholder")
+    func formatterEmitsLiteralBraces() throws
+    {
+        guard let harness = GraphExecutionTestHarness(renderWidth: 64, renderHeight: 64) else { return }
+
+        let formatter = StringFormatterNode(context: harness.context, formatString: #"\{a\} {a}"#)
+
+        let inputA = try #require(formatter.findPort(named: "a", as: ParameterPort<String>.self))
+        inputA.value = "value"
+
+        try harness.execute(formatter)
+
+        #expect(formatter.outputString.value == "{a} value")
+    }
+
+    @Test("A value that looks like a placeholder is not substituted into")
+    func placeholderShapedValueIsLeftAlone() throws
+    {
+        guard let harness = GraphExecutionTestHarness(renderWidth: 64, renderHeight: 64) else { return }
+
+        let formatter = StringFormatterNode(context: harness.context, formatString: "{a} {b}")
+
+        let inputA = try #require(formatter.findPort(named: "a", as: ParameterPort<String>.self))
+        let inputB = try #require(formatter.findPort(named: "b", as: ParameterPort<String>.self))
+        inputA.value = "{b}"
+        inputB.value = "second"
+
+        try harness.execute(formatter)
+
+        #expect(formatter.outputString.value == "{b} second")
+    }
+
+    // MARK: - String Scanner
+
+    @Test("Scanner matches across an escaped newline")
+    func scannerMatchesMultipleLines() throws
+    {
+        guard let harness = GraphExecutionTestHarness(renderWidth: 64, renderHeight: 64) else { return }
+
+        let scanner = StringScannerNode(context: harness.context, formatString: #"Frame {n:d}\nTime {t:f}"#)
+        scanner.inputString.value = "Frame 12\nTime 1.5"
+
+        try harness.execute(scanner)
+
+        let frameNumber = try #require(scanner.findPort(named: "n", as: NodePort<Int>.self))
+        let time = try #require(scanner.findPort(named: "t", as: NodePort<Float>.self))
+
+        #expect(scanner.outputMatched.value == true)
+        #expect(frameNumber.value == 12)
+        #expect(time.value == 1.5)
+    }
+
+    @Test("A String capture spans newlines")
+    func scannerCaptureSpansNewlines() throws
+    {
+        guard let harness = GraphExecutionTestHarness(renderWidth: 64, renderHeight: 64) else { return }
+
+        let scanner = StringScannerNode(context: harness.context, formatString: "Body: {body}")
+        scanner.inputString.value = "Body: first\nsecond"
+
+        try harness.execute(scanner)
+
+        let body = try #require(scanner.findPort(named: "body", as: NodePort<String>.self))
+
+        #expect(scanner.outputMatched.value == true)
+        #expect(body.value == "first\nsecond")
+    }
+
+    @Test("Scanner treats an escaped brace as literal input text")
+    func scannerMatchesLiteralBraces() throws
+    {
+        guard let harness = GraphExecutionTestHarness(renderWidth: 64, renderHeight: 64) else { return }
+
+        let scanner = StringScannerNode(context: harness.context, formatString: #"\{{n:d}\}"#)
+        scanner.inputString.value = "{7}"
+
+        try harness.execute(scanner)
+
+        let number = try #require(scanner.findPort(named: "n", as: NodePort<Int>.self))
+
+        #expect(scanner.outputMatched.value == true)
+        #expect(number.value == 7)
+    }
+
+    @Test("Regex metacharacters in literal text match themselves")
+    func scannerEscapesRegexMetacharacters() throws
+    {
+        guard let harness = GraphExecutionTestHarness(renderWidth: 64, renderHeight: 64) else { return }
+
+        let scanner = StringScannerNode(context: harness.context, formatString: "({n:d})")
+        scanner.inputString.value = "(7)"
+
+        try harness.execute(scanner)
+
+        let number = try #require(scanner.findPort(named: "n", as: NodePort<Int>.self))
+
+        #expect(scanner.outputMatched.value == true)
+        #expect(number.value == 7)
+    }
+}

--- a/Tests/StringFormatStringTests.swift
+++ b/Tests/StringFormatStringTests.swift
@@ -178,6 +178,25 @@ struct StringFormatStringTests
         #expect(number.value == 7)
     }
 
+    @Test("A repeated name does not shift the captures that follow it")
+    func scannerRepeatedNameKeepsLaterCapturesAligned() throws
+    {
+        guard let harness = GraphExecutionTestHarness(renderWidth: 64, renderHeight: 64) else { return }
+
+        let scanner = StringScannerNode(context: harness.context, formatString: "{a:d} {a:d} {b:d}")
+        scanner.inputString.value = "1 2 3"
+
+        try harness.execute(scanner)
+
+        let a = try #require(scanner.findPort(named: "a", as: NodePort<Int>.self))
+        let b = try #require(scanner.findPort(named: "b", as: NodePort<Int>.self))
+
+        #expect(scanner.outputMatched.value == true)
+        // Each occurrence captures independently; the port keeps the last.
+        #expect(a.value == 2)
+        #expect(b.value == 3)
+    }
+
     @Test("Regex metacharacters in literal text match themselves")
     func scannerEscapesRegexMetacharacters() throws
     {

--- a/Tests/StringFormatStringTests.swift
+++ b/Tests/StringFormatStringTests.swift
@@ -226,6 +226,27 @@ struct StringFormatStringTests
         #expect(formatter.outputString.value == "Goodbye Bob")
     }
 
+    @Test("A saved format string and its ports survive a round trip")
+    func formatStringSurvivesSerialization() throws
+    {
+        guard let harness = GraphExecutionTestHarness(renderWidth: 64, renderHeight: 64) else { return }
+
+        let graph = Graph(context: harness.context)
+        let formatter = StringFormatterNode(context: harness.context, formatString: "Frame {n:d} of {total:d}")
+        graph.addNode(formatter)
+
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        decoder.context = DecoderContext(documentContext: harness.context)
+
+        let decodedGraph = try decoder.decode(Graph.self, from: try encoder.encode(graph))
+        let decodedFormatter = try #require(decodedGraph.nodes.compactMap { $0 as? StringFormatterNode }.first)
+
+        #expect(decodedFormatter.formatString == "Frame {n:d} of {total:d}")
+        #expect(decodedFormatter.findPort(named: "n", as: ParameterPort<Int>.self) != nil)
+        #expect(decodedFormatter.findPort(named: "total", as: ParameterPort<Int>.self) != nil)
+    }
+
     // MARK: - String Scanner
 
     @Test("Scanner matches across an escaped newline")

--- a/Tests/StringFormatStringTests.swift
+++ b/Tests/StringFormatStringTests.swift
@@ -75,6 +75,40 @@ struct StringFormatStringTests
         #expect(parsed.tokens.count == 3)
     }
 
+    // MARK: - Specifiers
+
+    @Test("Well-formed specifiers keep their flags, width and precision")
+    func wellFormedSpecifiers()
+    {
+        #expect(FormatSpecifier("d") == .integer(printfFormat: "%ld"))
+        #expect(FormatSpecifier("i") == .integer(printfFormat: "%ld"))
+        #expect(FormatSpecifier("5d") == .integer(printfFormat: "%5ld"))
+        #expect(FormatSpecifier("f") == .floatingPoint(printfFormat: "%f"))
+        #expect(FormatSpecifier(".2f") == .floatingPoint(printfFormat: "%.2f"))
+        #expect(FormatSpecifier("-8.3e") == .floatingPoint(printfFormat: "%-8.3e"))
+    }
+
+    @Test("A specifier holding more than one conversion is not honoured")
+    func multipleConversionsAreRefused()
+    {
+        // Each of these would otherwise reach String(format:) with one argument
+        // and read a vararg that was never supplied.
+        #expect(FormatSpecifier("f%f") == .string)
+        #expect(FormatSpecifier("f%s") == .string)
+        #expect(FormatSpecifier(".2f%@") == .string)
+        #expect(FormatSpecifier("%s") == .string)
+    }
+
+    @Test("Unreadable specifiers fall back to plain string conversion")
+    func unreadableSpecifiers()
+    {
+        #expect(FormatSpecifier(nil) == .string)
+        #expect(FormatSpecifier("s") == .string)
+        #expect(FormatSpecifier("b") == .bool)
+        #expect(FormatSpecifier("zz") == .string)
+        #expect(FormatSpecifier("2") == .string)
+    }
+
     // MARK: - String Formatter
 
     @Test("Formatter writes escape sequences into its output")
@@ -124,6 +158,36 @@ struct StringFormatStringTests
         try harness.execute(formatter)
 
         #expect(formatter.outputString.value == "{b} second")
+    }
+
+    @Test("Int placeholders render their full 64-bit range")
+    func formatterRendersLargeIntegers() throws
+    {
+        guard let harness = GraphExecutionTestHarness(renderWidth: 64, renderHeight: 64) else { return }
+
+        let formatter = StringFormatterNode(context: harness.context, formatString: "{ms:d}")
+
+        let milliseconds = try #require(formatter.findPort(named: "ms", as: ParameterPort<Int>.self))
+        milliseconds.value = 5_000_000_000
+
+        try harness.execute(formatter)
+
+        #expect(formatter.outputString.value == "5000000000")
+    }
+
+    @Test("Float placeholders keep their width and precision")
+    func formatterRendersFloatPrecision() throws
+    {
+        guard let harness = GraphExecutionTestHarness(renderWidth: 64, renderHeight: 64) else { return }
+
+        let formatter = StringFormatterNode(context: harness.context, formatString: "[{x:8.2f}]")
+
+        let x = try #require(formatter.findPort(named: "x", as: ParameterPort<Float>.self))
+        x.value = 3.14159
+
+        try harness.execute(formatter)
+
+        #expect(formatter.outputString.value == "[    3.14]")
     }
 
     @Test("A format string of pure literal text still emits")

--- a/Tests/StringSplitNodeTests.swift
+++ b/Tests/StringSplitNodeTests.swift
@@ -107,18 +107,12 @@ struct StringSplitNodeTests
         #expect(result == [" first", " second", "", ""])
     }
 
-    @Test("Escaped tab and backslash separators remain expressible")
-    func escapedTabAndBackslashSeparators()
+    @Test("Custom separator decodes the shared escape sequences")
+    func customSeparatorDecodesEscapes()
     {
-        #expect(StringSplitNode.decodedSeparator(#"\t"#) == "\t")
-        #expect(StringSplitNode.decodedSeparator(#"\\"#) == "\\")
-        #expect(StringSplitNode.decodedSeparator(#"\\n"#) == #"\n"#)
-    }
-
-    @Test("Unknown and trailing escapes are preserved literally")
-    func unknownEscapesRemainLiteral()
-    {
-        #expect(StringSplitNode.decodedSeparator(#"\q"#) == #"\q"#)
-        #expect(StringSplitNode.decodedSeparator(#"ends\"#) == #"ends\"#)
+        // The vocabulary itself is covered by StringEscapeSequenceTests; this
+        // pins that Custom mode runs the separator through it.
+        #expect(StringSplitNode.split("a\tb", separator: #"\t"#) == ["a", "b"])
+        #expect(StringSplitNode.split(#"a\nb"#, separator: #"\\n"#) == ["a", "b"])
     }
 }

--- a/Tests/StringSplitNodeTests.swift
+++ b/Tests/StringSplitNodeTests.swift
@@ -1,9 +1,24 @@
+import Foundation
 import Testing
 @testable import Fabric
 
 @Suite("String Split Node")
 struct StringSplitNodeTests
 {
+    @Test("Split modes retain their user-facing serialized names")
+    func splitModeNames() throws
+    {
+        #expect(
+            StringSplitMode.allCases.map(\.rawValue)
+                == ["Exact Separator", "Words", "Commas", "Lines"]
+        )
+
+        let encodedMode = try JSONEncoder().encode(StringSplitMode.lines)
+        let decodedMode = try JSONDecoder().decode(StringSplitMode.self, from: encodedMode)
+
+        #expect(decodedMode == .lines)
+    }
+
     @Test("Escaped newline separates file contents into lines")
     func escapedNewlineSeparator()
     {
@@ -18,6 +33,54 @@ struct StringSplitNodeTests
         let result = StringSplitNode.split("first\r\nsecond", separator: #"\r\n"#)
 
         #expect(result == ["first", "second"])
+    }
+
+    @Test("Words split on any whitespace and remove empty values")
+    func wordsMode()
+    {
+        let result = StringSplitNode.split(
+            "  first\tsecond\nthird\u{00A0}fourth  ",
+            separator: ", ",
+            mode: .words
+        )
+
+        #expect(result == ["first", "second", "third", "fourth"])
+    }
+
+    @Test("Commas trim whitespace and remove empty values")
+    func commasMode()
+    {
+        let result = StringSplitNode.split(
+            " first, second ,, \nthird, ",
+            separator: ", ",
+            mode: .commas
+        )
+
+        #expect(result == ["first", "second", "third"])
+    }
+
+    @Test("Lines recognize Unicode newlines, trim whitespace, and remove empty values")
+    func linesMode()
+    {
+        let result = StringSplitNode.split(
+            " first\r\nsecond\u{2028} \nthird ",
+            separator: ", ",
+            mode: .lines
+        )
+
+        #expect(result == ["first", "second", "third"])
+    }
+
+    @Test("Exact separator retains empty and untrimmed values")
+    func exactSeparatorModePreservesExistingBehavior()
+    {
+        let result = StringSplitNode.split(
+            " first, second,,",
+            separator: ",",
+            mode: .exactSeparator
+        )
+
+        #expect(result == [" first", " second", "", ""])
     }
 
     @Test("Escaped tab and backslash separators remain expressible")

--- a/Tests/StringSplitNodeTests.swift
+++ b/Tests/StringSplitNodeTests.swift
@@ -43,6 +43,21 @@ struct StringSplitNodeTests
         #expect(node.inputSeparator != nil)
     }
 
+    @Test("A typed separator survives a trip through another mode")
+    func customSeparatorIsParkedAcrossModes() throws
+    {
+        guard let harness = GraphExecutionTestHarness(renderWidth: 64, renderHeight: 64) else { return }
+
+        let node = StringSplitNode(context: harness.context, strategy: StringSplitMode.custom)
+        try #require(node.inputSeparator).value = #"\t"#
+
+        node.strategy = StringSplitMode.comma.rawValue
+        #expect(node.customSeparator == #"\t"#)
+
+        node.strategy = StringSplitMode.custom.rawValue
+        #expect(node.inputSeparator?.value == #"\t"#)
+    }
+
     @Test("Escaped newline separates file contents into lines")
     func escapedNewlineSeparator()
     {

--- a/Tests/StringSplitNodeTests.swift
+++ b/Tests/StringSplitNodeTests.swift
@@ -10,13 +10,37 @@ struct StringSplitNodeTests
     {
         #expect(
             StringSplitMode.allCases.map(\.rawValue)
-                == ["Exact Separator", "Words", "Commas", "Lines"]
+                == ["Custom", "Comma", "Space", "Newline"]
         )
 
-        let encodedMode = try JSONEncoder().encode(StringSplitMode.lines)
-        let decodedMode = try JSONDecoder().decode(StringSplitMode.self, from: encodedMode)
+        #expect(StringSplitNode.strategies == StringSplitMode.allCases.map(\.rawValue))
+        #expect(StringSplitNode.defaultStrategy == StringSplitMode.custom.rawValue)
+    }
 
-        #expect(decodedMode == .lines)
+    @Test("Every split mode explains itself in the Settings pane")
+    func splitModeGuidance()
+    {
+        for mode in StringSplitMode.allCases
+        {
+            #expect(mode.usageGuidance.isEmpty == false)
+        }
+    }
+
+    @Test("Separator inlet exists only in Custom mode")
+    func separatorPortFollowsMode() throws
+    {
+        guard let harness = GraphExecutionTestHarness(renderWidth: 64, renderHeight: 64) else { return }
+
+        let node = StringSplitNode(context: harness.context, strategy: StringSplitMode.custom)
+        #expect(node.splitMode == .custom)
+        #expect(node.inputSeparator != nil)
+
+        node.strategy = StringSplitMode.newline.rawValue
+        #expect(node.splitMode == .newline)
+        #expect(node.inputSeparator == nil)
+
+        node.strategy = StringSplitMode.custom.rawValue
+        #expect(node.inputSeparator != nil)
     }
 
     @Test("Escaped newline separates file contents into lines")
@@ -35,49 +59,49 @@ struct StringSplitNodeTests
         #expect(result == ["first", "second"])
     }
 
-    @Test("Words split on any whitespace and remove empty values")
-    func wordsMode()
+    @Test("Space splits on any whitespace and removes empty values")
+    func spaceMode()
     {
         let result = StringSplitNode.split(
             "  first\tsecond\nthird\u{00A0}fourth  ",
             separator: ", ",
-            mode: .words
+            mode: .space
         )
 
         #expect(result == ["first", "second", "third", "fourth"])
     }
 
-    @Test("Commas trim whitespace and remove empty values")
-    func commasMode()
+    @Test("Comma trims whitespace and removes empty values")
+    func commaMode()
     {
         let result = StringSplitNode.split(
             " first, second ,, \nthird, ",
             separator: ", ",
-            mode: .commas
+            mode: .comma
         )
 
         #expect(result == ["first", "second", "third"])
     }
 
-    @Test("Lines recognize Unicode newlines, trim whitespace, and remove empty values")
-    func linesMode()
+    @Test("Newline recognizes Unicode newlines, trims whitespace, and removes empty values")
+    func newlineMode()
     {
         let result = StringSplitNode.split(
             " first\r\nsecond\u{2028} \nthird ",
             separator: ", ",
-            mode: .lines
+            mode: .newline
         )
 
         #expect(result == ["first", "second", "third"])
     }
 
-    @Test("Exact separator retains empty and untrimmed values")
-    func exactSeparatorModePreservesExistingBehavior()
+    @Test("Custom separator retains empty and untrimmed values")
+    func customModePreservesExistingBehavior()
     {
         let result = StringSplitNode.split(
             " first, second,,",
             separator: ",",
-            mode: .exactSeparator
+            mode: .custom
         )
 
         #expect(result == [" first", " second", "", ""])


### PR DESCRIPTION
Add a serialized Split Mode settings picker with Exact Separator, Words, Commas, and Lines behavior while preserving the existing Separator inlet and legacy default.

Cover Unicode whitespace and newlines, trimming, empty-value removal, and exact-separator compatibility.

<img width="369" height="392" alt="image" src="https://github.com/user-attachments/assets/125986c6-e2cb-419d-be7c-52b2d5434cc0" />

related #297 