### PR TITLE
Feat – Control first execution

### DIFF
--- a/Fabric/Graph/Graph.swift
+++ b/Fabric/Graph/Graph.swift
@@ -48,6 +48,14 @@ internal import AnyCodable
         nodes.filter { nodeViewModels[$0.id]?.isSelected == true }
     }
 
+    // NOTE (2026-07-24): the `true` seed makes this constant-true, so
+    // Processor-mode SubgraphNodes (which gate their execution on this via
+    // their isDirty override) always execute. Seeding with `false` would be
+    // the literal fix but a behaviour change: a subgraph whose inner graph
+    // self-animates (e.g. a time provider) while its outer inlets are static
+    // would freeze, since inner Providers execute without marking dirty. The
+    // commented-out hardcoded `true` at the isDirty override suggests this
+    // was parked deliberately — decide with vade before changing.
     var needsExecution:Bool {
         self.nodes.reduce(true) { (result, node) -> Bool in
             result || node.isDirty

--- a/Fabric/Graph/Graph.swift
+++ b/Fabric/Graph/Graph.swift
@@ -101,7 +101,18 @@ internal import AnyCodable
         case portConnectionMap
         case notes
     }
-    
+
+    /// Next per-graph execution slot handed to an adopted node (see
+    /// Node.executionSlot). Slots are never reused; a node claims one via the
+    /// didSet on its graph reference.
+    @ObservationIgnored private var nextExecutionSlot: Int = 0
+
+    internal func claimExecutionSlot() -> Int
+    {
+        defer { nextExecutionSlot += 1 }
+        return nextExecutionSlot
+    }
+
     public init(context:Context)
     {
         self.scene = Object(context: context)

--- a/Fabric/Graph/GraphRenderer.swift
+++ b/Fabric/Graph/GraphRenderer.swift
@@ -156,11 +156,13 @@ public class GraphRenderer : ViewRenderer
     /// Single recursive pull behind every execution path: upstream nodes are
     /// pulled depth-first and executed inline as soon as their own dependencies
     /// are satisfied, so downstream nodes always read values produced this
-    /// pass. Returns false when this pull contributes nothing fresh downstream
-    /// — the node declined the requested output port (its keep-alive control
-    /// inputs are still pulled, at most once per pass, so it can select a
-    /// different route later), or sat out the pass because every one of its
-    /// own upstream pulls declined.
+    /// pass. A node's control inputs (Index, map) are resolved before its
+    /// route selection is queried, so routing never lags a frame behind its
+    /// control values and control chains can never starve — even when every
+    /// consumed output declines. Returns false when this pull contributes
+    /// nothing fresh downstream: the node declined the requested output port,
+    /// or sat out the pass because every one of its own upstream pulls
+    /// declined.
     @discardableResult
     private func pullNode(feedbackCache: GraphRendererFeedbackCache,
                           node: Node,
@@ -170,48 +172,62 @@ public class GraphRenderer : ViewRenderer
                           commandBuffer: MTLCommandBuffer,
                           clearFlags: Bool) -> Bool
     {
-        switch node.respondToPull(requestedOutputPort: requestedOutputPort) {
-        case .declined(let keepAlivePorts):
-            // Unselected route: nothing flows downstream from this pull, but
-            // the node's control inputs (Index, map) must keep updating or it
-            // could never select a different route — a Gate whose selected
-            // output has no consumer would starve its own Index chain, the
-            // class fixed for Matrix Switch in e776d909. The node names those
-            // inputs as keepAlive; walk them once per pass, marked by
-            // .keepAliveWalked, which also terminates control chains that
-            // cycle back into another unselected output of this node.
-            if feedbackCache.processingState(forNode: node) == .unprocessed {
-                feedbackCache.setProcessingState(.keepAliveWalked,
-                                                 forNode: node,
-                                                 executionInfo: executionInfo)
-                for inputPort in keepAlivePorts {
-                    pullUpstreamNodes(of: inputPort,
-                                      feedbackCache: feedbackCache,
-                                      executionInfo: executionInfo,
-                                      renderPassDescriptor: renderPassDescriptor,
-                                      commandBuffer: commandBuffer,
-                                      clearFlags: clearFlags)
-                }
+        switch feedbackCache.processingState(forNode: node) {
+        case .processing:
+            // Mid-evaluation upstream in this very pull: a feedback back-edge.
+            // The inlet reads the injected previous-frame value.
+            return true
+        case .declined:
+            return false
+        case .processed:
+            // Already ran this pass; only the per-port routing question
+            // remains, answered against controls resolved during evaluation.
+            if case .declined = node.respondToPull(requestedOutputPort: requestedOutputPort) {
+                return false
             }
+            return true
+        case .unprocessed:
+            break
+        }
+
+        feedbackCache.setProcessingState(.processing, forNode: node, executionInfo: executionInfo)
+
+        var attemptedPullCount = 0
+        var activePullCount = 0
+
+        // Resolve control inputs first: their chains execute inline here, so
+        // the values routing depends on land on the ports before the node
+        // selects its route below. This is also what keeps control chains
+        // alive when every consumed output declines — the starvation class
+        // fixed for Matrix Switch in e776d909.
+        let controlPorts = node.controlInputPorts
+
+        if !controlPorts.isEmpty {
+            feedbackCache.injectFeedback(forInlets: controlPorts, executionInfo: executionInfo)
+
+            for controlPort in controlPorts {
+                let pulled = pullUpstreamNodes(of: controlPort,
+                                               feedbackCache: feedbackCache,
+                                               executionInfo: executionInfo,
+                                               renderPassDescriptor: renderPassDescriptor,
+                                               commandBuffer: commandBuffer,
+                                               clearFlags: clearFlags)
+                attemptedPullCount += pulled.attempted
+                activePullCount += pulled.active
+            }
+        }
+
+        switch node.respondToPull(requestedOutputPort: requestedOutputPort) {
+        case .declined:
+            // Unselected route: nothing flows downstream from this pull. The
+            // controls above stay resolved; the node itself did not run, so it
+            // returns to .unprocessed and a later pull for a live output still
+            // evaluates it fully.
+            feedbackCache.setProcessingState(.unprocessed, forNode: node, executionInfo: executionInfo)
             return false
 
         case .evaluate(let pullingPorts):
-            switch feedbackCache.processingState(forNode: node) {
-            case .processed, .processing:
-                return true
-            case .declined:
-                return false
-            case .unprocessed, .keepAliveWalked:
-                break
-            }
-
-            feedbackCache.setProcessingState(.processing,
-                                             forNode: node,
-                                             activeInputPorts: pullingPorts,
-                                             executionInfo: executionInfo)
-
-            var attemptedPullCount = 0
-            var activePullCount = 0
+            feedbackCache.injectFeedback(forInlets: pullingPorts, executionInfo: executionInfo)
 
             for inputPort in pullingPorts {
                 let pulled = pullUpstreamNodes(of: inputPort,

--- a/Fabric/Graph/GraphRenderer.swift
+++ b/Fabric/Graph/GraphRenderer.swift
@@ -254,7 +254,18 @@ public class GraphRenderer : ViewRenderer
                 node.resize(size: renderEncoder.size, scaleFactor: resizeScaleFactor)
             }
 
-            if node.isDirty || node.nodeExecutionMode == .Consumer || node.nodeExecutionMode == .Provider {
+            // Consumers and Providers always run; Processors run only when
+            // dirty — isDirty is the cross-frame change signal (inlet writes,
+            // parameter edits, async events like MIDI, subgraph inner state),
+            // which the traversal cannot derive: send-side value dedup is what
+            // stops always-executing Providers cascading re-execution through
+            // clean downstream chains. Mode is read once — it can be computed
+            // (SubgraphNode derives it from its proxy ports) — and the
+            // potentially costly isDirty (SubgraphNode walks its inner graph)
+            // is consulted last.
+            let executionMode = node.nodeExecutionMode
+
+            if executionMode == .Consumer || executionMode == .Provider || node.isDirty {
 #if DEBUG
                 commandBuffer.pushDebugGroup(node.name)
 #endif

--- a/Fabric/Graph/GraphRenderer.swift
+++ b/Fabric/Graph/GraphRenderer.swift
@@ -38,10 +38,6 @@ public class GraphRenderer : ViewRenderer
     private var graphRequiresResize: Bool = false
     public private(set) var resizeScaleFactor: Float = 1.0
 
-    // Pre-sorted node list built in update(), consumed in draw()
-    private var scheduledNodes: [Node] = []
-    private var pendingSceneSync = false
-
     // One feedback cache per graph/subgraph UUID to handle different execution cadences
     private var feedbackCaches: [UUID: GraphRendererFeedbackCache] = [:]
 
@@ -103,8 +99,6 @@ public class GraphRenderer : ViewRenderer
         )
         currentExecutionInfo = GraphExecutionInfo(timing: timing, eventInfo: pendingEventInfo)
         pendingEventInfo = nil
-
-        updateExecutionPlan()
     }
 
     override public func cleanup() {
@@ -131,72 +125,15 @@ public class GraphRenderer : ViewRenderer
         renderPassDescriptor.colorAttachments[0].storeAction = .store
         renderPassDescriptor.colorAttachments[0].clearColor = MTLClearColorMake(0, 0, 0, 0)
 
-        let feedbackCache = self.feedbackCache(for: graph.id)
-
-        for node in scheduledNodes {
-            if graphRequiresResize {
-                node.resize(size: renderEncoder.size, scaleFactor: resizeScaleFactor)
-            }
-
-#if DEBUG
-            commandBuffer.pushDebugGroup(node.name)
-#endif
-            node.execute(renderer: self,
-                         executionInfo: currentExecutionInfo,
-                         renderPassDescriptor: renderPassDescriptor,
-                         commandBuffer: commandBuffer)
-#if DEBUG
-            commandBuffer.popDebugGroup()
-#endif
-            node.markClean()
-            feedbackCache.cacheProcessedNode(node, executionInfo: currentExecutionInfo)
-        }
-
-        graphRequiresResize = false
-
-        if pendingSceneSync {
-            graph.syncNodesToScene()
-            pendingSceneSync = false
-        }
-
-        renderEncoder.draw(renderPassDescriptor: renderPassDescriptor,
-                           commandBuffer: commandBuffer,
-                           scene: graph.scene,
-                           camera: currentCamera ?? defaultCamera)
+        executeAndDraw(graph: graph,
+                       executionInfo: currentExecutionInfo,
+                       renderPassDescriptor: renderPassDescriptor,
+                       commandBuffer: commandBuffer)
 
         currentCamera = graph.firstCamera ?? defaultCamera
-        executionCount += 1
     }
 
-    // MARK: - Graph Analysis (update phase)
-
-    private func updateExecutionPlan() {
-        self.resetTextureCaches(for: currentExecutionInfo)
-
-        let feedbackCache = self.feedbackCache(for: graph.id)
-        feedbackCache.resetCacheFor(executionInfo: currentExecutionInfo)
-
-        pendingSceneSync = graph.consumePendingConnectionSceneSync()
-        if pendingSceneSync {
-            feedbackCache.invalidateTopologyCaches()
-        }
-
-        var ordered: [Node] = []
-        ordered.reserveCapacity(graph.nodes.count)
-
-        for root in evaluationRoots(for: graph) {
-            pullNode(feedbackCache: feedbackCache,
-                     node: root.node,
-                     requestedOutputPort: root.requestedOutputPort,
-                     executionInfo: currentExecutionInfo,
-                     cacheProcessedOutputs: false,
-                     onTraverse: nil) { ordered.append($0) }
-        }
-
-        scheduledNodes = ordered
-    }
-
-    // MARK: - Pull traversal (shared by planning and on-demand execution)
+    // MARK: - Pull traversal
 
     /// Where evaluation pulls start: every consumer node, every published output
     /// port's node (pulled for that specific port), and any explicitly forced
@@ -216,24 +153,22 @@ public class GraphRenderer : ViewRenderer
         return roots
     }
 
-    /// Single recursive pull behind both execution paths: the per-frame planning
-    /// pass visits by appending to the schedule (executed later in draw()), the
-    /// on-demand path visits by executing the node immediately. `onTraverse`
-    /// fires for every node the pull reaches whether or not it runs this pass
-    /// (the on-demand path applies pending resizes there); `visit` fires when
-    /// the node should run. Returns false when this pull contributes nothing
-    /// fresh downstream — the node declined the requested output port (its
-    /// keep-alive control inputs are still pulled, at most once per pass, so it
-    /// can select a different route later), or sat out the pass because every
-    /// one of its own upstream pulls declined.
+    /// Single recursive pull behind every execution path: upstream nodes are
+    /// pulled depth-first and executed inline as soon as their own dependencies
+    /// are satisfied, so downstream nodes always read values produced this
+    /// pass. Returns false when this pull contributes nothing fresh downstream
+    /// — the node declined the requested output port (its keep-alive control
+    /// inputs are still pulled, at most once per pass, so it can select a
+    /// different route later), or sat out the pass because every one of its
+    /// own upstream pulls declined.
     @discardableResult
     private func pullNode(feedbackCache: GraphRendererFeedbackCache,
                           node: Node,
                           requestedOutputPort: Port?,
                           executionInfo: GraphExecutionInfo,
-                          cacheProcessedOutputs: Bool,
-                          onTraverse: ((Node) -> Void)?,
-                          visit: (Node) -> Void) -> Bool
+                          renderPassDescriptor: MTLRenderPassDescriptor,
+                          commandBuffer: MTLCommandBuffer,
+                          clearFlags: Bool) -> Bool
     {
         switch node.respondToPull(requestedOutputPort: requestedOutputPort) {
         case .declined(let keepAlivePorts):
@@ -253,9 +188,9 @@ public class GraphRenderer : ViewRenderer
                     pullUpstreamNodes(of: inputPort,
                                       feedbackCache: feedbackCache,
                                       executionInfo: executionInfo,
-                                      cacheProcessedOutputs: cacheProcessedOutputs,
-                                      onTraverse: onTraverse,
-                                      visit: visit)
+                                      renderPassDescriptor: renderPassDescriptor,
+                                      commandBuffer: commandBuffer,
+                                      clearFlags: clearFlags)
                 }
             }
             return false
@@ -282,9 +217,9 @@ public class GraphRenderer : ViewRenderer
                 let pulled = pullUpstreamNodes(of: inputPort,
                                                feedbackCache: feedbackCache,
                                                executionInfo: executionInfo,
-                                               cacheProcessedOutputs: cacheProcessedOutputs,
-                                               onTraverse: onTraverse,
-                                               visit: visit)
+                                               renderPassDescriptor: renderPassDescriptor,
+                                               commandBuffer: commandBuffer,
+                                               clearFlags: clearFlags)
                 attemptedPullCount += pulled.attempted
                 activePullCount += pulled.active
             }
@@ -299,14 +234,29 @@ public class GraphRenderer : ViewRenderer
                 return false
             }
 
-            onTraverse?(node)
+            if graphRequiresResize {
+                node.resize(size: renderEncoder.size, scaleFactor: resizeScaleFactor)
+            }
 
             if node.isDirty || node.nodeExecutionMode == .Consumer || node.nodeExecutionMode == .Provider {
-                visit(node)
+#if DEBUG
+                commandBuffer.pushDebugGroup(node.name)
+#endif
+                node.execute(renderer: self,
+                             executionInfo: executionInfo,
+                             renderPassDescriptor: renderPassDescriptor,
+                             commandBuffer: commandBuffer)
+#if DEBUG
+                commandBuffer.popDebugGroup()
+#endif
+
+                if clearFlags {
+                    node.markClean()
+                }
+
                 feedbackCache.setProcessingState(.processed,
                                                  forNode: node,
-                                                 executionInfo: executionInfo,
-                                                 cacheProcessedOutputs: cacheProcessedOutputs)
+                                                 executionInfo: executionInfo)
             }
 
             return true
@@ -318,9 +268,9 @@ public class GraphRenderer : ViewRenderer
     private func pullUpstreamNodes(of inputPort: Port,
                                    feedbackCache: GraphRendererFeedbackCache,
                                    executionInfo: GraphExecutionInfo,
-                                   cacheProcessedOutputs: Bool,
-                                   onTraverse: ((Node) -> Void)?,
-                                   visit: (Node) -> Void) -> (attempted: Int, active: Int)
+                                   renderPassDescriptor: MTLRenderPassDescriptor,
+                                   commandBuffer: MTLCommandBuffer,
+                                   clearFlags: Bool) -> (attempted: Int, active: Int)
     {
         var attempted = 0
         var active = 0
@@ -334,9 +284,9 @@ public class GraphRenderer : ViewRenderer
                         node: upstreamNode,
                         requestedOutputPort: upstreamOutputPort,
                         executionInfo: executionInfo,
-                        cacheProcessedOutputs: cacheProcessedOutputs,
-                        onTraverse: onTraverse,
-                        visit: visit) {
+                        renderPassDescriptor: renderPassDescriptor,
+                        commandBuffer: commandBuffer,
+                        clearFlags: clearFlags) {
                 active += 1
             }
         }
@@ -395,29 +345,6 @@ public class GraphRenderer : ViewRenderer
 
         let firstCamera = graph.firstCamera ?? self.currentCamera ?? self.defaultCamera
 
-        let applyPendingResize: (Node) -> Void = { node in
-            if self.graphRequiresResize {
-                node.resize(size: self.renderEncoder.size, scaleFactor: self.resizeScaleFactor)
-            }
-        }
-
-        let executeNode: (Node) -> Void = { node in
-#if DEBUG
-            commandBuffer.pushDebugGroup(node.name)
-#endif
-            node.execute(renderer: self,
-                         executionInfo: executionInfo,
-                         renderPassDescriptor: renderPassDescriptor,
-                         commandBuffer: commandBuffer)
-#if DEBUG
-            commandBuffer.popDebugGroup()
-#endif
-
-            if clearFlags {
-                node.markClean()
-            }
-        }
-
         let roots = evaluationRoots(for: graph, forcing: forceEvaluationForTheseNodes)
 
         for root in roots {
@@ -425,9 +352,9 @@ public class GraphRenderer : ViewRenderer
                      node: root.node,
                      requestedOutputPort: root.requestedOutputPort,
                      executionInfo: executionInfo,
-                     cacheProcessedOutputs: true,
-                     onTraverse: applyPendingResize,
-                     visit: executeNode)
+                     renderPassDescriptor: renderPassDescriptor,
+                     commandBuffer: commandBuffer,
+                     clearFlags: clearFlags)
         }
 
         if !roots.isEmpty {

--- a/Fabric/Graph/GraphRendererFeedbackCache.swift
+++ b/Fabric/Graph/GraphRendererFeedbackCache.swift
@@ -19,12 +19,6 @@ internal final class GraphRendererFeedbackCache
     {
         case unprocessed
         case processing
-        /// Declined a pull for an unselected output and had its keep-alive
-        /// control inputs pulled. Guards that walk to once per pass and
-        /// terminates control chains that cycle back into another unselected
-        /// output. Unlike .declined it is not final: a later pull for a live
-        /// output upgrades the node to full evaluation.
-        case keepAliveWalked
         /// Visited this pass but sitting it out: every upstream pull declined
         /// (e.g. all inlets hang off unselected Gate branches). Distinct from
         /// .processing so an abandoned pull is never mistaken for a satisfied
@@ -97,38 +91,29 @@ internal final class GraphRendererFeedbackCache
     func setProcessingState(
         _ state: NodeProcessingState,
         forNode node:Node,
-        activeInputPorts: [Port] = [],
         executionInfo:GraphExecutionInfo
     )
     {
         nodeProcessingStateCache[node.id] = state
 
-        switch state
+        if state == .processed
         {
-        case .unprocessed, .keepAliveWalked, .declined:
-            return
-
-        case .processing:
-            self.setFeedbackState(activeInputPorts: activeInputPorts,
-                                  executionInfo: executionInfo)
-
-        case .processed:
             self.cacheProcessedNode(node, executionInfo: executionInfo)
         }
     }
 
-    private func setFeedbackState(activeInputPorts: [Port],
-                                  executionInfo:GraphExecutionInfo)
+    /// Injects cached previous-frame values into inlets whose upstream node is
+    /// currently .processing (a feedback back-edge). The renderer calls this
+    /// with each pull's inlets afresh — the active-inlet set can follow
+    /// runtime routing values — and only the per-inlet upstream pairing is
+    /// cached.
+    func injectFeedback(forInlets inlets: [Port], executionInfo: GraphExecutionInfo)
     {
         guard !previousFrameCache.isEmpty else { return }
 
         let previousFrame = executionInfo.timing.frameNumber - 1
 
-        // Inject cached previous-frame values for back-edges (upstream node is
-        // currently .processing). The active-inlet set can follow runtime
-        // routing values, so the renderer passes each pull's inlets afresh;
-        // only the per-inlet upstream pairing is cached.
-        for inlet in activeInputPorts
+        for inlet in inlets
         {
             guard let candidate = feedbackCandidate(forInlet: inlet) else { continue }
 

--- a/Fabric/Graph/GraphRendererFeedbackCache.swift
+++ b/Fabric/Graph/GraphRendererFeedbackCache.swift
@@ -14,7 +14,15 @@ import Foundation
 internal final class GraphRendererFeedbackCache
 {
 
-    // TODO: in theory we can remove the dirty semantics from node?
+    // Resolved (2026-07-24): node dirty semantics cannot fold into this
+    // state tracking — they are orthogonal axes. NodeProcessingState is
+    // per-pass traversal dedup; isDirty is the cross-frame change signal
+    // (inlet writes, parameter edits, async events, subgraph inner state).
+    // Deriving "should execute" from "an upstream executed this pass" would
+    // break zero-work steady state: Providers execute every frame, and it is
+    // send-side value dedup + dirty marking that stops them cascading
+    // re-execution through clean chains. Port-level alternatives collide with
+    // the valueDidChange edge-detection contract nodes consume internally.
     public enum NodeProcessingState
     {
         case unprocessed

--- a/Fabric/Graph/GraphRendererFeedbackCache.swift
+++ b/Fabric/Graph/GraphRendererFeedbackCache.swift
@@ -39,6 +39,13 @@ internal final class GraphRendererFeedbackCache
     private var slotStates: [SlotState] = []
     private var generation: UInt64 = 1
 
+    // Per-pass state for nodes with no execution slot — nodes pulled via
+    // connections without ever being adopted by a graph. Empty in practice
+    // (every added/decoded node claims a slot), but without it such a node
+    // could never be marked .processing, so it would re-execute per consumer
+    // and a cycle through it would recurse without terminating.
+    private var slotlessNodeStates: [UUID: SlotState] = [:]
+
     private struct FeedbackCandidate
     {
         let upstreamOutlet: Port
@@ -89,7 +96,14 @@ internal final class GraphRendererFeedbackCache
     {
         let slot = node.executionSlot
 
-        guard slot >= 0, slot < slotStates.count, slotStates[slot].generation == generation
+        guard slot >= 0 else
+        {
+            guard let slotless = slotlessNodeStates[node.id], slotless.generation == generation
+            else { return .unprocessed }
+            return slotless.state
+        }
+
+        guard slot < slotStates.count, slotStates[slot].generation == generation
         else { return .unprocessed }
 
         return slotStates[slot].state
@@ -102,14 +116,20 @@ internal final class GraphRendererFeedbackCache
     )
     {
         let slot = node.executionSlot
-        guard slot >= 0 else { return }
 
-        if slot >= slotStates.count
+        if slot >= 0
         {
-            slotStates.append(contentsOf: repeatElement(SlotState(), count: slot - slotStates.count + 1))
-        }
+            if slot >= slotStates.count
+            {
+                slotStates.append(contentsOf: repeatElement(SlotState(), count: slot - slotStates.count + 1))
+            }
 
-        slotStates[slot] = SlotState(generation: generation, state: state)
+            slotStates[slot] = SlotState(generation: generation, state: state)
+        }
+        else
+        {
+            slotlessNodeStates[node.id] = SlotState(generation: generation, state: state)
+        }
 
         if state == .processed
         {

--- a/Fabric/Graph/GraphRendererFeedbackCache.swift
+++ b/Fabric/Graph/GraphRendererFeedbackCache.swift
@@ -98,8 +98,7 @@ internal final class GraphRendererFeedbackCache
         _ state: NodeProcessingState,
         forNode node:Node,
         activeInputPorts: [Port] = [],
-        executionInfo:GraphExecutionInfo,
-        cacheProcessedOutputs: Bool = true
+        executionInfo:GraphExecutionInfo
     )
     {
         nodeProcessingStateCache[node.id] = state
@@ -113,11 +112,8 @@ internal final class GraphRendererFeedbackCache
             self.setFeedbackState(activeInputPorts: activeInputPorts,
                                   executionInfo: executionInfo)
 
-        case .processed where cacheProcessedOutputs:
-            self.cacheProcessedNode(node, executionInfo: executionInfo)
-
         case .processed:
-            return
+            self.cacheProcessedNode(node, executionInfo: executionInfo)
         }
     }
 

--- a/Fabric/Graph/GraphRendererFeedbackCache.swift
+++ b/Fabric/Graph/GraphRendererFeedbackCache.swift
@@ -13,7 +13,7 @@ import Foundation
 
 internal final class GraphRendererFeedbackCache
 {
-    
+
     // TODO: in theory we can remove the dirty semantics from node?
     public enum NodeProcessingState
     {
@@ -27,54 +27,56 @@ internal final class GraphRendererFeedbackCache
         case processed
     }
 
-    private var nodeProcessingStateCache: [UUID: NodeProcessingState] = [:]
-        
-    private struct PortCacheKey: Hashable
+    /// Per-pass node state, indexed by Node.executionSlot and validated by
+    /// pass generation: bumping `generation` in resetCacheFor invalidates
+    /// every entry at once, with no per-pass allocation or UUID hashing.
+    private struct SlotState
     {
-        let portID: UUID
-        let frameNumber: Int
+        var generation: UInt64 = 0
+        var state: NodeProcessingState = .unprocessed
     }
+
+    private var slotStates: [SlotState] = []
+    private var generation: UInt64 = 1
 
     private struct FeedbackCandidate
     {
         let upstreamOutlet: Port
-        let upstreamNodeID: UUID
+        let upstreamNode: Node
     }
 
     private let graphID:UUID
 
-    private var lastCachePruneFrameNumber: Int = -1
-    private var previousFrameCache: [PortCacheKey: PortValue] = [:]
+    // Previous / current frame port values, swapped on frame change. Writes
+    // land in the current buffer; feedback injection reads the previous one.
+    private var previousFramePortValues: [UUID: PortValue] = [:]
+    private var currentFramePortValues: [UUID: PortValue] = [:]
+    private var lastBufferSwapFrameNumber: Int = Int.min
 
     // Resolved inlet -> upstream outlet pairing (nil = unconnected inlet), keyed
     // by inlet ID. Pure topology, so it stays valid however the *set* of active
     // inlets varies with runtime routing values; rebuilt on topology change.
     private var feedbackCandidateCache: [UUID: FeedbackCandidate?] = [:]
     private var connectedOutputPortCache: [UUID: [Port]] = [:]
-    
+
     internal init(graphID:UUID)
     {
         self.graphID = graphID
     }
-    
+
     public func resetCacheFor(executionInfo:GraphExecutionInfo)
     {
-        // Clear execution state
-        self.nodeProcessingStateCache = [:]
-        
-        let currentFrame = executionInfo.timing.frameNumber
-        let previousFrame = currentFrame - 1
+        // Invalidate all per-pass node state at once.
+        generation &+= 1
 
-        if self.lastCachePruneFrameNumber != currentFrame
+        let currentFrame = executionInfo.timing.frameNumber
+
+        if lastBufferSwapFrameNumber != currentFrame
         {
-            let staleKeys = previousFrameCache.keys.filter { $0.frameNumber < previousFrame }
-            for key in staleKeys {
-                previousFrameCache.removeValue(forKey: key)
-            }
-            self.lastCachePruneFrameNumber = currentFrame
+            swap(&previousFramePortValues, &currentFramePortValues)
+            currentFramePortValues.removeAll(keepingCapacity: true)
+            lastBufferSwapFrameNumber = currentFrame
         }
-        
-//        print("GraphRendererFeedbackCache: resetCacheFor: \(graphID) frame \(currentFrame)")
     }
 
     func invalidateTopologyCaches()
@@ -82,19 +84,32 @@ internal final class GraphRendererFeedbackCache
         feedbackCandidateCache.removeAll(keepingCapacity: true)
         connectedOutputPortCache.removeAll(keepingCapacity: true)
     }
-    
+
     func processingState(forNode node:Node) -> NodeProcessingState
     {
-        return nodeProcessingStateCache[node.id, default: .unprocessed]
+        let slot = node.executionSlot
+
+        guard slot >= 0, slot < slotStates.count, slotStates[slot].generation == generation
+        else { return .unprocessed }
+
+        return slotStates[slot].state
     }
-    
+
     func setProcessingState(
         _ state: NodeProcessingState,
         forNode node:Node,
         executionInfo:GraphExecutionInfo
     )
     {
-        nodeProcessingStateCache[node.id] = state
+        let slot = node.executionSlot
+        guard slot >= 0 else { return }
+
+        if slot >= slotStates.count
+        {
+            slotStates.append(contentsOf: repeatElement(SlotState(), count: slot - slotStates.count + 1))
+        }
+
+        slotStates[slot] = SlotState(generation: generation, state: state)
 
         if state == .processed
         {
@@ -109,18 +124,15 @@ internal final class GraphRendererFeedbackCache
     /// cached.
     func injectFeedback(forInlets inlets: [Port], executionInfo: GraphExecutionInfo)
     {
-        guard !previousFrameCache.isEmpty else { return }
-
-        let previousFrame = executionInfo.timing.frameNumber - 1
+        guard !previousFramePortValues.isEmpty else { return }
 
         for inlet in inlets
         {
             guard let candidate = feedbackCandidate(forInlet: inlet) else { continue }
 
-            if nodeProcessingStateCache[candidate.upstreamNodeID, default: .unprocessed] == .processing
+            if processingState(forNode: candidate.upstreamNode) == .processing
             {
-                let key = PortCacheKey(portID: candidate.upstreamOutlet.id, frameNumber: previousFrame)
-                if let cached = previousFrameCache[key] // PortValue?
+                if let cached = previousFramePortValues[candidate.upstreamOutlet.id] // PortValue?
                 {
                     // This is the critical part: make the inlet read last frame instead of recursing
                     inlet.restoreValue(from: cached)
@@ -143,7 +155,7 @@ internal final class GraphRendererFeedbackCache
         {
             candidate = FeedbackCandidate(
                 upstreamOutlet: upstreamOutlet,
-                upstreamNodeID: upstreamNode.id
+                upstreamNode: upstreamNode
             )
         }
         else
@@ -157,22 +169,16 @@ internal final class GraphRendererFeedbackCache
 
     func cacheProcessedNode(_ node: Node, executionInfo:GraphExecutionInfo)
     {
-        let currentFrame = executionInfo.timing.frameNumber
-
         for outlet in connectedOutputPorts(forNode: node)
         {
-            let key = PortCacheKey(portID: outlet.id, frameNumber: currentFrame)
-
             if let boxed = outlet.snapshotValue()
             {
-                previousFrameCache[key] = boxed
+                currentFramePortValues[outlet.id] = boxed
             }
             else
             {
-                previousFrameCache.removeValue(forKey: key)
+                currentFramePortValues.removeValue(forKey: outlet.id)
             }
-
-//            print("GraphRendererFeedbackCache: cacheProcessedNode: \(graphID) frame \(currentFrame) node: \(node.name) outlet port: \(outlet.name)")
         }
     }
 
@@ -187,5 +193,5 @@ internal final class GraphRendererFeedbackCache
         connectedOutputPortCache[node.id] = connectedOutputs
         return connectedOutputs
     }
-    
+
 }

--- a/Fabric/Graph/Node/Node.swift
+++ b/Fabric/Graph/Node/Node.swift
@@ -76,6 +76,24 @@ public class Node : Codable, Equatable, Identifiable, Hashable, Copyable
     var context:Context
 
     weak var graph:Graph?
+    {
+        didSet
+        {
+            // Claim a per-graph execution slot on first adoption (or adoption
+            // by a different graph). Slots index the renderer's per-pass node
+            // state arrays, replacing UUID-keyed dictionary lookups on the
+            // render path. ARC nil-ing a weak reference does not fire didSet,
+            // and re-adding to the same graph (undo) keeps the claimed slot.
+            if let graph, graph !== oldValue
+            {
+                executionSlot = graph.claimExecutionSlot()
+            }
+        }
+    }
+
+    /// Index into per-pass execution state storage, unique within this node's
+    /// graph. -1 until the node is added to a graph.
+    internal private(set) var executionSlot: Int = -1
 
     // Method to register ports
     public class func registerPorts(context: Context) -> [(name: String, port: Port)] { [] }

--- a/Fabric/Graph/Node/Node.swift
+++ b/Fabric/Graph/Node/Node.swift
@@ -95,23 +95,30 @@ public class Node : Codable, Equatable, Identifiable, Hashable, Copyable
     public enum PullResponse
     {
         /// Run this node this pass, after pulling the upstream nodes feeding
-        /// these input ports.
+        /// these input ports (control inputs need not be listed — the renderer
+        /// has already resolved them).
         case evaluate(pulling: [Port])
 
         /// The requested output port is inactive (an unselected route): the
         /// node does not run for this pull and the port's consumers see a
-        /// frozen value. The renderer still pulls the upstream nodes feeding
-        /// `keepAlive` — the control inputs (Index, map) whose values let the
-        /// node select a different route later. A node must never decline a
-        /// nil requested port.
-        case declined(keepAlive: [Port])
+        /// frozen value. Control inputs stay live regardless — the renderer
+        /// resolves them before asking. A node must never decline a nil
+        /// requested port.
+        case declined
     }
 
+    /// Input ports whose values select this node's routing (Index, map). The
+    /// renderer resolves these first — pulling and executing their upstream
+    /// chains — before asking respondToPull, so a route selection always reads
+    /// values produced this pass, and control chains stay alive even when
+    /// every consumed output declines.
+    public var controlInputPorts: [Port] { [] }
+
     /// Answer a pull for `requestedOutputPort` (nil when the pull is not for a
-    /// specific port, e.g. a consumer root). The default evaluates
-    /// unconditionally, depending on every inlet; routing nodes override this
-    /// to expose only their active branch's data/control dependencies, or to
-    /// decline pulls for unselected outputs.
+    /// specific port, e.g. a consumer root). Called with controlInputPorts
+    /// already resolved. The default evaluates unconditionally, depending on
+    /// every inlet; routing nodes override this to expose only their active
+    /// branch's data dependencies, or to decline pulls for unselected outputs.
     public func respondToPull(requestedOutputPort: Port?) -> PullResponse { .evaluate(pulling: inputPorts()) }
 
     public var nodeSize:CGSize { self.computeNodeSize() }

--- a/Fabric/Graph/Port/Port.swift
+++ b/Fabric/Graph/Port/Port.swift
@@ -88,6 +88,22 @@ extension UTType
     public var portDescription: String = ""
 
     public var published: Bool = false
+    {
+        didSet
+        {
+            // Published output ports are evaluation roots: the renderer pulls
+            // them each pass via graph.publishedOutputPorts(), which caches on
+            // connectionRevision. Invalidate here so a bare toggle is enough —
+            // no mutation site has to remember to bump the revision itself.
+            // (Decode assigns in init, before didSet fires; a port not yet
+            // owned by a node in a graph no-ops here and is covered by the
+            // revision bump when its node or port is added.)
+            if published != oldValue
+            {
+                node?.graph?.markConnectionsChanged()
+            }
+        }
+    }
 
     public var publishedName: String? = nil
 

--- a/Fabric/Nodes/Utility/GateNode.swift
+++ b/Fabric/Nodes/Utility/GateNode.swift
@@ -26,12 +26,10 @@ public final class GateNode: RoutingNode
     {
         if let requestedOutputPort, requestedOutputPort.id != selectedOutputPort()?.id
         {
-            // Unselected branch: nothing to contribute, but a connected Index
-            // must keep updating so the gate can switch routes.
-            return .declined(keepAlive: [inputIndex])
+            return .declined
         }
 
-        return .evaluate(pulling: [inputIndex, input])
+        return .evaluate(pulling: [input])
     }
 
     public override func rebuildPorts(forStrategy strategy: String)

--- a/Fabric/Nodes/Utility/MatrixSwitchNode.swift
+++ b/Fabric/Nodes/Utility/MatrixSwitchNode.swift
@@ -24,8 +24,8 @@ import Satin
 /// Unlike [[GateNode]], this node never declines a pull: an unrouted output's
 /// consumer still runs (reading the frozen value) rather than being skipped as
 /// Gate skips consumers of unselected branches. Neither node can starve its
-/// control input — a declining node names its control inputs as keepAlive in
-/// its PullResponse, so the renderer keeps a connected map/Index updating.
+/// control input — the renderer resolves controlInputPorts (map / Index)
+/// before asking respondToPull, whether or not the pull is then declined.
 public final class MatrixSwitchNode: RoutingNodeBase
 {
     override public class var name: String { "Matrix Switch" }
@@ -83,13 +83,16 @@ public final class MatrixSwitchNode: RoutingNodeBase
         applyPortOrder(orderedPortNames)
     }
 
+    /// The renderer resolves the map chain before routing is read.
+    override public var controlInputPorts: [Port] { [inputMap] }
+
     public override func respondToPull(requestedOutputPort: Port?) -> Node.PullResponse
     {
         // A node executes once per pass, but each output may draw from a different
-        // input and planning asks each node only once (the node is deduplicated
+        // input and the renderer asks each node only once (the node is deduplicated
         // after its first visit). So any pull must schedule *every* routed source
         // input, not merely the one feeding the requested output.
-        .evaluate(pulling: [inputMap] + routedSourceInputPorts())
+        .evaluate(pulling: routedSourceInputPorts())
     }
 
     override public func execute(renderer: GraphRenderer,

--- a/Fabric/Nodes/Utility/RoutingNode.swift
+++ b/Fabric/Nodes/Utility/RoutingNode.swift
@@ -127,6 +127,9 @@ public class RoutingNode: RoutingNodeBase
 {
     public var inputIndex: ParameterPort<Int> { port(named: "inputIndex") }
 
+    /// The renderer resolves the Index chain before route selection.
+    override public var controlInputPorts: [Port] { [inputIndex] }
+
     public required init(context: Context)
     {
         super.init(context: context)

--- a/Fabric/Nodes/Utility/SwitchNode.swift
+++ b/Fabric/Nodes/Utility/SwitchNode.swift
@@ -51,9 +51,9 @@ public final class SwitchNode: RoutingNode
     public override func respondToPull(requestedOutputPort: Port?) -> Node.PullResponse
     {
         guard let selectedInput: Port = findPort(named: Self.inputPortName(selectedRouteIndex()))
-        else { return .evaluate(pulling: [inputIndex]) }
+        else { return .evaluate(pulling: []) }
 
-        return .evaluate(pulling: [inputIndex, selectedInput])
+        return .evaluate(pulling: [selectedInput])
     }
 
     override public func execute(renderer: GraphRenderer,

--- a/Tests/GraphExecutionTests.swift
+++ b/Tests/GraphExecutionTests.swift
@@ -122,6 +122,32 @@ struct GraphExecutionTests {
         try expectEqual(numberNode.output.value, 3.5)
     }
 
+    @Test("Publishing an output port alone makes it an evaluation root on the next pass")
+    func barePublishToggleInvalidatesEvaluationRoots() throws {
+        guard let harness = GraphExecutionTestHarness() else { return }
+
+        let graph = Graph(context: harness.context)
+        let numberNode = PassThroughNode<Float>(context: harness.context)
+        numberNode.input.value = 3.5
+        graph.addNode(numberNode)
+
+        harness.renderer.startExecution(graph: graph)
+        defer { harness.renderer.stopExecution(graph: graph) }
+
+        // Nothing is published or consumed: the first pass has no evaluation
+        // roots, and the renderer caches that answer against the graph's
+        // connection revision.
+        try harness.execute(graph, frameNumber: 0)
+        #expect(numberNode.output.value == nil)
+
+        // A bare toggle — no publish helper, no rebuildPublishedParameterGroup,
+        // no other topology change — must invalidate the cached roots by itself.
+        numberNode.output.published = true
+
+        try harness.execute(graph, frameNumber: 1)
+        try expectEqual(numberNode.output.value, 3.5)
+    }
+
     @Test("Connected number nodes feed Number Binary Operator add")
     func connectedNumberNodesComputeSum() throws {
         guard let harness = GraphExecutionTestHarness() else { return }

--- a/Tests/RoutingNodeExecutionTests.swift
+++ b/Tests/RoutingNodeExecutionTests.swift
@@ -373,6 +373,32 @@ struct RoutingNodeExecutionTests
         #expect(consumer.executionCount == 0)
     }
 
+    @Test("A node pulled via connections without graph membership still deduplicates per pass")
+    func graphlessNodeExecutesOncePerPass() throws
+    {
+        guard let harness = GraphExecutionTestHarness(renderWidth: 64, renderHeight: 64) else { return }
+
+        let graph = Graph(context: harness.context)
+        let orphanSource = CountingFloatProviderNode(context: harness.context, value: 30)
+        let firstConsumer = CountingFloatConsumerNode(context: harness.context)
+        let secondConsumer = CountingFloatConsumerNode(context: harness.context)
+
+        // The provider is deliberately never added to the graph, so it has no
+        // execution slot; per-pass state must still stick (the slotless
+        // fallback) or it would run once per consumer pull.
+        graph.addNode(firstConsumer)
+        graph.addNode(secondConsumer)
+
+        orphanSource.output.connect(to: firstConsumer.input)
+        orphanSource.output.connect(to: secondConsumer.input)
+
+        try harness.execute(graph, frameNumber: 0)
+
+        #expect(orphanSource.executionCount == 1)
+        #expect(firstConsumer.lastValue == 30)
+        #expect(secondConsumer.lastValue == 30)
+    }
+
     @Test("A gated inlet does not stall a consumer's live inlets")
     func gatedInletDoesNotStallSiblingInlets() throws
     {

--- a/Tests/RoutingNodeExecutionTests.swift
+++ b/Tests/RoutingNodeExecutionTests.swift
@@ -142,29 +142,14 @@ private func publish(_ port: Fabric.Port, in graph: Graph)
 @Suite("Routing Nodes")
 struct RoutingNodeExecutionTests
 {
-    // Routing selection has a one-frame cold-start latency. A routing node picks its
-    // active branch in respondToPull(requestedOutputPort:) from its index/map input,
-    // but that control input is itself pulled lazily within the same pass — so on the
-    // very first frame after creation the control port is still empty (index nil -> 0,
-    // map empty) and the wrong branch is chosen. It self-corrects on the next frame,
-    // once the control value has been produced and persists on the port. This is a
-    // property of the pull-based GraphRenderer (unchanged since the port-level
-    // dependency rework in 3ee85258) and is shared by Switch, Gate and Matrix Switch.
-    //
-    // Each connected-control node therefore has two tests: a `.disabled` cold-start test
-    // that asserts the *desired* first-frame routing (it fails today, and documents the
-    // limitation — re-enable it if the pull model is changed to evaluate control inputs
-    // before data-input selection), and a steady-state test that warms up one frame then
-    // asserts routing on the following frame. Tests that set the control value directly
-    // before executing need no warm-up, since the value is present when the first pass
-    // reads it.
+    // A routing node picks its active branch in respondToPull(requestedOutputPort:)
+    // from its index/map input. The renderer resolves controlInputPorts — pulling and
+    // executing their upstream chains — before asking, so routing is correct from the
+    // very first frame; the historical one-frame cold-start latency (control values
+    // pulled lazily within the same pass, so the first pass read an empty port) is
+    // gone, and the cold-start tests below assert first-frame routing directly.
 
-    // Cold-start: on the very first frame the connected index has not yet been produced,
-    // so the wrong input branch is selected (see the note above). This asserts the desired
-    // first-frame routing and therefore FAILS today; it is disabled so the suite stays
-    // green while documenting the limitation.
-    @Test("Switch routes correctly on the first frame — cold-start latency (known limitation)",
-          .disabled("One-frame routing cold-start latency inherent to the pull-based GraphRenderer; see the note at the top of the suite."))
+    @Test("Switch routes correctly on the first frame")
     func switchColdStartRoutesCorrectlyOnFirstFrame() throws
     {
         guard let harness = GraphExecutionTestHarness(renderWidth: 64, renderHeight: 64) else { return }
@@ -187,8 +172,8 @@ struct RoutingNodeExecutionTests
 
         try harness.execute(graph, frameNumber: 0)
 
-        // Desired first-frame routing (index 1 -> only the active branch). Fails today
-        // because the index port is still empty when the branch is chosen.
+        // The connected index resolves before the branch is chosen, so frame 0
+        // already routes index 1 -> only the active branch.
         #expect(inactive.executionCount == 0)
         #expect(active.executionCount == 1)
         #expect((switchNode.output as? NodePort<Float>)?.value == 20)
@@ -252,12 +237,7 @@ struct RoutingNodeExecutionTests
         #expect((switchNode.output as? NodePort<PortValue>)?.value == .Float(12))
     }
 
-    // Cold-start: on the very first frame the connected index has not yet been produced,
-    // so the wrong output branch is selected (see the note above). This asserts the desired
-    // first-frame routing and therefore FAILS today; it is disabled so the suite stays
-    // green while documenting the limitation.
-    @Test("Gate routes correctly on the first frame — cold-start latency (known limitation)",
-          .disabled("One-frame routing cold-start latency inherent to the pull-based GraphRenderer; see the note at the top of the suite."))
+    @Test("Gate routes correctly on the first frame")
     func gateColdStartRoutesCorrectlyOnFirstFrame() throws
     {
         guard let harness = GraphExecutionTestHarness(renderWidth: 64, renderHeight: 64) else { return }
@@ -282,8 +262,8 @@ struct RoutingNodeExecutionTests
 
         try harness.execute(graph, frameNumber: 0)
 
-        // Desired first-frame routing (index 1 -> only the active output branch). Fails
-        // today because the index port is still empty when the branch is chosen.
+        // The connected index resolves before the branch is chosen, so frame 0
+        // already routes index 1 -> only the active output branch.
         #expect(inactiveConsumer.executionCount == 0)
         #expect(activeConsumer.executionCount == 1)
         #expect(activeConsumer.lastValue == 30)
@@ -345,19 +325,18 @@ struct RoutingNodeExecutionTests
 
         index.output.connect(to: gate.inputIndex)
         source.output.connect(to: gate.port(named: "input", as: NodePort<Float>.self))
-        // Only output 1 has a consumer. On cold start the index port is empty, so
-        // route 0 — which nothing consumes — is selected, and every pull arrives
-        // via the unselected output 1.
+        // Only output 1 has a consumer; whether it is selected depends entirely
+        // on the connected index chain staying alive.
         gate.port(named: "output1", as: NodePort<Float>.self).connect(to: consumer.input)
 
         try harness.execute(graph, frameNumber: 0)
         try harness.execute(graph, frameNumber: 1)
 
-        // A declined pull must still keep the gate's index chain alive, or the
-        // index provider never runs, route 0 stays selected forever, and the gate
-        // deadlocks — the starvation class fixed for Matrix Switch in e776d909.
+        // The index chain resolves before route selection every frame — it can
+        // never starve (the class fixed for Matrix Switch in e776d909), and with
+        // control-first resolution route 1 is selected from frame 0.
         #expect(index.executionCount == 2)
-        #expect(consumer.executionCount == 1)
+        #expect(consumer.executionCount == 2)
         #expect(consumer.lastValue == 30)
     }
 
@@ -386,9 +365,9 @@ struct RoutingNodeExecutionTests
         try harness.execute(graph, frameNumber: 0)
         try harness.execute(graph, frameNumber: 1)
 
-        // A declined pull walks only the keepAlive ports the gate names (its
-        // Index chain); the data input feeds no consumed route, so its provider
-        // must stay lazy rather than being evaluated for a value nobody reads.
+        // A declined pull resolves only the gate's control inputs (its Index
+        // chain); the data input feeds no consumed route, so its provider must
+        // stay lazy rather than being evaluated for a value nobody reads.
         #expect(index.executionCount == 2)
         #expect(source.executionCount == 0)
         #expect(consumer.executionCount == 0)
@@ -595,9 +574,9 @@ struct RoutingNodeExecutionTests
         matrix.port(named: "output0", as: NodePort<Float>.self).connect(to: consumer0.input)
         matrix.port(named: "output1", as: NodePort<Float>.self).connect(to: consumer1.input)
 
-        // The map is empty during the first pass (its provider has not run yet), so routing
-        // lags by one frame — the same cold-start latency as Switch/Gate. The node must not
-        // gate itself off, or the map would never populate and routing would never recover.
+        // The map chain resolves before routing is read, so the connected map
+        // routes correctly from the first frame. The node must never gate itself
+        // off, or the map could never influence later frames.
         try harness.execute(graph, frameNumber: 0)
         try harness.execute(graph, frameNumber: 1)
 
@@ -633,7 +612,7 @@ struct RoutingNodeExecutionTests
         loopback.output.send(9, force: true)
         cache.cacheProcessedNode(loopback, executionInfo: harness.makeExecutionInfo(frameNumber: 0))
 
-        // The renderer passes each pull's active inlets into the cache, taken
+        // The renderer injects feedback for each pull's active inlets, taken
         // from the node's PullResponse at that moment; do the same here.
         func pulledInlets() throws -> [Fabric.Port]
         {
@@ -645,7 +624,8 @@ struct RoutingNodeExecutionTests
         let frame1 = harness.makeExecutionInfo(frameNumber: 1)
         cache.resetCacheFor(executionInfo: frame1)
         switchNode.inputIndex.value = 0
-        cache.setProcessingState(.processing, forNode: switchNode, activeInputPorts: try pulledInlets(), executionInfo: frame1)
+        cache.setProcessingState(.processing, forNode: switchNode, executionInfo: frame1)
+        cache.injectFeedback(forInlets: try pulledInlets(), executionInfo: frame1)
         loopback.output.send(9, force: true)
         cache.cacheProcessedNode(loopback, executionInfo: frame1)
 
@@ -655,7 +635,8 @@ struct RoutingNodeExecutionTests
         let selectedInlet = switchNode.port(named: "input1", as: NodePort<Float>.self)
         selectedInlet.value = 123
         cache.setProcessingState(.processing, forNode: loopback, executionInfo: frame2)
-        cache.setProcessingState(.processing, forNode: switchNode, activeInputPorts: try pulledInlets(), executionInfo: frame2)
+        cache.setProcessingState(.processing, forNode: switchNode, executionInfo: frame2)
+        cache.injectFeedback(forInlets: try pulledInlets(), executionInfo: frame2)
 
         // With candidates cached from the input-0 selection, the injection missed
         // the newly selected inlet and it kept its sentinel value.


### PR DESCRIPTION
Via Fable, having been tasked to look at architectural rationalisations after the added complexity Switch/Gate/Matrix introduced.

Removing the update-phase planning pass may not be compatible with current Satin prototype multi-threading work, but given this work has been done, posting here whether for study at minimum, or ultimately a merge.

> ## Summary
> 
> Removes the one-frame routing cold-start latency by resolving a routing node's control inputs (Index, map) before its route selection is read, and simplifies the GraphRenderer to a single inline execution path in the process. Both previously `.disabled` cold-start tests are re-enabled and pass: a Switch or Gate with a connected index routes correctly on the very first frame.
> 
> This reworks the execution core from the port-level dependency rework (`3ee85258`) — the update-phase planning pass is deleted entirely — which is why it's on its own branch rather than folded into the routing-node branch. Design rationale and the full tier history live in `FABRIC_EXECUTION_ARCHITECTURE.md` (project root, alongside the other audit docs).
> 
> ## Problem
> 
> Every routing pain point on the base branch traces to one circularity: **which edges are live this frame is a function of values computed during the same traversal that needs to know which edges are live.** A Gate's Index was pulled lazily inside the very pass asking the Gate which branch to pull, so:
> 
> - First frame after creation/load chose the wrong branch (index port still empty), self-correcting a frame later — the documented cold-start latency, with two `.disabled` tests asserting the behaviour we actually wanted.
> - The renderer needed keep-alive machinery (`PullResponse.declined(keepAlive:)`, the `.keepAliveWalked` state) purely so declined pulls couldn't starve control chains.
> - Routing correctness was traversal-order-sensitive by nature, guarded rather than guaranteed.
> 
> ## What changed
> 
> ### 1. `14778b03` — One inline execution path
> 
> The live view previously planned in `update()` (via a pullNode closure appending to `scheduledNodes`) and executed in `draw()`, while exporters/subgraphs/iterators executed inline during traversal. The split is *why* selections read stale values — the plan was built before anything executed — and the two closure parameters on `pullNode` existed only to serve it.
> 
> `draw()` now runs the same `executeAndDraw` traversal as every other caller: nodes execute depth-first as their dependencies resolve; pending resizes and `markClean` apply at the execution site. Deleted: `scheduledNodes`, `updateExecutionPlan`, `pendingSceneSync`, the `onTraverse`/`visit` closures, and the feedback cache's `cacheProcessedOutputs` split. Net −77 lines. Public API for exporters/subgraphs (`execute(graph:...)`, `executeAndDraw`) is unchanged.
> 
> Note: the originally proposed alternative — materialize the traversal into a `[Node]` plan and run it — turns out to be incompatible with fixing cold-start at all: building a plan queries route selections, and correct selections need values produced *this* pass. Inline execution isn't a compromise; it's the enabling move.
> 
> ### 2. `ca6028c9` — Control-first pulls (the actual fix)
> 
> `Node` gains `controlInputPorts` (default `[]`; `RoutingNode` → `[inputIndex]`, `MatrixSwitchNode` → `[inputMap]`). `pullNode` resolves these first — pulling and executing their upstream chains inline — *before* calling `respondToPull`. Route selection therefore always reads values produced this pass.
> 
> This is per-node resolution inside the recursion, not a global "control phase": no control-subgraph registry, laziness preserved (chains feeding routing nodes nothing consumes never run), and nested routing — a Switch inside another node's control chain — resolves naturally.
> 
> With controls resolved before the decline decision exists, the keep-alive machinery became redundant:
> 
> - `PullResponse.declined` loses its `keepAlive` payload.
> - `.keepAliveWalked` is deleted; a declined node returns to `.unprocessed`, so a later pull for a live output still evaluates it fully.
> - Feedback injection is split out of `setProcessingState` into an explicit `injectFeedback(forInlets:)`, called for control inlets and data inlets as each set becomes known.
> 
> ### 3. `a40d7e20` — Per-pass state without dictionaries
> 
> The per-pass costs on the render path: a `[UUID: NodeProcessingState]` reallocated from empty every pass (UUID hash per read/write), and port feedback values keyed by `(portID, frameNumber)` with a filter-allocating prune sweep per frame.
> 
> - Nodes claim a per-graph `executionSlot` when adopted by a graph — assigned in the `graph` reference's `didSet`, a single choke point covering `addNode`, document decode, and undo-restore. Slots are never reused.
> - The feedback cache keeps per-pass node state in a flat array indexed by slot, validated by a pass generation counter. `resetCacheFor` invalidates everything by bumping the generation: no allocation, no hashing.
> - Feedback candidates hold the upstream `Node` directly, making the back-edge check an array read.
> - Port values move to two buffers keyed by port ID alone, swapped on frame change.
> 
> ### 4. `b7482c13` — Published-flag invalidation (closes deferred review finding #7)
> 
> `graph.publishedOutputPorts()` caches against `connectionRevision`, and with the single inline path that cache decides what executes at all — published output ports are evaluation roots. Every existing mutation path bumped the revision through a side door (context menu via `rebuildPublishedParameterGroup`, auto-layout via `addNode`, port rebuilds via `addDynamicPort`/`removePort`), but a bare `port.published` toggle left the cached roots stale until an unrelated topology change. A `didSet` on `Port.published` now invalidates at the source, so no mutation site has to remember to. Regression test toggles the flag bare and asserts the port becomes a root on the next pass.
> 
> ### 5. `f889ba16` — Slotless-node fallback
> 
> A node pulled via its connections but never adopted by a graph has no execution slot, so its per-pass state silently failed to stick — it re-executed once per consumer pull, and a cycle through it would recurse without terminating (the UUID-dictionary implementation tolerated the case). A small generation-validated fallback dictionary — empty in practice, since every added or decoded node claims a slot — restores the tolerance. Regression test pulls a deliberately never-added provider from two consumers and asserts one execution per pass.
> 
> ### 6. `ee294b63` — Dirty-system TODO resolved as "dirty stays"
> 
> The feedback cache carried a TODO theorizing that node `isDirty`/`markClean` duplicated the renderer's per-pass processing-state tracking and could fold into it. The investigation refutes it — they are orthogonal axes: processing state is per-pass traversal dedup, `isDirty` is the cross-frame change signal whose writers the traversal cannot see (inlet/parameter writes, async IO events that mark dirty from callbacks, JavaScriptNode settings changes, undo-restore, Processor-mode SubgraphNode aggregating inner-graph state). Deriving execution from "an upstream ran this pass" would break zero-work steady state — Providers execute every frame, and it is send-side value dedup plus dirty marking that stops them cascading through clean chains; a port-level substitute collides with the `valueDidChange` edge-detection contract ~20 nodes consume inside `execute`.
> 
> No behavioural change: the TODO is replaced with this resolution, and the execute gate now reads `nodeExecutionMode` once with `isDirty` consulted last (both are computed on SubgraphNode — mode filters proxy ports, `isDirty` walks the inner graph). The investigation also surfaced one real bug, documented in place for a decision with vade rather than changed: **`Graph.needsExecution` seeds its `reduce` with `true` and is therefore constant-true**, so Processor-mode SubgraphNodes always execute — the literal `false`-seed fix would freeze subgraphs that self-animate behind static inlets (inner Providers execute without marking dirty), and the commented-out hardcoded `true` at the adjacent `isDirty` override suggests the current behaviour was parked deliberately.
> 
> ## Behaviour changes (intended)
> 
> | Behaviour | Before | After |
> | --- | --- | --- |
> | First frame with connected Index/map | Wrong branch, corrects next frame | Correct branch immediately (tests re-enabled) |
> | Gate recovery when only an unselected output is consumed | Frame 1 | Frame 0 |
> | Feedback injection after a dropped frame | Silenced (value had to be cached at exactly frame−1) | Injects last executed frame's values |
> | Live-view camera | `renderEncoder.draw` used previous frame's `firstCamera` | Uses this frame's (same as exporter path) |
> 
> Unchanged, deliberately: consumers of unselected Gate branches freeze; unrouted Matrix outputs freeze their consumers; a node sits out a pass only when *every* upstream pull declined (pull-order-independent); a Gate pulled only via unselected outputs keeps its data input lazy (regression-pinned).
> 
> ## Testing
> 
> `swift test` at every commit: zero issues outside the known pre-existing `MTLCommandBufferErrorDomain` GPU-fault flakes in "Graph Execution" / "Graph Export Renderer" (headless-Metal environment issue, identical set at base). Routing Nodes suite fully green, including the two re-enabled cold-start tests, the declined-pull-laziness regression, and the new published-flag and slotless-fallback regressions.
> 
> Incidental finding while writing the new tests: the GPU faults originate in the *Satin scene draw* (harness `drawScene: true` / `renderEncoder.draw`), not graph execution — the execute-only harness path is reliably green. Fixing the headless scene draw would unmask those two suites' logic coverage.
> 
> ## Review notes
> 
> - The decline flow in `pullNode` re-asks `respondToPull` for `.processed` nodes pulled on another port (Matrix recomputes its inverse map then). Cheap; a per-pass memo is possible if profiling ever cares.

