### PR TITLE
Feature/satin 2.0 plugin interface redux

### DIFF
--- a/Fabric Editor/Export/GraphMovieExporter.swift
+++ b/Fabric Editor/Export/GraphMovieExporter.swift
@@ -176,7 +176,7 @@ final class GraphMovieExporter {
         let colorTexture = try self.makeIntermediateColorTexture()
         let depthTexture = try self.makeIntermediateDepthTexture()
 
-        renderer.start()
+        try renderer.start()
 
         let frameDuration = self.frameDuration()
         let sourceColorSpace = CGColorSpace(name: CGColorSpace.linearSRGB) ?? CGColorSpaceCreateDeviceRGB()
@@ -254,13 +254,13 @@ final class GraphMovieExporter {
                 await progressHandler?(frameIndex + 1, frameCount)
             }
         } catch {
-            renderer.finish()
+            try? renderer.finish()
             writerInput.markAsFinished()
             writer.cancelWriting()
             throw error
         }
 
-        renderer.finish()
+        try renderer.finish()
         writerInput.markAsFinished()
 
         if let completionError = try await self.finishWriting(writer) {

--- a/Fabric Editor/FabricDocument.swift
+++ b/Fabric Editor/FabricDocument.swift
@@ -65,13 +65,13 @@ class FabricDocument: FileDocument
         // Time source
         let currentTimeNode = CurrentTimeNode(context: self.context)
 
-        currentTimeNode.enableExecution(renderer: self.renderer)
-        currentTimeNode.startExecution(renderer: self.renderer)
+        try? currentTimeNode.enableExecution(renderer: self.renderer)
+        try? currentTimeNode.startExecution(renderer: self.renderer)
         
         // Math expression: secs * speed
         let mathNode = MathExpressionNode(context: self.context, expression: "secs * speed")
-        mathNode.enableExecution(renderer: self.renderer)
-        mathNode.startExecution(renderer: self.renderer)
+        try? mathNode.enableExecution(renderer: self.renderer)
+        try? mathNode.startExecution(renderer: self.renderer)
 
         // Publish the 'speed' port with a default of 10
         let speedPort = mathNode.findPort(named: "speed", as: ParameterPort<Float>.self)!
@@ -84,31 +84,31 @@ class FabricDocument: FileDocument
         // ports are dynamic (added by StrategyNode), hence findPort below
         // instead of typed accessor properties.
         let eulerNode = ComposeOrientationNode(context: self.context)
-        eulerNode.enableExecution(renderer: self.renderer)
-        eulerNode.startExecution(renderer: self.renderer)
+        try? eulerNode.enableExecution(renderer: self.renderer)
+        try? eulerNode.startExecution(renderer: self.renderer)
 
         // Geometry, material, mesh
         let boxNode = BoxGeometryNode(context: self.context)
-        boxNode.enableExecution(renderer: self.renderer)
-        boxNode.startExecution(renderer: self.renderer)
+        try? boxNode.enableExecution(renderer: self.renderer)
+        try? boxNode.startExecution(renderer: self.renderer)
 
         let materialNode = StandardMaterialNode(context: self.context)
-        materialNode.enableExecution(renderer: self.renderer)
-        materialNode.startExecution(renderer: self.renderer)
+        try? materialNode.enableExecution(renderer: self.renderer)
+        try? materialNode.startExecution(renderer: self.renderer)
 
         let meshNode = MeshNode(context: self.context)
-        meshNode.enableExecution(renderer: self.renderer)
-        meshNode.startExecution(renderer: self.renderer)
+        try? meshNode.enableExecution(renderer: self.renderer)
+        try? meshNode.startExecution(renderer: self.renderer)
 
         // Camera and light
         let cameraNode = PerspectiveCameraNode(context: self.context)
-        cameraNode.enableExecution(renderer: self.renderer)
-        cameraNode.startExecution(renderer: self.renderer)
+        try? cameraNode.enableExecution(renderer: self.renderer)
+        try? cameraNode.startExecution(renderer: self.renderer)
         cameraNode.inputPosition.value = simd_float3(0, 0, 3)
 
         let directionalLightNode = DirectionalLightNode(context: self.context)
-        directionalLightNode.enableExecution(renderer: self.renderer)
-        directionalLightNode.startExecution(renderer: self.renderer)
+        try? directionalLightNode.enableExecution(renderer: self.renderer)
+        try? directionalLightNode.startExecution(renderer: self.renderer)
         directionalLightNode.inputPosition.value = SIMD3<Float>(1, 2, 5)
 
         // Connections — animation chain. The Math Expression node derives its

--- a/Fabric Editor/Views/DocumentWindowManager.swift
+++ b/Fabric Editor/Views/DocumentWindowManager.swift
@@ -25,6 +25,8 @@ class DocumentOutputWindowManager : NSObject
     private var outputwindow: NSWindow? = nil
     private var outputViewController: MetalViewController? = nil
     private weak var graphRenderer: GraphRenderer? = nil
+    private var didPresentFatalRuntimeError = false
+    private var lastRecoverableRuntimeError: (any FabricErrorProtocol)?
 
     // Toolbar shit
     private weak var playPauseItem: NSToolbarItem?
@@ -59,6 +61,7 @@ class DocumentOutputWindowManager : NSObject
     func setGraphRenderer(_ graphRenderer: GraphRenderer)
     {
         self.graphRenderer = graphRenderer
+        graphRenderer.errorDelegate = self
 
         let vc = MetalViewController(renderer: graphRenderer)
         vc.view.frame = self.outputwindow?.contentView?.bounds ?? .zero
@@ -97,9 +100,58 @@ extension DocumentOutputWindowManager: NSWindowDelegate
 
     func windowWillClose(_ notification: Notification)
     {
+        self.graphRenderer?.errorDelegate = nil
         self.outputwindow?.contentViewController = nil  // triggers MetalViewController.cleanup() → renderer.cleanup()
         self.outputViewController = nil
         self.graphRenderer = nil
+    }
+}
+
+extension DocumentOutputWindowManager: ErrorRenderDelegate
+{
+    func renderer(_ renderer: Renderer, didFailWith error: any Error)
+    {
+        MainActor.assumeIsolated {
+            self.handleRuntimeError(error)
+        }
+    }
+
+    private func handleRuntimeError(_ error: any Error)
+    {
+        let fabricError = self.fabricError(from: error)
+
+        switch fabricError.severity {
+        case .recoverable:
+            self.lastRecoverableRuntimeError = fabricError
+            print("Recoverable Fabric runtime error: \(fabricError.localizedDescription)")
+
+        case .fatal:
+            guard !self.didPresentFatalRuntimeError else { return }
+            self.didPresentFatalRuntimeError = true
+            self.graphRenderer?.metalView.isPaused = true
+            self.presentFatalRuntimeErrorAlert(fabricError)
+        }
+    }
+
+    private func fabricError(from error: any Error) -> any FabricErrorProtocol
+    {
+        if let fabricError = error as? any FabricErrorProtocol {
+            return fabricError
+        }
+
+        return FabricError(.execution(.failed),
+                           severity: .fatal,
+                           message: error.localizedDescription,
+                           underlyingError: error)
+    }
+
+    private func presentFatalRuntimeErrorAlert(_ error: any FabricErrorProtocol)
+    {
+        let alert = NSAlert()
+        alert.alertStyle = .critical
+        alert.messageText = "Rendering Stopped"
+        alert.informativeText = error.localizedDescription
+        alert.runModal()
     }
 }
 

--- a/Fabric.xcodeproj/project.pbxproj
+++ b/Fabric.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		1BB453442F42919100F641AE /* Fabric in Frameworks */ = {isa = PBXBuildFile; productRef = 1BB453432F42919100F641AE /* Fabric */; };
+		1BBC136C3017D66F0039260E /* Fabric in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 1BFD79222F367C6E00F84067 /* Fabric */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		1BE00A5D2DC936A50061EAFD /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1BE00A5B2DC936A50061EAFD /* CoreFoundation.framework */; };
 		1BE00A5E2DC936A50061EAFD /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1BE00A5C2DC936A50061EAFD /* Foundation.framework */; };
 		1BE00A612DC936AC0061EAFD /* MetalKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1BE00A5F2DC936AC0061EAFD /* MetalKit.framework */; };
@@ -23,6 +24,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				1BBC136C3017D66F0039260E /* Fabric in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Fabric.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Fabric.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/orchetect/MIDIKit",
       "state" : {
-        "revision" : "5af7926114fab97a9dd8c3e2068e0f9c65c1c20f",
-        "version" : "0.11.0"
+        "revision" : "f947e7119c73a55c8a12b43f0073059cde746b01",
+        "version" : "0.12.0"
       }
     },
     {
@@ -137,15 +137,6 @@
       }
     },
     {
-      "identity" : "swift-case-paths",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-case-paths",
-      "state" : {
-        "revision" : "6989976265be3f8d2b5802c722f9ba168e227c71",
-        "version" : "1.7.2"
-      }
-    },
-    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
@@ -170,6 +161,15 @@
       "state" : {
         "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
         "version" : "4.5.0"
+      }
+    },
+    {
+      "identity" : "swift-data-parsing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/orchetect/swift-data-parsing",
+      "state" : {
+        "revision" : "b5c4d0455151c30069bb435e86a7cafa937c6e47",
+        "version" : "0.1.2"
       }
     },
     {
@@ -227,30 +227,12 @@
       }
     },
     {
-      "identity" : "swift-parsing",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-parsing",
-      "state" : {
-        "revision" : "3432cb81164dd3d69a75d0d63205be5fbae2c34b",
-        "version" : "0.14.1"
-      }
-    },
-    {
       "identity" : "swift-png",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tayloraswift/swift-png",
       "state" : {
         "revision" : "d444d98aa32f022bf4a8e74b5a697c7ee856a6ad",
         "version" : "4.4.9"
-      }
-    },
-    {
-      "identity" : "swift-syntax",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-syntax",
-      "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
       }
     },
     {
@@ -267,8 +249,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/orchetect/swift-timecode",
       "state" : {
-        "revision" : "f9a9e88c8e4c38b1b29d3db8130e1f07112e8b9e",
-        "version" : "3.0.0"
+        "revision" : "88591f790378125627e5467a552dbbc831cca752",
+        "version" : "3.1.2"
       }
     },
     {
@@ -305,15 +287,6 @@
       "state" : {
         "revision" : "5b06b811c0f5313b6b84bbef98c635a630638c38",
         "version" : "0.3.1"
-      }
-    },
-    {
-      "identity" : "xctest-dynamic-overlay",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
-      "state" : {
-        "revision" : "34e463e98ab8541c604af706c99bed7160f5ec70",
-        "version" : "1.8.1"
       }
     },
     {

--- a/Fabric.xcodeproj/xcshareddata/xcschemes/Fabric Editor.xcscheme
+++ b/Fabric.xcodeproj/xcshareddata/xcschemes/Fabric Editor.xcscheme
@@ -24,7 +24,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
@@ -40,7 +40,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      enableGPUFrameCaptureMode = "1"
+      enableGPUFrameCaptureMode = "3"
       enableGPUValidationMode = "1"
       showGraphicsOverview = "Yes"
       allowLocationSimulation = "YES"

--- a/Fabric/Graph/FabricError.swift
+++ b/Fabric/Graph/FabricError.swift
@@ -1,0 +1,82 @@
+//
+//  FabricError.swift
+//  Fabric
+//
+//  Created by Anton Marini on 7/24/26.
+//
+
+import Foundation
+
+public protocol FabricErrorProtocol: Error, LocalizedError, Sendable
+{
+    var severity: FabricErrorSeverity { get }
+}
+
+public enum FabricErrorSeverity: Sendable, Codable, Equatable
+{
+    case recoverable
+    case fatal
+}
+
+public struct FabricError: FabricErrorProtocol
+{
+    public let severity: FabricErrorSeverity
+    public let kind: FabricErrorKind
+    public let message: String
+    public let underlyingError: (any Error)?
+
+    public init(_ kind: FabricErrorKind,
+                severity: FabricErrorSeverity,
+                message: String,
+                underlyingError: (any Error)? = nil)
+    {
+        self.kind = kind
+        self.severity = severity
+        self.message = message
+        self.underlyingError = underlyingError
+    }
+
+    public var errorDescription: String?
+    {
+        message
+    }
+}
+
+public enum FabricErrorKind: Sendable, Codable, Equatable
+{
+    case general(General)
+    case loading(Loading)
+    case deserialization(Deserialization)
+    case execution(Execution)
+
+    public enum General: Sendable, Codable, Equatable
+    {
+        case unknown
+        case invalidState
+        case unsupported
+    }
+
+    public enum Loading: Sendable, Codable, Equatable
+    {
+        case pluginNotFound
+        case pluginLoadFailed
+        case resourceNotFound
+    }
+
+    public enum Deserialization: Sendable, Codable, Equatable
+    {
+        case documentInvalid
+        case nodeNotFound
+        case nodeInvalid
+    }
+
+    public enum Execution: Sendable, Codable, Equatable
+    {
+        case failed
+        case fileNotFound
+        case deviceNotFound
+        case outOfMemory
+        case gpu
+        case syntax
+    }
+}

--- a/Fabric/Graph/Graph.swift
+++ b/Fabric/Graph/Graph.swift
@@ -166,7 +166,7 @@ internal import AnyCodable
 //                print(anyCodableMap.type)
 //                print(anyCodableMap.value)
                 
-                if let nodeClass = NodeRegistry.shared.nodeClass(for: anyCodableMap.type)
+                if let nodeClass = try NodeRegistry.shared.nodeClass(for: anyCodableMap.type)
                 {
                     let jsonData = try encoder.encode(anyCodableMap.value)
                     decoder.context = decodeContext
@@ -760,7 +760,7 @@ internal import AnyCodable
 
             let jsonData = try encoder.encode(map.value)
 
-            if let nodeClass = NodeRegistry.shared.nodeClass(for: map.type)
+            if let nodeClass = try NodeRegistry.shared.nodeClass(for: map.type)
             {
                 return try decoder.decode(nodeClass, from: jsonData)
             }

--- a/Fabric/Graph/Graph.swift
+++ b/Fabric/Graph/Graph.swift
@@ -97,6 +97,7 @@ internal import AnyCodable
     {
         case id
         case version
+        case requiredPlugins
         case nodeMap
         case portConnectionMap
         case notes
@@ -131,6 +132,9 @@ internal import AnyCodable
         self.scene = Object(context: context)
 
         self.notes = try container.decodeIfPresent([Note].self, forKey: .notes) ?? []
+        let requiredPlugins = try container.decodeIfPresent([PluginRequirement].self, forKey: .requiredPlugins) ?? []
+        let nodeRegistry = try NodeRegistry.shared
+        try nodeRegistry.validatePluginRequirements(requiredPlugins)
 
         // For Subgraphs - we capture and reset state
         // this is needed for ProxyPorts which expose inner graph ports
@@ -166,7 +170,9 @@ internal import AnyCodable
 //                print(anyCodableMap.type)
 //                print(anyCodableMap.value)
                 
-                if let nodeClass = try NodeRegistry.shared.nodeClass(for: anyCodableMap.type)
+                let nodeID = Self.qualifiedNodeID(fromSerializedType: anyCodableMap.type)
+
+                if let nodeClass = nodeRegistry.nodeClass(pluginID: nodeID.pluginID, nodeID: nodeID.nodeID)
                 {
                     let jsonData = try encoder.encode(anyCodableMap.value)
                     decoder.context = decodeContext
@@ -243,12 +249,14 @@ internal import AnyCodable
                
                 else
                 {
-                    print("Failed to find nodeClass for \(anyCodableMap.type)")
+                    throw FabricError(.deserialization(.nodeNotFound),
+                                      severity: .fatal,
+                                      message: "Could not find node '\(nodeID.nodeID)' in plugin '\(nodeID.pluginID)'")
                 }
             }
             catch
             {
-                print("Failed to decode node: \(error)")
+                throw error
             }
         }
         
@@ -285,10 +293,13 @@ internal import AnyCodable
 
         try container.encode(self.id, forKey: .id)
         try container.encode(self.version, forKey: .version)
+        let requiredPlugins = try self.requiredPlugins(for: self.nodes)
+        try container.encode(requiredPlugins, forKey: .requiredPlugins)
 
-        let nodeMap:[ AnyCodableMap ] = self.nodes.compactMap {
-            return AnyCodableMap(type: String(describing: type(of: $0)),
-                                   value: AnyCodable($0))
+        let nodeMap:[ AnyCodableMap ] = try self.nodes.map {
+            let qualifiedNodeID = try self.qualifiedNodeID(for: type(of: $0))
+            return AnyCodableMap(type: qualifiedNodeID.description,
+                                 value: AnyCodable($0))
         }
         
         try container.encode(self.notes, forKey: .notes)
@@ -760,7 +771,10 @@ internal import AnyCodable
 
             let jsonData = try encoder.encode(map.value)
 
-            if let nodeClass = try NodeRegistry.shared.nodeClass(for: map.type)
+            let nodeID = Self.qualifiedNodeID(fromSerializedType: map.type)
+            let nodeRegistry = try NodeRegistry.shared
+
+            if let nodeClass = nodeRegistry.nodeClass(pluginID: nodeID.pluginID, nodeID: nodeID.nodeID)
             {
                 return try decoder.decode(nodeClass, from: jsonData)
             }
@@ -833,6 +847,60 @@ internal import AnyCodable
         default:
             break
         }
+    }
+
+    private func qualifiedNodeID(for nodeClass: Node.Type) throws -> PluginQualifiedNodeID
+    {
+        let registry = try NodeRegistry.shared
+
+        if let qualifiedNodeID = registry.qualifiedNodeID(for: nodeClass)
+        {
+            return qualifiedNodeID
+        }
+
+        throw FabricError(.deserialization(.nodeNotFound),
+                          severity: .fatal,
+                          message: "Could not find plugin registration for node class '\(String(describing: nodeClass))'")
+    }
+
+    private func requiredPlugins(for nodes: [Node]) throws -> [PluginRequirement]
+    {
+        let registry = try NodeRegistry.shared
+        var requirementsByID: [String: PluginRequirement] = [:]
+
+        for node in nodes
+        {
+            guard let qualifiedNodeID = registry.qualifiedNodeID(for: type(of: node)) else
+            {
+                throw FabricError(.deserialization(.nodeNotFound),
+                                  severity: .fatal,
+                                  message: "Could not find plugin registration for node class '\(String(describing: type(of: node)))'")
+            }
+
+            guard let pluginInfo = PluginLoader.shared.loadedPlugins[qualifiedNodeID.pluginID] else
+            {
+                throw FabricError(.loading(.pluginNotFound),
+                                  severity: .fatal,
+                                  message: "Required plugin '\(qualifiedNodeID.pluginID)' is not loaded")
+            }
+
+            requirementsByID[qualifiedNodeID.pluginID] = PluginRequirement(id: pluginInfo.id,
+                                                                          version: pluginInfo.version)
+        }
+
+        return requirementsByID.values.sorted { $0.id < $1.id }
+    }
+
+    private static func qualifiedNodeID(fromSerializedType serializedType: String) -> PluginQualifiedNodeID
+    {
+        guard let separatorRange = serializedType.range(of: PluginQualifiedNodeID.separator) else
+        {
+            return PluginQualifiedNodeID(pluginID: PluginLoader.coreNodesPluginID,
+                                         nodeID: serializedType)
+        }
+
+        return PluginQualifiedNodeID(pluginID: String(serializedType[..<separatorRange.lowerBound]),
+                                     nodeID: String(serializedType[separatorRange.upperBound...]))
     }
 
     /// Finds all UUID-formatted strings in JSON data by traversing the parsed structure
@@ -916,13 +984,13 @@ internal import AnyCodable
 
         for node in nodesToDuplicate
         {
-            let map = AnyCodableMap(
-                type: String(describing: type(of: node)),
-                value: AnyCodable(node)
-            )
-
             do
             {
+                let qualifiedNodeID = try self.qualifiedNodeID(for: type(of: node))
+                let map = AnyCodableMap(
+                    type: qualifiedNodeID.description,
+                    value: AnyCodable(node)
+                )
                 let data = try encoder.encode(map)
                 encodedEntries.append(data)
 
@@ -1026,11 +1094,22 @@ extension Graph
 
         let internalConnections = buildInternalConnectionMap(for: nodes)
 
-        let nodeEntries: [AnyCodableMap] = nodes.map {
-            AnyCodableMap(
-                type: String(describing: type(of: $0)),
-                value: AnyCodable($0)
-            )
+        let nodeEntries: [AnyCodableMap]
+
+        do
+        {
+            nodeEntries = try nodes.map {
+                let qualifiedNodeID = try self.qualifiedNodeID(for: type(of: $0))
+                return AnyCodableMap(
+                    type: qualifiedNodeID.description,
+                    value: AnyCodable($0)
+                )
+            }
+        }
+        catch
+        {
+            print("copyNodesToPasteboard: Failed to resolve plugin node IDs: \(error)")
+            return
         }
 
         // Store connection map with string keys for Codable compatibility

--- a/Fabric/Graph/GraphExportRenderer.swift
+++ b/Fabric/Graph/GraphExportRenderer.swift
@@ -60,7 +60,7 @@ public final class GraphExportRenderer {
         self.renderPassDescriptor.depthAttachment.clearDepth = 1.0
     }
 
-    public func start() {
+    public func start() throws {
         guard !self.started else { return }
 
         self.graphRenderer.resize(
@@ -68,8 +68,8 @@ public final class GraphExportRenderer {
             scaleFactor: 1.0
         )
 
-        self.graphRenderer.enableExecution(graph: self.graph)
-        self.graphRenderer.startExecution(graph: self.graph)
+        try self.graphRenderer.enableExecution(graph: self.graph)
+        try self.graphRenderer.startExecution(graph: self.graph)
 
         self.frameNumber = 0
         self.lastRenderedTime = nil
@@ -106,10 +106,10 @@ public final class GraphExportRenderer {
             throw GraphExportRendererError.commandBufferCreationFailed
         }
         
-        self.graphRenderer.executeAndDraw(graph: self.graph,
-                                          executionInfo: executionInfo,
-                                          renderPassDescriptor: self.renderPassDescriptor,
-                                          commandBuffer: commandBuffer)
+        try self.graphRenderer.executeAndDraw(graph: self.graph,
+                                              executionInfo: executionInfo,
+                                              renderPassDescriptor: self.renderPassDescriptor,
+                                              commandBuffer: commandBuffer)
 
         commandBuffer.commit()
         commandBuffer.waitUntilCompleted()
@@ -127,16 +127,16 @@ public final class GraphExportRenderer {
         depthTexture: MTLTexture? = nil,
         time: TimeInterval
     ) throws {
-        self.start()
-        defer { self.finish() }
+        try self.start()
+        defer { try? self.finish() }
         try self.renderFrame(into: colorTexture, depthTexture: depthTexture, time: time)
     }
 
-    public func finish() {
+    public func finish() throws {
         guard self.started else { return }
 
-        self.graphRenderer.disableExecution(graph: self.graph)
-        self.graphRenderer.stopExecution(graph: self.graph)
+        try self.graphRenderer.disableExecution(graph: self.graph)
+        try self.graphRenderer.stopExecution(graph: self.graph)
         self.graphRenderer.teardown(graph: self.graph)
 
         self.renderPassDescriptor.colorAttachments[0].texture = nil

--- a/Fabric/Graph/GraphRenderer.swift
+++ b/Fabric/Graph/GraphRenderer.swift
@@ -41,6 +41,7 @@ public class GraphRenderer : ViewRenderer
     // Pre-sorted node list built in update(), consumed in draw()
     private var scheduledNodes: [Node] = []
     private var pendingSceneSync = false
+    public private(set) var lastRuntimeError: (any FabricErrorProtocol)?
 
     // One feedback cache per graph/subgraph UUID to handle different execution cadences
     private var feedbackCaches: [UUID: GraphRendererFeedbackCache] = [:]
@@ -83,8 +84,15 @@ public class GraphRenderer : ViewRenderer
 
     override public func setup() {
         super.setup()
-        enableExecution(graph: graph)
-        startExecution(graph: graph)
+        do
+        {
+            try enableExecution(graph: graph)
+            try startExecution(graph: graph)
+        }
+        catch
+        {
+            handleRuntimeError(error)
+        }
     }
 
     override public func update() {
@@ -108,8 +116,15 @@ public class GraphRenderer : ViewRenderer
     }
 
     override public func cleanup() {
-        stopExecution(graph: graph)
-        disableExecution(graph: graph)
+        do
+        {
+            try stopExecution(graph: graph)
+            try disableExecution(graph: graph)
+        }
+        catch
+        {
+            handleRuntimeError(error)
+        }
         teardown(graph: graph)
         super.cleanup()
     }
@@ -141,10 +156,17 @@ public class GraphRenderer : ViewRenderer
 #if DEBUG
             commandBuffer.pushDebugGroup(node.name)
 #endif
-            node.execute(renderer: self,
-                         executionInfo: currentExecutionInfo,
-                         renderPassDescriptor: renderPassDescriptor,
-                         commandBuffer: commandBuffer)
+            do
+            {
+                try node.execute(renderer: self,
+                                 executionInfo: currentExecutionInfo,
+                                 renderPassDescriptor: renderPassDescriptor,
+                                 commandBuffer: commandBuffer)
+            }
+            catch
+            {
+                handleRuntimeError(error)
+            }
 #if DEBUG
             commandBuffer.popDebugGroup()
 #endif
@@ -346,22 +368,22 @@ public class GraphRenderer : ViewRenderer
 
     // MARK: - On-demand graph evaluation (for exporters and subgraph callers)
 
-    public func executeAndDraw(graph: Graph, renderPassDescriptor: MTLRenderPassDescriptor, commandBuffer: MTLCommandBuffer)
+    public func executeAndDraw(graph: Graph, renderPassDescriptor: MTLRenderPassDescriptor, commandBuffer: MTLCommandBuffer) throws
     {
-        executeAndDraw(graph: graph, executionInfo: currentExecutionInfo, renderPassDescriptor: renderPassDescriptor, commandBuffer: commandBuffer)
+        try executeAndDraw(graph: graph, executionInfo: currentExecutionInfo, renderPassDescriptor: renderPassDescriptor, commandBuffer: commandBuffer)
     }
 
-    public func executeAndDraw(graph: Graph, executionInfo: GraphExecutionInfo, renderPassDescriptor: MTLRenderPassDescriptor, commandBuffer: MTLCommandBuffer)
+    public func executeAndDraw(graph: Graph, executionInfo: GraphExecutionInfo, renderPassDescriptor: MTLRenderPassDescriptor, commandBuffer: MTLCommandBuffer) throws
     {
         let needsSceneSync = graph.consumePendingConnectionSceneSync()
         if needsSceneSync {
             invalidateFeedbackTopologyCaches(for: graph)
         }
 
-        self.execute(graph: graph,
-                     executionInfo: executionInfo,
-                     renderPassDescriptor: renderPassDescriptor,
-                     commandBuffer: commandBuffer)
+        try self.execute(graph: graph,
+                         executionInfo: executionInfo,
+                         renderPassDescriptor: renderPassDescriptor,
+                         commandBuffer: commandBuffer)
 
         if needsSceneSync {
             graph.syncNodesToScene()
@@ -380,7 +402,7 @@ public class GraphRenderer : ViewRenderer
                         renderPassDescriptor: MTLRenderPassDescriptor,
                         commandBuffer: MTLCommandBuffer,
                         clearFlags: Bool = true,
-                        forceEvaluationForTheseNodes: [Node] = [])
+                        forceEvaluationForTheseNodes: [Node] = []) throws
     {
         self.resetTextureCaches(for: executionInfo)
 
@@ -401,14 +423,24 @@ public class GraphRenderer : ViewRenderer
             }
         }
 
+        var capturedError: (any Error)?
+
         let executeNode: (Node) -> Void = { node in
+            guard capturedError == nil else { return }
 #if DEBUG
             commandBuffer.pushDebugGroup(node.name)
 #endif
-            node.execute(renderer: self,
-                         executionInfo: executionInfo,
-                         renderPassDescriptor: renderPassDescriptor,
-                         commandBuffer: commandBuffer)
+            do
+            {
+                try node.execute(renderer: self,
+                                 executionInfo: executionInfo,
+                                 renderPassDescriptor: renderPassDescriptor,
+                                 commandBuffer: commandBuffer)
+            }
+            catch
+            {
+                capturedError = error
+            }
 #if DEBUG
             commandBuffer.popDebugGroup()
 #endif
@@ -433,6 +465,11 @@ public class GraphRenderer : ViewRenderer
         if !roots.isEmpty {
             self.currentCamera = firstCamera
         }
+
+        if let capturedError
+        {
+            throw capturedError
+        }
     }
 
     private func resetTextureCaches(for executionInfo: GraphExecutionInfo)
@@ -443,31 +480,31 @@ public class GraphRenderer : ViewRenderer
 
     // MARK: - Graph Execution Lifecycle
 
-    public func enableExecution(graph: Graph)
+    public func enableExecution(graph: Graph) throws
     {
         for node in graph.nodes {
-            node.enableExecution(renderer: self)
+            try node.enableExecution(renderer: self)
         }
     }
 
-    public func startExecution(graph: Graph)
+    public func startExecution(graph: Graph) throws
     {
         for node in graph.nodes {
-            node.startExecution(renderer: self)
+            try node.startExecution(renderer: self)
         }
     }
 
-    public func stopExecution(graph: Graph)
+    public func stopExecution(graph: Graph) throws
     {
         for node in graph.nodes {
-            node.stopExecution(renderer: self)
+            try node.stopExecution(renderer: self)
         }
     }
 
-    public func disableExecution(graph: Graph)
+    public func disableExecution(graph: Graph) throws
     {
         for node in graph.nodes {
-            node.disableExecution(renderer: self)
+            try node.disableExecution(renderer: self)
         }
         self.currentCamera = nil
     }
@@ -476,6 +513,21 @@ public class GraphRenderer : ViewRenderer
     {
         for node in graph.nodes {
             node.teardown()
+        }
+    }
+
+    private func handleRuntimeError(_ error: any Error)
+    {
+        if let fabricError = error as? any FabricErrorProtocol
+        {
+            self.lastRuntimeError = fabricError
+        }
+        else
+        {
+            self.lastRuntimeError = FabricError(.execution(.failed),
+                                                severity: .recoverable,
+                                                message: error.localizedDescription,
+                                                underlyingError: error)
         }
     }
 

--- a/Fabric/Graph/GraphRenderer.swift
+++ b/Fabric/Graph/GraphRenderer.swift
@@ -38,10 +38,6 @@ public class GraphRenderer : ViewRenderer
     private var graphRequiresResize: Bool = false
     public private(set) var resizeScaleFactor: Float = 1.0
 
-    // Pre-sorted node list built in update(), consumed in draw()
-    private var scheduledNodes: [Node] = []
-    private var pendingSceneSync = false
-
     // One feedback cache per graph/subgraph UUID to handle different execution cadences
     private var feedbackCaches: [UUID: GraphRendererFeedbackCache] = [:]
 
@@ -89,11 +85,11 @@ public class GraphRenderer : ViewRenderer
 
     override public func update() throws {
         try super.update()
-
+        
         let now = CACurrentMediaTime()
         let delta = now - lastGraphExecutionTime
         lastGraphExecutionTime = now
-
+        
         let timing = GraphExecutionTiming(
             time: now,
             deltaTime: delta,
@@ -103,8 +99,13 @@ public class GraphRenderer : ViewRenderer
         )
         currentExecutionInfo = GraphExecutionInfo(timing: timing, eventInfo: pendingEventInfo)
         pendingEventInfo = nil
+        
+    }
 
-        updateExecutionPlan()
+    /// Set the execution info without reading the wall clock. Tests call this
+    /// directly to drive the update/draw path with deterministic timing.
+    func planFrame(executionInfo: GraphExecutionInfo) {
+        currentExecutionInfo = executionInfo
     }
 
     override public func cleanup() throws {
@@ -131,67 +132,10 @@ public class GraphRenderer : ViewRenderer
         renderPassDescriptor.colorAttachments[0].storeAction = .store
         renderPassDescriptor.colorAttachments[0].clearColor = MTLClearColorMake(0, 0, 0, 0)
 
-        let feedbackCache = self.feedbackCache(for: graph.id)
-
-        for node in scheduledNodes {
-            if graphRequiresResize {
-                node.resize(size: renderEncoder.size, scaleFactor: resizeScaleFactor)
-            }
-
-#if DEBUG
-            commandBuffer.pushDebugGroup(node.name)
-            defer { commandBuffer.popDebugGroup() }
-#endif
-            try node.execute(renderer: self,
-                             executionInfo: currentExecutionInfo,
-                             renderPassDescriptor: renderPassDescriptor,
-                             commandBuffer: commandBuffer)
-            node.markClean()
-            feedbackCache.cacheProcessedNode(node, executionInfo: currentExecutionInfo)
-        }
-
-        graphRequiresResize = false
-
-        if pendingSceneSync {
-            graph.syncNodesToScene()
-            pendingSceneSync = false
-        }
-
-        renderEncoder.draw(renderPassDescriptor: renderPassDescriptor,
-                           commandBuffer: commandBuffer,
-                           scene: graph.scene,
-                           camera: currentCamera ?? defaultCamera)
-
-        currentCamera = graph.firstCamera ?? defaultCamera
-        executionCount += 1
-    }
-
-    // MARK: - Graph Analysis (update phase)
-
-    private func updateExecutionPlan() {
-        self.resetTextureCaches(for: currentExecutionInfo)
-
-        let feedbackCache = self.feedbackCache(for: graph.id)
-        feedbackCache.resetCacheFor(executionInfo: currentExecutionInfo)
-
-        pendingSceneSync = graph.consumePendingConnectionSceneSync()
-        if pendingSceneSync {
-            feedbackCache.invalidateTopologyCaches()
-        }
-
-        var ordered: [Node] = []
-        ordered.reserveCapacity(graph.nodes.count)
-
-        for root in evaluationRoots(for: graph) {
-            pullNode(feedbackCache: feedbackCache,
-                     node: root.node,
-                     requestedOutputPort: root.requestedOutputPort,
-                     executionInfo: currentExecutionInfo,
-                     cacheProcessedOutputs: false,
-                     onTraverse: nil) { ordered.append($0) }
-        }
-
-        scheduledNodes = ordered
+        try executeAndDraw(graph: graph,
+                           executionInfo: currentExecutionInfo,
+                           renderPassDescriptor: renderPassDescriptor,
+                           commandBuffer: commandBuffer)
     }
 
     // MARK: - Pull traversal (shared by planning and on-demand execution)

--- a/Fabric/Graph/GraphRenderer.swift
+++ b/Fabric/Graph/GraphRenderer.swift
@@ -41,7 +41,6 @@ public class GraphRenderer : ViewRenderer
     // Pre-sorted node list built in update(), consumed in draw()
     private var scheduledNodes: [Node] = []
     private var pendingSceneSync = false
-    public private(set) var lastRuntimeError: (any FabricErrorProtocol)?
 
     // One feedback cache per graph/subgraph UUID to handle different execution cadences
     private var feedbackCaches: [UUID: GraphRendererFeedbackCache] = [:]
@@ -82,21 +81,14 @@ public class GraphRenderer : ViewRenderer
 
     // MARK: - Satin ViewRenderer Lifecycle
 
-    override public func setup() {
-        super.setup()
-        do
-        {
-            try enableExecution(graph: graph)
-            try startExecution(graph: graph)
-        }
-        catch
-        {
-            handleRuntimeError(error)
-        }
+    override public func setup() throws {
+        try super.setup()
+        try enableExecution(graph: graph)
+        try startExecution(graph: graph)
     }
 
-    override public func update() {
-        super.update()
+    override public func update() throws {
+        try super.update()
 
         let now = CACurrentMediaTime()
         let delta = now - lastGraphExecutionTime
@@ -115,18 +107,11 @@ public class GraphRenderer : ViewRenderer
         updateExecutionPlan()
     }
 
-    override public func cleanup() {
-        do
-        {
-            try stopExecution(graph: graph)
-            try disableExecution(graph: graph)
-        }
-        catch
-        {
-            handleRuntimeError(error)
-        }
+    override public func cleanup() throws {
+        try stopExecution(graph: graph)
+        try disableExecution(graph: graph)
         teardown(graph: graph)
-        super.cleanup()
+        try super.cleanup()
     }
 
     override public func resize(size: (width: Float, height: Float), scaleFactor: Float)
@@ -140,7 +125,7 @@ public class GraphRenderer : ViewRenderer
 
     // MARK: - Draw
 
-    override public func draw(renderPassDescriptor: MTLRenderPassDescriptor, commandBuffer: MTLCommandBuffer)
+    override public func draw(renderPassDescriptor: MTLRenderPassDescriptor, commandBuffer: MTLCommandBuffer) throws
     {
         renderPassDescriptor.colorAttachments[0].loadAction = .clear
         renderPassDescriptor.colorAttachments[0].storeAction = .store
@@ -155,21 +140,12 @@ public class GraphRenderer : ViewRenderer
 
 #if DEBUG
             commandBuffer.pushDebugGroup(node.name)
+            defer { commandBuffer.popDebugGroup() }
 #endif
-            do
-            {
-                try node.execute(renderer: self,
-                                 executionInfo: currentExecutionInfo,
-                                 renderPassDescriptor: renderPassDescriptor,
-                                 commandBuffer: commandBuffer)
-            }
-            catch
-            {
-                handleRuntimeError(error)
-            }
-#if DEBUG
-            commandBuffer.popDebugGroup()
-#endif
+            try node.execute(renderer: self,
+                             executionInfo: currentExecutionInfo,
+                             renderPassDescriptor: renderPassDescriptor,
+                             commandBuffer: commandBuffer)
             node.markClean()
             feedbackCache.cacheProcessedNode(node, executionInfo: currentExecutionInfo)
         }
@@ -513,21 +489,6 @@ public class GraphRenderer : ViewRenderer
     {
         for node in graph.nodes {
             node.teardown()
-        }
-    }
-
-    private func handleRuntimeError(_ error: any Error)
-    {
-        if let fabricError = error as? any FabricErrorProtocol
-        {
-            self.lastRuntimeError = fabricError
-        }
-        else
-        {
-            self.lastRuntimeError = FabricError(.execution(.failed),
-                                                severity: .recoverable,
-                                                message: error.localizedDescription,
-                                                underlyingError: error)
         }
     }
 

--- a/Fabric/Graph/GraphRenderer.swift
+++ b/Fabric/Graph/GraphRenderer.swift
@@ -548,70 +548,96 @@ public class GraphRenderer : ViewRenderer
 
     // MARK: - Execution Helpers
 
-    public func newImage(withWidth width: Int, height: Int) -> FabricImage?
+    public func newImage(withWidth width: Int, height: Int) throws -> FabricImage
     {
-        return self.newImage(withWidth: width, height: height, format: self.colorPixelFormat)
+        return try self.newImage(withWidth: width, height: height, format: self.colorPixelFormat)
     }
 
-    public func newImage(withWidth width: Int, height: Int, format: MTLPixelFormat) -> FabricImage?
+    public func newImage(withWidth width: Int, height: Int, format: MTLPixelFormat) throws -> FabricImage
     {
-        return self.privateTextureCache.newManagedImage(width: width, height: height, pixelFormat: format)
+        if let image = self.privateTextureCache.newManagedImage(width: width, height: height, pixelFormat: format)
             ?? self.newImageDirect(withWidth: width, height: height, format: format)
+        {
+            return image
+        }
+
+        throw FabricError(.execution(.outOfMemory),
+                          severity: .recoverable,
+                          message: "Could not allocate image: \(width)x\(height), \(format)")
     }
 
     public func newImage(withWidth width: Int,
                          height: Int,
                          format: MTLPixelFormat,
-                         mipmapped: Bool) -> FabricImage?
+                         mipmapped: Bool) throws -> FabricImage
     {
         guard mipmapped else {
-            return newImage(withWidth: width, height: height, format: format)
+            return try newImage(withWidth: width, height: height, format: format)
         }
 
-        return privateTextureCache.newManagedImage(width: width,
-                                                   height: height,
-                                                   pixelFormat: format,
-                                                   mipmapped: true)
+        if let image = privateTextureCache.newManagedImage(width: width,
+                                                           height: height,
+                                                           pixelFormat: format,
+                                                           mipmapped: true)
             ?? newImageDirect(withWidth: width, height: height, format: format, mipmapped: true)
+        {
+            return image
+        }
+
+        throw FabricError(.execution(.outOfMemory),
+                          severity: .recoverable,
+                          message: "Could not allocate mipmapped image: \(width)x\(height), \(format)")
     }
 
-    public func newImage(fromPixelBuffer pixelBuffer: CVPixelBuffer) -> FabricImage?
+    public func newImage(fromPixelBuffer pixelBuffer: CVPixelBuffer) throws -> FabricImage
     {
-        var image:FabricImage?
+        let image: FabricImage
         
         if let surface = CVPixelBufferGetIOSurface(pixelBuffer)?.takeUnretainedValue()
         {
-             image = self.newImage(fromSurface: surface)
+             image = try self.newImage(fromSurface: surface)
         }
         else
         {
-            image = newSharedImage(fromPixelBuffer: pixelBuffer)
+            image = try newSharedImage(fromPixelBuffer: pixelBuffer)
         }
         
-        image?.isFlipped = CVImageBufferIsFlipped(pixelBuffer)
+        image.isFlipped = CVImageBufferIsFlipped(pixelBuffer)
         
         return image
     }
 
     // MARK: - Private Image Helpers
 
-    private func newSharedImage(fromPixelBuffer pixelBuffer: CVPixelBuffer) -> FabricImage?
+    private func newSharedImage(fromPixelBuffer pixelBuffer: CVPixelBuffer) throws -> FabricImage
     {
         guard let format = self.metalPixelFormatForOSType(format: CVPixelBufferGetPixelFormatType(pixelBuffer))
-        else { return nil }
+        else {
+            throw FabricError(.general(.unsupported),
+                              severity: .recoverable,
+                              message: "Unsupported pixel buffer format: \(CVPixelBufferGetPixelFormatType(pixelBuffer))")
+        }
 
         let width = CVPixelBufferGetWidth(pixelBuffer)
         let height = CVPixelBufferGetHeight(pixelBuffer)
 
         guard let image = self.sharedTextureCache.newManagedImage(width: width, height: height, pixelFormat: format)
-        else { return nil }
+        else {
+            throw FabricError(.execution(.outOfMemory),
+                              severity: .recoverable,
+                              message: "Could not allocate shared image from pixel buffer: \(width)x\(height), \(format)")
+        }
 
         let bpr = CVPixelBufferGetBytesPerRow(pixelBuffer)
 
         CVPixelBufferLockBaseAddress(pixelBuffer, .readOnly)
         defer { CVPixelBufferUnlockBaseAddress(pixelBuffer, .readOnly) }
 
-        guard let baseAddr = CVPixelBufferGetBaseAddress(pixelBuffer) else { return nil }
+        guard let baseAddr = CVPixelBufferGetBaseAddress(pixelBuffer) else {
+            throw FabricError(.execution(.failed),
+                              severity: .recoverable,
+                              message: "Could not read pixel buffer base address")
+        }
 
         let region = MTLRegionMake3D(0, 0, 0, width, height, 1)
         image.texture.replace(region: region, mipmapLevel: 0, withBytes: baseAddr, bytesPerRow: bpr)
@@ -620,7 +646,7 @@ public class GraphRenderer : ViewRenderer
         return image
     }
 
-    private func newImage(fromSurface surface: IOSurface) -> FabricImage?
+    private func newImage(fromSurface surface: IOSurface) throws -> FabricImage
     {
         let descriptor = self.metalTextureDescriptorForIOSurface(surface: surface)
 
@@ -632,7 +658,10 @@ public class GraphRenderer : ViewRenderer
                 IOSurfaceDecrementUseCount(surface)
             }
         }
-        return nil
+
+        throw FabricError(.execution(.outOfMemory),
+                          severity: .recoverable,
+                          message: "Could not allocate image from IOSurface")
     }
 
     private func metalTextureDescriptorForIOSurface(surface: IOSurfaceRef) -> MTLTextureDescriptor?

--- a/Fabric/Graph/Node/Node.swift
+++ b/Fabric/Graph/Node/Node.swift
@@ -58,12 +58,12 @@ open class Node : Codable, Equatable, Identifiable, Hashable, Copyable
         return userName ?? displayName ?? myType.name
     }
 
-    public var nodeType:NodeType
+    open var nodeType:NodeType
     {
         return Self.nodeType
     }
 
-    public var nodeExecutionMode:ExecutionMode
+    open var nodeExecutionMode:ExecutionMode
     {
         return Self.nodeExecutionMode
     }
@@ -73,7 +73,7 @@ open class Node : Codable, Equatable, Identifiable, Hashable, Copyable
         return Self.nodeTimeMode
     }
 
-    var context:Context
+    public private(set) var context:Context
 
     weak var graph:Graph?
 
@@ -128,14 +128,14 @@ open class Node : Codable, Equatable, Identifiable, Hashable, Copyable
     // MARK: - Combine subjects for NodeViewModel sync
 
     /// Fires whenever offset changes so NodeViewModel can update its cached copy.
-    public let offsetSubject = CurrentValueSubject<CGSize, Never>(.zero)
+    internal let offsetSubject = CurrentValueSubject<CGSize, Never>(.zero)
 
     /// Fires whenever the port list changes (addDynamicPort / removePort).
-    public let portsChangedSubject = PassthroughSubject<Void, Never>()
+    internal let portsChangedSubject = PassthroughSubject<Void, Never>()
 
     /// Fires whenever the node's computed `name` changes (e.g. after a math
     /// expression re-parses). NodeViewModel subscribes and caches the result.
-    public let nameSubject = PassthroughSubject<Void, Never>()
+    internal let nameSubject = PassthroughSubject<Void, Never>()
 
     // Dirty Handling
     private(set) public var isDirty: Bool = true
@@ -264,7 +264,7 @@ open class Node : Codable, Equatable, Identifiable, Hashable, Copyable
     // This function clears references to other nodes and node ports
     // removing any circular references allowing proper cleanup
     // This must is called by GraphRenderer.
-    open func teardown()
+    internal func teardown()
     {
         self.inputNodes.removeAll()
         self.outputNodes.removeAll()
@@ -320,7 +320,7 @@ open class Node : Codable, Equatable, Identifiable, Hashable, Copyable
         self.portsChangedSubject.send()
     }
 
-    public func replaceParameterOfPort(_ port:Port, withParam param:(any Parameter))
+    internal func replaceParameterOfPort(_ port:Port, withParam param:(any Parameter))
     {
         // Remove existing param from group
         if let existingParam = port.parameter
@@ -334,7 +334,7 @@ open class Node : Codable, Equatable, Identifiable, Hashable, Copyable
         port.parameter = param
     }
 
-    public func reorderPorts(_ reordered: [Port])
+    internal func reorderPorts(_ reordered: [Port])
     {
         self.registry.reorder(reordered)
         self.invalidatePortCaches()
@@ -368,30 +368,30 @@ open class Node : Codable, Equatable, Identifiable, Hashable, Copyable
         self.cachedOutputPorts = nil
     }
 
-    public func publishedPorts() -> [Port]
+    internal func publishedPorts() -> [Port]
     {
         return self.ports.filter(\.published)
     }
 
-    public func publishedInputPorts() -> [Port]
+    internal func publishedInputPorts() -> [Port]
     {
         return self.inputPorts().filter(\.published)
     }
 
-    public func publishedOutputPorts() -> [Port]
+    internal func publishedOutputPorts() -> [Port]
     {
         return self.outputPorts().filter(\.published)
     }
 
     // MARK: - Connections
 
-    open func didConnectToNode(_ node: Node)
+    internal func didConnectToNode(_ node: Node)
     {
         self.inputNodes = calcInputNodes()
         self.outputNodes = calcOutputNodes()
     }
 
-    open func didDisconnectFromNode(_ node: Node)
+    internal func didDisconnectFromNode(_ node: Node)
     {
         self.inputNodes = calcInputNodes()
         self.outputNodes = calcOutputNodes()

--- a/Fabric/Graph/Node/Node.swift
+++ b/Fabric/Graph/Node/Node.swift
@@ -75,7 +75,7 @@ open class Node : Codable, Equatable, Identifiable, Hashable, Copyable
 
     public private(set) var context:Context
 
-    weak var graph:Graph?
+    public internal(set) weak var graph:Graph?
 
     // Method to register ports
     open class func registerPorts(context: Context) -> [(name: String, port: Port)] { [] }

--- a/Fabric/Graph/Node/Node.swift
+++ b/Fabric/Graph/Node/Node.swift
@@ -12,30 +12,30 @@ import Combine
 import UniformTypeIdentifiers
 
 
-public class Node : Codable, Equatable, Identifiable, Hashable, Copyable
+open class Node : Codable, Equatable, Identifiable, Hashable, Copyable
 {
     // User interface name — the node's TYPE name (each subclass overrides).
-    public class var name: String {  fatalError("\(String(describing:self)) Must implement name") }
+    open class var name: String {  fatalError("\(String(describing:self)) Must implement name") }
 
     // Node-provided dynamic name, e.g. Math Expression shows its expression.
     // Override THIS (not the instance `name`) to give a node a self-generated
     // title; return nil for none. A user-supplied `userName` always wins over it.
-    public var displayName: String? { nil }
+    open var displayName: String? { nil }
 
     // User-supplied custom name (rename). Overrides any `displayName`.
     public var userName: String?
 
     // User interface organizing principle
-    public class var nodeType:Node.NodeType { fatalError("\(String(describing:self)) Must implement nodeType") }
+    open class var nodeType:Node.NodeType { fatalError("\(String(describing:self)) Must implement nodeType") }
 
     // Execution mode value is used to determine when this node is evaluated
-    public class var nodeExecutionMode: Node.ExecutionMode { fatalError("\(String(describing:self)) Must implement nodeExecutionMode") }
+    open class var nodeExecutionMode: Node.ExecutionMode { fatalError("\(String(describing:self)) Must implement nodeExecutionMode") }
 
     // Execution mode value is used to determine when this node is evaluated
-    public class var nodeTimeMode: Node.TimeMode {  fatalError("\(String(describing:self)) Must implement nodeTimeMode") }
+    open class var nodeTimeMode: Node.TimeMode {  fatalError("\(String(describing:self)) Must implement nodeTimeMode") }
 
     // User interface description
-    public class var nodeDescription: String { fatalError("\(String(describing:self)) Must implement nodeDescription") }
+    open class var nodeDescription: String { fatalError("\(String(describing:self)) Must implement nodeDescription") }
 
     // Identifiable
     public let id:UUID
@@ -78,14 +78,14 @@ public class Node : Codable, Equatable, Identifiable, Hashable, Copyable
     weak var graph:Graph?
 
     // Method to register ports
-    public class func registerPorts(context: Context) -> [(name: String, port: Port)] { [] }
+    open class func registerPorts(context: Context) -> [(name: String, port: Port)] { [] }
     // All port serilization, adding, removing and key value access goes through the port registry
     private let registry = PortRegistry()
 
     // Sadly this needs to be observed
     public let parameterGroup:ParameterGroup = ParameterGroup("Parameters", [])
 
-    public var ports:[Port] { self.registry.all()   }
+    open var ports:[Port] { self.registry.all()   }
     private var cachedInputPorts: [Port]?
     private var cachedOutputPorts: [Port]?
     public private(set) var inputNodes:[Node] = []
@@ -112,7 +112,7 @@ public class Node : Codable, Equatable, Identifiable, Hashable, Copyable
     /// unconditionally, depending on every inlet; routing nodes override this
     /// to expose only their active branch's data/control dependencies, or to
     /// decline pulls for unselected outputs.
-    public func respondToPull(requestedOutputPort: Port?) -> PullResponse { .evaluate(pulling: inputPorts()) }
+    open func respondToPull(requestedOutputPort: Port?) -> PullResponse { .evaluate(pulling: inputPorts()) }
 
     public var nodeSize:CGSize { self.computeNodeSize() }
 
@@ -214,7 +214,7 @@ public class Node : Codable, Equatable, Identifiable, Hashable, Copyable
         }
     }
 
-    public func encode(to encoder:Encoder) throws
+    open func encode(to encoder:Encoder) throws
     {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
@@ -250,7 +250,7 @@ public class Node : Codable, Equatable, Identifiable, Hashable, Copyable
         }
     }
 
-    public class func initWithContext(context: Context) throws -> Node
+    open class func initWithContext(context: Context) throws -> Node
     {
         self.init(context: context)
     }
@@ -264,7 +264,7 @@ public class Node : Codable, Equatable, Identifiable, Hashable, Copyable
     // This function clears references to other nodes and node ports
     // removing any circular references allowing proper cleanup
     // This must is called by GraphRenderer.
-    public func teardown()
+    open func teardown()
     {
         self.inputNodes.removeAll()
         self.outputNodes.removeAll()
@@ -385,13 +385,13 @@ public class Node : Codable, Equatable, Identifiable, Hashable, Copyable
 
     // MARK: - Connections
 
-    public func didConnectToNode(_ node: Node)
+    open func didConnectToNode(_ node: Node)
     {
         self.inputNodes = calcInputNodes()
         self.outputNodes = calcOutputNodes()
     }
 
-    public func didDisconnectFromNode(_ node: Node)
+    open func didDisconnectFromNode(_ node: Node)
     {
         self.inputNodes = calcInputNodes()
         self.outputNodes = calcOutputNodes()
@@ -453,18 +453,18 @@ public class Node : Codable, Equatable, Identifiable, Hashable, Copyable
 
     // MARK: - Execution
 
-    public func startExecution(renderer:GraphRenderer) throws { }
-    public func stopExecution(renderer:GraphRenderer) throws { }
+    open func startExecution(renderer:GraphRenderer) throws { }
+    open func stopExecution(renderer:GraphRenderer) throws { }
 
-    public func enableExecution(renderer:GraphRenderer) throws { }
-    public func disableExecution(renderer:GraphRenderer) throws { }
+    open func enableExecution(renderer:GraphRenderer) throws { }
+    open func disableExecution(renderer:GraphRenderer) throws { }
 
-    public func execute(renderer:GraphRenderer,
-                        executionInfo:GraphExecutionInfo,
-                        renderPassDescriptor: MTLRenderPassDescriptor,
-                        commandBuffer: MTLCommandBuffer) throws { }
+    open func execute(renderer:GraphRenderer,
+                      executionInfo:GraphExecutionInfo,
+                      renderPassDescriptor: MTLRenderPassDescriptor,
+                      commandBuffer: MTLCommandBuffer) throws { }
 
-    public func resize(size: (width: Float, height: Float), scaleFactor: Float) { }
+    open func resize(size: (width: Float, height: Float), scaleFactor: Float) { }
 
     // MARK: - Node Settings
 
@@ -495,17 +495,17 @@ public class Node : Codable, Equatable, Identifiable, Hashable, Copyable
 
     }
 
-    public func providesSettingsView() -> Bool
+    open func providesSettingsView() -> Bool
     {
         return false
     }
 
-    public func settingsView() -> AnyView
+    open func settingsView() -> AnyView
     {
         AnyView(EmptyView())
     }
 
-    public var settingsSize:SettingsViewSize { .Small }
+    open var settingsSize:SettingsViewSize { .Small }
 
     // MARK: - Helpers
 

--- a/Fabric/Graph/Node/Node.swift
+++ b/Fabric/Graph/Node/Node.swift
@@ -250,6 +250,11 @@ public class Node : Codable, Equatable, Identifiable, Hashable, Copyable
         }
     }
 
+    public class func initWithContext(context: Context) throws -> Node
+    {
+        self.init(context: context)
+    }
+
     deinit
     {
 //        print("Deleted node \(id)")
@@ -448,16 +453,16 @@ public class Node : Codable, Equatable, Identifiable, Hashable, Copyable
 
     // MARK: - Execution
 
-    public func startExecution(renderer:GraphRenderer) { }
-    public func stopExecution(renderer:GraphRenderer) { }
+    public func startExecution(renderer:GraphRenderer) throws { }
+    public func stopExecution(renderer:GraphRenderer) throws { }
 
-    public func enableExecution(renderer:GraphRenderer) { }
-    public func disableExecution(renderer:GraphRenderer) { }
+    public func enableExecution(renderer:GraphRenderer) throws { }
+    public func disableExecution(renderer:GraphRenderer) throws { }
 
     public func execute(renderer:GraphRenderer,
                         executionInfo:GraphExecutionInfo,
                         renderPassDescriptor: MTLRenderPassDescriptor,
-                        commandBuffer: MTLCommandBuffer) { }
+                        commandBuffer: MTLCommandBuffer) throws { }
 
     public func resize(size: (width: Float, height: Float), scaleFactor: Float) { }
 

--- a/Fabric/Graph/Node/NodeClassWrapper.swift
+++ b/Fabric/Graph/Node/NodeClassWrapper.swift
@@ -18,6 +18,7 @@ public struct NodeClassWrapper: Identifiable
     public var fileURL:URL? = nil
     public var nodeName:String
     public var nodeDescription:String
+    public var pluginBundleID:String?
 
 
     // Specify a overridden node type for say, nodeType image with specific image types (effects)
@@ -28,16 +29,28 @@ public struct NodeClassWrapper: Identifiable
         self.fileURL = fileURL
         self.nodeName = nodeName ?? nodeClass.name
         self.nodeDescription = nodeClass.nodeDescription
+        self.pluginBundleID = nil
     }
 
     /// Initialise with an explicit description (e.g. parsed from a shader file).
-    public init(nodeClass: Node.Type, nodeType:Node.NodeType? = nil, fileURL:URL? = nil, nodeName:String? = nil, nodeDescription:String)
+    public init(nodeClass: Node.Type, nodeType:Node.NodeType? = nil, fileURL:URL? = nil, nodeName:String? = nil, nodeDescription:String, pluginBundleID:String? = nil)
     {
         self.nodeClass = nodeClass
         self.nodeType = nodeType ?? nodeClass.nodeType
         self.fileURL = fileURL
         self.nodeName = nodeName ?? nodeClass.name
         self.nodeDescription = nodeDescription
+        self.pluginBundleID = pluginBundleID
+    }
+
+    public init(nodeClass: Node.Type, nodeType:Node.NodeType? = nil, fileURL:URL? = nil, nodeName:String? = nil, pluginBundleID:String?)
+    {
+        self.nodeClass = nodeClass
+        self.nodeType = nodeType ?? nodeClass.nodeType
+        self.fileURL = fileURL
+        self.nodeName = nodeName ?? nodeClass.name
+        self.nodeDescription = nodeClass.nodeDescription
+        self.pluginBundleID = pluginBundleID
     }
     
     public func initializeNode(context:Context) throws -> Node
@@ -48,7 +61,7 @@ public struct NodeClassWrapper: Identifiable
             return try nodeClassFile.init(context:context, fileURL: fileURL)
         }
         
-        return  self.nodeClass.init(context:context)
+        return try self.nodeClass.initWithContext(context: context)
     }
 }
 

--- a/Fabric/Nodes/Base/BaseGeometryNode.swift
+++ b/Fabric/Nodes/Base/BaseGeometryNode.swift
@@ -55,7 +55,7 @@ public class BaseGeometryNode : Node
         return shouldOutput
     }
     
-    public override func execute(renderer:GraphRenderer, executionInfo:GraphExecutionInfo, renderPassDescriptor: MTLRenderPassDescriptor, commandBuffer: MTLCommandBuffer)
+    public override func execute(renderer:GraphRenderer, executionInfo:GraphExecutionInfo, renderPassDescriptor: MTLRenderPassDescriptor, commandBuffer: MTLCommandBuffer) throws
     {
         let shouldOutput = self.evaluate(geometry: self.geometry, atTime: executionInfo.timing.time)
 

--- a/Fabric/Nodes/Base/BaseImageNode.swift
+++ b/Fabric/Nodes/Base/BaseImageNode.swift
@@ -655,10 +655,7 @@ public class BaseImageNode: Node, NodeFileLoadingProtocol
             self.postProcessor.renderer.size.width = Float(width)
             self.postProcessor.renderer.size.height = Float(height)
 
-            guard let outImage = renderer.newImage(withWidth: width, height: height) else {
-                self.outputTexturePort.send(nil)
-                return
-            }
+            let outImage = try renderer.newImage(withWidth: width, height: height)
 
             let renderPassDesc = MTLRenderPassDescriptor()
             renderPassDesc.colorAttachments[0].texture = outImage.texture
@@ -680,10 +677,7 @@ public class BaseImageNode: Node, NodeFileLoadingProtocol
             return
         }
 
-        guard let outImage = renderer.newImage(withWidth: inputTexture0.width, height: inputTexture0.height) else {
-            self.outputTexturePort.send(nil)
-            return
-        }
+        let outImage = try renderer.newImage(withWidth: inputTexture0.width, height: inputTexture0.height)
 
         let textures = self.imageInputPorts().map { $0.value?.texture }
 

--- a/Fabric/Nodes/Base/BaseImageNode.swift
+++ b/Fabric/Nodes/Base/BaseImageNode.swift
@@ -631,7 +631,7 @@ public class BaseImageNode: Node, NodeFileLoadingProtocol
         return (3, originalIndex)
     }
 
-    public override func execute(renderer:GraphRenderer, executionInfo:GraphExecutionInfo, renderPassDescriptor: MTLRenderPassDescriptor, commandBuffer: MTLCommandBuffer)
+    public override func execute(renderer:GraphRenderer, executionInfo:GraphExecutionInfo, renderPassDescriptor: MTLRenderPassDescriptor, commandBuffer: MTLCommandBuffer) throws
     {
         let anyPortChanged = self.ports.reduce(false) { partialResult, next in
             partialResult || next.valueDidChange

--- a/Fabric/Nodes/Base/BaseMaterialNode.swift
+++ b/Fabric/Nodes/Base/BaseMaterialNode.swift
@@ -84,7 +84,7 @@ public class BaseMaterialNode : Node
         return shouldOutput
     }
     
-    public override func execute(renderer:GraphRenderer, executionInfo:GraphExecutionInfo, renderPassDescriptor: MTLRenderPassDescriptor, commandBuffer: MTLCommandBuffer)
+    public override func execute(renderer:GraphRenderer, executionInfo:GraphExecutionInfo, renderPassDescriptor: MTLRenderPassDescriptor, commandBuffer: MTLCommandBuffer) throws
     {
         let shouldOutput = self.evaluate(material: self.material, atTime: executionInfo.timing.time)
 

--- a/Fabric/Nodes/Base/BaseMultiPassBlurEffectNode.swift
+++ b/Fabric/Nodes/Base/BaseMultiPassBlurEffectNode.swift
@@ -73,7 +73,7 @@ public class BaseMultiPassBlurEffectNode: BaseImageNode
         var currentImage: FabricImage? = nil
 
         for (index, step) in steps.enumerated() {
-            guard let nextImage = renderer.newImage(withWidth: step.width, height: step.height) else {
+            guard let nextImage = try? renderer.newImage(withWidth: step.width, height: step.height) else {
                 currentImage?.release()
                 return nil
             }

--- a/Fabric/Nodes/Base/BaseMultiPassBlurEffectTwoChannelNode.swift
+++ b/Fabric/Nodes/Base/BaseMultiPassBlurEffectTwoChannelNode.swift
@@ -77,7 +77,7 @@ public class BaseMultiPassBlurEffectTwoChannelNode: BaseImageNode
         var currentImage: FabricImage? = nil
 
         for (index, step) in steps.enumerated() {
-            guard let nextImage = renderer.newImage(withWidth: step.width, height: step.height) else {
+            guard let nextImage = try? renderer.newImage(withWidth: step.width, height: step.height) else {
                 currentImage?.release()
                 return nil
             }

--- a/Fabric/Nodes/Base/BaseObjectNode.swift
+++ b/Fabric/Nodes/Base/BaseObjectNode.swift
@@ -11,12 +11,12 @@ import Satin
 import simd
 import Metal
 
-public class BaseObjectNode : Node
+open class BaseObjectNode : Node
 {
-    override public class var nodeExecutionMode: Node.ExecutionMode { .Consumer }
-    override public class var nodeTimeMode: Node.TimeMode { .None }
+    override open class var nodeExecutionMode: Node.ExecutionMode { .Consumer }
+    override open class var nodeTimeMode: Node.TimeMode { .None }
 
-    public func getObject() -> Object? {
+    open func getObject() -> Object? {
         return nil
     }
 }
@@ -53,7 +53,7 @@ public class ObjectNode<ObjectType : Satin.Object> : BaseObjectNode
     override public func getObject() -> Object? {
         return self.object
     }
-    
+
     var object: ObjectType? {
         return nil
     }

--- a/Fabric/Nodes/Base/BaseObjectNode.swift
+++ b/Fabric/Nodes/Base/BaseObjectNode.swift
@@ -22,9 +22,9 @@ open class BaseObjectNode : Node
 }
 
 
-public class ObjectNode<ObjectType : Satin.Object> : BaseObjectNode
+open class ObjectNode<ObjectType : Satin.Object> : BaseObjectNode
 {
-    override public class func registerPorts(context: Context) -> [(name: String, port: Port)] {
+    override open class func registerPorts(context: Context) -> [(name: String, port: Port)] {
         let ports = super.registerPorts(context: context)
         
         return [
@@ -50,15 +50,15 @@ public class ObjectNode<ObjectType : Satin.Object> : BaseObjectNode
     public var inputScale:ParameterPort<simd_float3>          { port(named: "inputScale") }
     public var inputOrientation:ParameterPort<simd_float4>          { port(named: "inputOrientation") }
     
-    override public func getObject() -> Object? {
+    override open func getObject() -> Object? {
         return self.object
     }
 
-    var object: ObjectType? {
+    open var object: ObjectType? {
         return nil
     }
 
-    public func evaluate(object:Object?, atTime:TimeInterval) -> Bool
+    open func evaluate(object:Object?, atTime:TimeInterval) -> Bool
     {
         var shouldOutput = false
         

--- a/Fabric/Nodes/Base/BaseRenderableNode.swift
+++ b/Fabric/Nodes/Base/BaseRenderableNode.swift
@@ -12,10 +12,10 @@ import simd
 import Metal
 
 
-public class BaseRenderableNode<ObjectType : Renderable> : ObjectNode<ObjectType>
+open class BaseRenderableNode<ObjectType : Renderable> : ObjectNode<ObjectType>
 {
-    
-    override public func evaluate(object:Object?, atTime:TimeInterval) -> Bool
+
+    override open func evaluate(object:Object?, atTime:TimeInterval) -> Bool
     {
         var shouldOutput = super.evaluate(object: object, atTime: atTime)
 

--- a/Fabric/Nodes/Base/BaseTextureComputeProcessorNode.swift
+++ b/Fabric/Nodes/Base/BaseTextureComputeProcessorNode.swift
@@ -89,11 +89,24 @@ public class BaseTextureComputeProcessorNode: Node, NodeFileLoadingProtocol
     public override func execute(renderer:GraphRenderer, executionInfo:GraphExecutionInfo, renderPassDescriptor: MTLRenderPassDescriptor, commandBuffer: MTLCommandBuffer) throws
     {
         guard self.inputImage.valueDidChange,
-              let inTex = self.inputImage.value?.texture,
-              let outImage = renderer.newImage(withWidth: inTex.width, height: inTex.height),
-              let computeEncoder = commandBuffer.makeComputeCommandEncoder()
-                
+              let inTex = self.inputImage.value?.texture
         else { return }
+
+        guard self.compute != nil else
+        {
+            throw FabricError(.execution(.gpu),
+                              severity: .recoverable,
+                              message: "\(name) compute processor is unavailable")
+        }
+
+        let outImage = try renderer.newImage(withWidth: inTex.width, height: inTex.height)
+
+        guard let computeEncoder = commandBuffer.makeComputeCommandEncoder() else
+        {
+            throw FabricError(.execution(.gpu),
+                              severity: .recoverable,
+                              message: "Could not create \(name) compute encoder")
+        }
         
         // Input Texture to Compute
         self.compute.set(inTex, index: .Custom0)

--- a/Fabric/Nodes/Base/BaseTextureComputeProcessorNode.swift
+++ b/Fabric/Nodes/Base/BaseTextureComputeProcessorNode.swift
@@ -86,7 +86,7 @@ public class BaseTextureComputeProcessorNode: Node, NodeFileLoadingProtocol
     }
 
     // MARK: - Execution
-    public override func execute(renderer:GraphRenderer, executionInfo:GraphExecutionInfo, renderPassDescriptor: MTLRenderPassDescriptor, commandBuffer: MTLCommandBuffer)
+    public override func execute(renderer:GraphRenderer, executionInfo:GraphExecutionInfo, renderPassDescriptor: MTLRenderPassDescriptor, commandBuffer: MTLCommandBuffer) throws
     {
         guard self.inputImage.valueDidChange,
               let inTex = self.inputImage.value?.texture,

--- a/Fabric/Nodes/Geometry/ExtrudedTextGeometryNode.swift
+++ b/Fabric/Nodes/Geometry/ExtrudedTextGeometryNode.swift
@@ -34,9 +34,9 @@ public class ExtrudedTextGeometryNode : BaseGeometryNode
 
     private lazy var _geometry = ExtrudedTextGeometry(context:self.context, text: "Testing", fontSize: 1.0)
 
-    override public func startExecution(renderer: GraphRenderer)
+    override public func startExecution(renderer: GraphRenderer) throws
     {
-        super.startExecution(renderer:renderer)
+        try super.startExecution(renderer:renderer)
 
         if let fontParam = self.inputFont.parameter as? StringParameter
         {

--- a/Fabric/Nodes/Geometry/MathExpressionParametricGeometryNode.swift
+++ b/Fabric/Nodes/Geometry/MathExpressionParametricGeometryNode.swift
@@ -316,6 +316,25 @@ public class MathExpressionParametricGeometryNode: BaseGeometryNode
 
     // MARK: - Evaluate
 
+    public override func execute(renderer: GraphRenderer,
+                                 executionInfo: GraphExecutionInfo,
+                                 renderPassDescriptor: MTLRenderPassDescriptor,
+                                 commandBuffer: MTLCommandBuffer)
+    throws
+    {
+        guard evalX != nil, evalY != nil, evalZ != nil else
+        {
+            throw FabricError(.execution(.syntax),
+                              severity: .recoverable,
+                              message: "Parametric geometry expressions must compile to one float output per axis.")
+        }
+
+        try super.execute(renderer: renderer,
+                          executionInfo: executionInfo,
+                          renderPassDescriptor: renderPassDescriptor,
+                          commandBuffer: commandBuffer)
+    }
+
     override public func evaluate(geometry: Geometry, atTime: TimeInterval) -> Bool
     {
         var shouldOutput = super.evaluate(geometry: geometry, atTime: atTime)

--- a/Fabric/Nodes/Geometry/TesselatedTextGeometryNode.swift
+++ b/Fabric/Nodes/Geometry/TesselatedTextGeometryNode.swift
@@ -34,8 +34,8 @@ public class TesselatedTextGeometryNode : BaseGeometryNode
 
     private lazy var _geometry = TesselatedTextGeometry(context:self.context, text: "Testing", fontSize: 1.0)
 
-    override public func startExecution(renderer:GraphRenderer) {
-        super.startExecution(renderer:renderer)
+    override public func startExecution(renderer:GraphRenderer) throws {
+        try super.startExecution(renderer:renderer)
 
         if let fontParam = self.inputFont.parameter as? StringParameter
         {

--- a/Fabric/Nodes/Image/Analysis/ContourPathNode.swift
+++ b/Fabric/Nodes/Image/Analysis/ContourPathNode.swift
@@ -83,6 +83,7 @@ public final class ContourPathNode: Node {
 
     // MARK: - Execute
     public override func execute(renderer:GraphRenderer, executionInfo:GraphExecutionInfo, renderPassDescriptor: MTLRenderPassDescriptor, commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard
             inputMask.valueDidChange,
@@ -114,7 +115,7 @@ public final class ContourPathNode: Node {
         proc.set("MaxSegments", UInt32(maxSegs))
 
         // Clear the counter to zero before compute (tiny inline reset)
-        zeroCounter(commandBuffer: commandBuffer)
+        try zeroCounter(commandBuffer: commandBuffer)
         
         if let computeEncoder = commandBuffer.makeComputeCommandEncoder()
         {
@@ -163,7 +164,8 @@ public final class ContourPathNode: Node {
         lastAllocatedFor = (width, height, maxSegments)
     }
 
-    private func zeroCounter(commandBuffer: MTLCommandBuffer) {
+    private func zeroCounter(commandBuffer: MTLCommandBuffer) throws
+    {
         
         if let blit = commandBuffer.makeBlitCommandEncoder(),
            let counterBuffer,

--- a/Fabric/Nodes/Image/Analysis/DCTTransformNode.swift
+++ b/Fabric/Nodes/Image/Analysis/DCTTransformNode.swift
@@ -259,6 +259,7 @@ public class BaseDCTTransformNode: Node
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         let subsamplePortsChanged =
             inputChannel1HorizontalSubsample.valueDidChange ||
@@ -272,13 +273,16 @@ public class BaseDCTTransformNode: Node
 
         guard inputImage.valueDidChange || inputBlockSize.valueDidChange || subsamplePortsChanged else { return }
 
-        guard
-            let sourceTexture = inputImage.value?.texture,
-            let computePipeline,
-            let basisBuffer
-        else {
+        guard let sourceTexture = inputImage.value?.texture else {
             outputImage.send(nil)
             return
+        }
+
+        guard let computePipeline, let basisBuffer else
+        {
+            throw FabricError(.execution(.gpu),
+                              severity: .recoverable,
+                              message: "DCT Transform compute resources are unavailable")
         }
 
         let maximumSupportedBlockSize = min(
@@ -302,16 +306,17 @@ public class BaseDCTTransformNode: Node
             UInt32(Self.clampedSubsample(inputChannel4VerticalSubsample.value, blockSize: blockSize))
         )
 
-        guard
-            let transformedImage = renderer.newImage(
-                withWidth: sourceTexture.width,
-                height: sourceTexture.height,
-                format: .rgba16Float
-            ),
-            let computeEncoder = commandBuffer.makeComputeCommandEncoder()
-        else {
-            outputImage.send(nil)
-            return
+        let transformedImage = try renderer.newImage(
+            withWidth: sourceTexture.width,
+            height: sourceTexture.height,
+            format: .rgba16Float
+        )
+
+        guard let computeEncoder = commandBuffer.makeComputeCommandEncoder() else
+        {
+            throw FabricError(.execution(.gpu),
+                              severity: .recoverable,
+                              message: "Could not create DCT Transform compute encoder")
         }
 
         transformedImage.texture.label = "\(name) Output"

--- a/Fabric/Nodes/Image/Analysis/FacePoseAnalysisNode.swift
+++ b/Fabric/Nodes/Image/Analysis/FacePoseAnalysisNode.swift
@@ -74,7 +74,8 @@ public class FacePoseAnalysisNode: Node
     
     private var ciContext:CIContext!
     
-    override public func startExecution(renderer:GraphRenderer) {
+    override public func startExecution(renderer:GraphRenderer) throws
+    {
 
         let options = [
             CIContextOption.cacheIntermediates : false,
@@ -91,6 +92,7 @@ public class FacePoseAnalysisNode: Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.inputImage.valueDidChange
         {

--- a/Fabric/Nodes/Image/Analysis/HandPoseAnalysisNode.swift
+++ b/Fabric/Nodes/Image/Analysis/HandPoseAnalysisNode.swift
@@ -120,7 +120,8 @@ public class HandPoseAnalysisNode: Node
     
     private var ciContext:CIContext!
     
-    override public func startExecution(renderer:GraphRenderer) {
+    override public func startExecution(renderer:GraphRenderer) throws
+    {
         
         let options = [
             CIContextOption.cacheIntermediates : false,
@@ -134,6 +135,7 @@ public class HandPoseAnalysisNode: Node
     }
     
     public override func execute(renderer:GraphRenderer, executionInfo:GraphExecutionInfo, renderPassDescriptor: MTLRenderPassDescriptor, commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.inputImage.valueDidChange
         {

--- a/Fabric/Nodes/Image/Analysis/LucasKanadeOpticalFlowNode.swift
+++ b/Fabric/Nodes/Image/Analysis/LucasKanadeOpticalFlowNode.swift
@@ -123,20 +123,33 @@ public class LucasKanadeOpticalFlowNode: Node
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard
             self.inputImage.valueDidChange
                 || self.inputPrevImage.valueDidChange
                 || self.inputQuality.valueDidChange
                 || self.inputPreviousFlow.valueDidChange
-                || self.inputTemporalSmoothing.valueDidChange,
-            let inTex      = self.inputImage.value?.texture,
-            let preProc    = preprocessPipeline,
-            let flowLvl    = flowLevelPipeline,
-            let median     = medianFilterPipeline,
-            let bilat      = bilateralUpsamplePipeline,
-            let temporalSmooth = temporalSmoothingPipeline
+                || self.inputTemporalSmoothing.valueDidChange
         else { return }
+
+        guard let inTex = self.inputImage.value?.texture else
+        {
+            outputFlow.send(nil)
+            return
+        }
+
+        guard
+            let preProc = preprocessPipeline,
+            let flowLvl = flowLevelPipeline,
+            let median = medianFilterPipeline,
+            let bilat = bilateralUpsamplePipeline,
+            let temporalSmooth = temporalSmoothingPipeline
+        else {
+            throw FabricError(.execution(.gpu),
+                              severity: .recoverable,
+                              message: "Lucas-Kanade Optical Flow compute pipelines are unavailable")
+        }
 
         // Fall back to the current frame as "previous" when inputPrevImage is not
         // connected — produces zero flow, which is the correct identity output.
@@ -148,17 +161,16 @@ public class LucasKanadeOpticalFlowNode: Node
         let cfg     = levelConfig(for: quality)
 
         commandBuffer.pushDebugGroup("Lucas-Kanade Optical Flow (\(W)×\(H) \(quality))")
+        defer { commandBuffer.popDebugGroup() }
 
-        guard
-            let currentPyramid = renderer.newImage(withWidth: W,
+        let currentPyramid = try renderer.newImage(withWidth: W,
                                                    height: H,
                                                    format: .rgba16Float,
-                                                   mipmapped: true),
-            let previousPyramid = renderer.newImage(withWidth: W,
+                                                   mipmapped: true)
+        let previousPyramid = try renderer.newImage(withWidth: W,
                                                     height: H,
                                                     format: .rgba16Float,
                                                     mipmapped: true)
-        else { return }
         currentPyramid.texture.label = "LK Current Feature Pyramid"
         previousPyramid.texture.label = "LK Previous Feature Pyramid"
 
@@ -168,8 +180,7 @@ public class LucasKanadeOpticalFlowNode: Node
             let shift = cfg.coarsestShift - lvl
             let lw    = max(1, W >> shift)
             let lh    = max(1, H >> shift)
-            guard let img = renderer.newImage(withWidth: lw, height: lh, format: .rg16Float)
-            else { return }
+            let img = try renderer.newImage(withWidth: lw, height: lh, format: .rg16Float)
             img.texture.label = "LK Flow Level \(lvl) (\(lw)×\(lh))"
             flowImages.append(img)
         }
@@ -181,24 +192,29 @@ public class LucasKanadeOpticalFlowNode: Node
         for _ in 0 ..< cfg.bilatPassCount {
             bW = min(W, bW * 2)
             bH = min(H, bH * 2)
-            guard let img = renderer.newImage(withWidth: bW, height: bH, format: .rg16Float)
-            else { return }
+            let img = try renderer.newImage(withWidth: bW, height: bH, format: .rg16Float)
             img.texture.label = "LK Edge-Aware Upsample \(upsampledFlowImages.count) (\(bW)×\(bH))"
             upsampledFlowImages.append(img)
         }
 
-        guard let unusedCoarseFlow = renderer.newImage(
+        let unusedCoarseFlow = try renderer.newImage(
             withWidth: flowImages[0].texture.width,
             height: flowImages[0].texture.height,
             format: .rg16Float
-        ), let medianFlow = renderer.newImage(
+        )
+        let medianFlow = try renderer.newImage(
             withWidth: flowImages.last!.texture.width,
             height: flowImages.last!.texture.height,
             format: .rg16Float
-        ) else { return }
+        )
 
         // Preprocessing must finish before the blit encoder generates mips.
-        guard let enc = commandBuffer.makeComputeCommandEncoder() else { return }
+        guard let enc = commandBuffer.makeComputeCommandEncoder() else
+        {
+            throw FabricError(.execution(.gpu),
+                              severity: .recoverable,
+                              message: "Could not create Lucas-Kanade preprocess compute encoder")
+        }
         enc.label = "LK Preprocess"
         enc.pushDebugGroup("LK Preprocess")
         enc.setComputePipelineState(preProc)
@@ -211,13 +227,23 @@ public class LucasKanadeOpticalFlowNode: Node
         enc.popDebugGroup()
         enc.endEncoding()
 
-        guard let blitEncoder = commandBuffer.makeBlitCommandEncoder() else { return }
+        guard let blitEncoder = commandBuffer.makeBlitCommandEncoder() else
+        {
+            throw FabricError(.execution(.gpu),
+                              severity: .recoverable,
+                              message: "Could not create Lucas-Kanade mipmap blit encoder")
+        }
         blitEncoder.label = "LK Generate Feature Mipmaps"
         blitEncoder.generateMipmaps(for: currentPyramid.texture)
         blitEncoder.generateMipmaps(for: previousPyramid.texture)
         blitEncoder.endEncoding()
 
-        guard let flowEncoder = commandBuffer.makeComputeCommandEncoder() else { return }
+        guard let flowEncoder = commandBuffer.makeComputeCommandEncoder() else
+        {
+            throw FabricError(.execution(.gpu),
+                              severity: .recoverable,
+                              message: "Could not create Lucas-Kanade flow compute encoder")
+        }
         flowEncoder.label = "LK Flow"
         let barrier: () -> Void = { flowEncoder.memoryBarrier(scope: .textures) }
 
@@ -283,11 +309,12 @@ public class LucasKanadeOpticalFlowNode: Node
         var outputImage = reconstructedFlow
 
         if let previousFlowTexture,
-           shouldApplyTemporalSmoothing,
-           let temporallySmoothedFlow = renderer.newImage(withWidth: W,
-                                                          height: H,
-                                                          format: .rg16Float)
+           shouldApplyTemporalSmoothing
         {
+            let temporallySmoothedFlow = try renderer.newImage(withWidth: W,
+                                                               height: H,
+                                                               format: .rg16Float)
+
             var previousFlowWeight = temporalSmoothing
             flowEncoder.pushDebugGroup("LK Temporal Smoothing")
             flowEncoder.setComputePipelineState(temporalSmooth)
@@ -303,7 +330,6 @@ public class LucasKanadeOpticalFlowNode: Node
         }
 
         flowEncoder.endEncoding()
-        commandBuffer.popDebugGroup()
 
         outputFlow.send(outputImage)
     }

--- a/Fabric/Nodes/Image/Analysis/MetalFXSpatialUpsample2xNode.swift
+++ b/Fabric/Nodes/Image/Analysis/MetalFXSpatialUpsample2xNode.swift
@@ -35,6 +35,7 @@ final class MetalFXSpatialUpsample2xNode: BaseImageNode
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard self.imageInputPorts().first?.valueDidChange == true || isDirty else {
             return
@@ -57,17 +58,17 @@ final class MetalFXSpatialUpsample2xNode: BaseImageNode
             self.rebuildScalerAndTargets(for: inTex)
         }
 
-        guard let scaler = self.spatialScaler,
-              let outImage = renderer.newImage(
-                withWidth: inputWidth * 2,
-                height: inputHeight * 2,
-                format: inputFormat
-              )
-        else
+        guard let scaler = self.spatialScaler else
         {
             self.outputTexturePort.send(nil)
             return
         }
+
+        let outImage = try renderer.newImage(
+            withWidth: inputWidth * 2,
+            height: inputHeight * 2,
+            format: inputFormat
+        )
 
         // Validate usage (best-effort). MetalFX requires the texture usage be a superset of these.
         // (Some upstream nodes may create textures with too-restrictive usage flags.)

--- a/Fabric/Nodes/Image/Analysis/VLM/LocalVLMNode.swift
+++ b/Fabric/Nodes/Image/Analysis/VLM/LocalVLMNode.swift
@@ -75,11 +75,11 @@ public class LocalVLMNode : Node
         try super.init(from: decoder)
     }
     
-    override public func stopExecution(renderer:GraphRenderer) {
+    override public func stopExecution(renderer:GraphRenderer) throws {
         
         self.vlmEvaluator.cancelGeneration()
 
-        super.stopExecution(renderer:renderer)
+        try super.stopExecution(renderer:renderer)
     }
     
     override public func execute(renderer:GraphRenderer,

--- a/Fabric/Nodes/Image/Analysis/VLM/LocalVLMNode.swift
+++ b/Fabric/Nodes/Image/Analysis/VLM/LocalVLMNode.swift
@@ -86,6 +86,7 @@ public class LocalVLMNode : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.inputModel.valueDidChange,
            let name = self.inputModel.value,

--- a/Fabric/Nodes/Image/Blur/DepthOfFieldNode.swift
+++ b/Fabric/Nodes/Image/Blur/DepthOfFieldNode.swift
@@ -63,6 +63,7 @@ public final class DepthOfFieldNode: Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard
               let colorTexture = self.inputImage.value?.texture,
@@ -89,23 +90,29 @@ public final class DepthOfFieldNode: Node
         self.postProcessor.resize(size: (Float(colorTexture.width), Float(colorTexture.height)), scaleFactor: 1.0)
         self.postProcessor.draw(renderPassDescriptor: MTLRenderPassDescriptor(), commandBuffer: commandBuffer)
 
-        guard let processedTexture = self.postProcessor.outputTexture,
-              let outputImage = renderer.newImage(withWidth: processedTexture.width,
-                                                       height: processedTexture.height,
-                                                       format: processedTexture.pixelFormat)
-        else
+        guard let processedTexture = self.postProcessor.outputTexture else
         {
             self.outputImage.send(nil)
             return
         }
 
-        self.copyTexture(processedTexture, to: outputImage.texture, using: commandBuffer)
+        let outputImage = try renderer.newImage(withWidth: processedTexture.width,
+                                                height: processedTexture.height,
+                                                format: processedTexture.pixelFormat)
+
+        try self.copyTexture(processedTexture, to: outputImage.texture, using: commandBuffer)
         self.outputImage.send(outputImage)
     }
 
     private func copyTexture(_ source: MTLTexture, to destination: MTLTexture, using commandBuffer: MTLCommandBuffer)
+    throws
     {
-        guard let blitEncoder = commandBuffer.makeBlitCommandEncoder() else { return }
+        guard let blitEncoder = commandBuffer.makeBlitCommandEncoder() else
+        {
+            throw FabricError(.execution(.gpu),
+                              severity: .recoverable,
+                              message: "Could not create \(name) copy blit encoder")
+        }
         blitEncoder.label = "\(self.name) Copy"
         blitEncoder.copy(from: source,
                          sourceSlice: 0,

--- a/Fabric/Nodes/Image/Blur/GaussianBlurChannelsNode.swift
+++ b/Fabric/Nodes/Image/Blur/GaussianBlurChannelsNode.swift
@@ -55,7 +55,8 @@ public final class GaussianBlurChannelsNode: BaseMultiPassBlurEffectTwoChannelNo
     override public func execute(renderer: GraphRenderer,
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
-                                 commandBuffer: MTLCommandBuffer) {
+                                 commandBuffer: MTLCommandBuffer) throws
+    {
         let inputs = self.imageInputPorts()
         guard inputs.count >= 1,
               let inputTexture = inputs[0].value?.texture else {
@@ -128,7 +129,7 @@ public final class GaussianBlurChannelsNode: BaseMultiPassBlurEffectTwoChannelNo
         var currentImage: FabricImage? = nil
 
         for (index, step) in steps.enumerated() {
-            guard let nextImage = renderer.newImage(withWidth: step.width, height: step.height) else {
+            guard let nextImage = try? renderer.newImage(withWidth: step.width, height: step.height) else {
                 currentImage?.release()
                 return nil
             }

--- a/Fabric/Nodes/Image/Blur/GaussianBlurMaskNode.swift
+++ b/Fabric/Nodes/Image/Blur/GaussianBlurMaskNode.swift
@@ -46,6 +46,7 @@ public final class GaussianBlurMaskNode: BaseMultiPassBlurEffectTwoChannelNode {
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard let (inputTexture, inputMask) = self.validatedTwoInputTextures() else {
             self.outputTexturePort.send(nil)

--- a/Fabric/Nodes/Image/Blur/GaussianBlurNode.swift
+++ b/Fabric/Nodes/Image/Blur/GaussianBlurNode.swift
@@ -46,6 +46,7 @@ public final class GaussianBlurNode: BaseMultiPassBlurEffectNode {
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard let inputTexture = self.validatedSingleInputTexture() else {
             self.outputTexturePort.send(nil)

--- a/Fabric/Nodes/Image/Blur/MotionBlurNode.swift
+++ b/Fabric/Nodes/Image/Blur/MotionBlurNode.swift
@@ -43,6 +43,7 @@ public final class MotionBlurNode: BaseMultiPassBlurEffectNode {
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
 
         guard let inputTexture = self.validatedSingleInputTexture() else {

--- a/Fabric/Nodes/Image/Blur/PostProcessMotionBlurNode.swift
+++ b/Fabric/Nodes/Image/Blur/PostProcessMotionBlurNode.swift
@@ -53,6 +53,7 @@ public final class PostProcessMotionBlurNode: Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard
               let colorTexture = self.inputImage.value?.texture,
@@ -72,23 +73,29 @@ public final class PostProcessMotionBlurNode: Node
         self.postProcessor.resize(size: (Float(colorTexture.width), Float(colorTexture.height)), scaleFactor: 1.0)
         self.postProcessor.draw(renderPassDescriptor: MTLRenderPassDescriptor(), commandBuffer: commandBuffer)
 
-        guard let processedTexture = self.postProcessor.outputTexture,
-              let outputImage = renderer.newImage(withWidth: processedTexture.width,
-                                                  height: processedTexture.height,
-                                                  format: processedTexture.pixelFormat)
-        else
+        guard let processedTexture = self.postProcessor.outputTexture else
         {
             self.outputImage.send(nil)
             return
         }
 
-        self.copyTexture(processedTexture, to: outputImage.texture, using: commandBuffer)
+        let outputImage = try renderer.newImage(withWidth: processedTexture.width,
+                                                height: processedTexture.height,
+                                                format: processedTexture.pixelFormat)
+
+        try self.copyTexture(processedTexture, to: outputImage.texture, using: commandBuffer)
         self.outputImage.send(outputImage)
     }
 
     private func copyTexture(_ source: MTLTexture, to destination: MTLTexture, using commandBuffer: MTLCommandBuffer)
+    throws
     {
-        guard let blitEncoder = commandBuffer.makeBlitCommandEncoder() else { return }
+        guard let blitEncoder = commandBuffer.makeBlitCommandEncoder() else
+        {
+            throw FabricError(.execution(.gpu),
+                              severity: .recoverable,
+                              message: "Could not create \(name) copy blit encoder")
+        }
         blitEncoder.label = "\(self.name) Copy"
         blitEncoder.copy(from: source,
                          sourceSlice: 0,

--- a/Fabric/Nodes/Image/Blur/ZoomBlurNode.swift
+++ b/Fabric/Nodes/Image/Blur/ZoomBlurNode.swift
@@ -43,6 +43,7 @@ public final class ZoomBlurNode: BaseMultiPassBlurEffectNode {
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
 
         guard let inputTexture = self.validatedSingleInputTexture() else {

--- a/Fabric/Nodes/Image/CameraProviderNode.swift
+++ b/Fabric/Nodes/Image/CameraProviderNode.swift
@@ -162,17 +162,19 @@ public class CameraProviderNode : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         
         if self.inputCamera.valueDidChange
         {
-            updateCameraSession()
+            try updateCameraSession()
         }
         
         if self.captureDelegate.gotNewPixelBuffer,
-           let pixelBuffer = self.captureDelegate.pixelBuffer,
-           let image = renderer.newImage(fromPixelBuffer: pixelBuffer)
+           let pixelBuffer = self.captureDelegate.pixelBuffer
         {
+            let image = try renderer.newImage(fromPixelBuffer: pixelBuffer)
+
             self.outputTexturePort.send( image )
             self.captureDelegate.gotNewPixelBuffer = false
         }
@@ -212,25 +214,26 @@ public class CameraProviderNode : Node
         ] as [String : Any]
     }
     
-    private func updateCameraSession()
+    private func updateCameraSession() throws
     {
         if let deviceLocalizedName = self.inputCamera.value
         {
             if let uniqueIDForDeviceWithMatchingName = self.devices.first(where: { $0.localizedName == deviceLocalizedName })?.uniqueID,
                let device = AVCaptureDevice.init(uniqueID: uniqueIDForDeviceWithMatchingName)
             {
-                self.setupCaptureSession(videoDevice: device)
+                try self.setupCaptureSession(videoDevice: device)
             }
             else
             {
                 self.outputTexturePort.send( nil )
-                
-                print("wtf")
+                throw FabricError(.execution(.deviceNotFound),
+                                  severity: .recoverable,
+                                  message: "Camera device not found: \(deviceLocalizedName)")
             }
         }
     }
     
-    private func setupCaptureSession(videoDevice:AVCaptureDevice)
+    private func setupCaptureSession(videoDevice:AVCaptureDevice) throws
     {
         if self.captureSession.isRunning
         {
@@ -245,13 +248,24 @@ public class CameraProviderNode : Node
             }
         }
 
-        guard
-            let videoDeviceInput = try? AVCaptureDeviceInput(device: videoDevice),
-            self.captureSession.canAddInput(videoDeviceInput)
-        else
+        let videoDeviceInput: AVCaptureDeviceInput
+        do
         {
-            print("Error: Could not create video device input.")
-            return
+            videoDeviceInput = try AVCaptureDeviceInput(device: videoDevice)
+        }
+        catch
+        {
+            throw FabricError(.execution(.deviceNotFound),
+                              severity: .recoverable,
+                              message: "Could not create camera input for \(videoDevice.localizedName)",
+                              underlyingError: error)
+        }
+
+        guard self.captureSession.canAddInput(videoDeviceInput) else
+        {
+            throw FabricError(.execution(.deviceNotFound),
+                              severity: .recoverable,
+                              message: "Could not add camera input for \(videoDevice.localizedName)")
         }
         
         self.captureSession.beginConfiguration()
@@ -269,8 +283,9 @@ public class CameraProviderNode : Node
             self.captureSession.canAddOutput(videoOutput)
         else
         {
-            print("Error: Could not add video output.")
-            return
+            throw FabricError(.execution(.deviceNotFound),
+                              severity: .recoverable,
+                              message: "Could not add camera output for \(videoDevice.localizedName)")
         }
 
         self.captureSession.addOutput(videoOutput)

--- a/Fabric/Nodes/Image/ColorAdjust/LUTProcessorNode.swift
+++ b/Fabric/Nodes/Image/ColorAdjust/LUTProcessorNode.swift
@@ -42,14 +42,14 @@ public class LUTProcessorNode : BaseImageNode
     {
         super.init(context: context)
           
-        self.loadLUTFromInputValue()
+        try? self.loadLUTFromInputValue()
     }
     
     public required init(context:Context)
     {
         super.init(context: context)
           
-        self.loadLUTFromInputValue()
+        try? self.loadLUTFromInputValue()
     }
     
     public required init(from decoder: any Decoder) throws
@@ -61,25 +61,27 @@ public class LUTProcessorNode : BaseImageNode
         
         try super.init(from:decoder)
         
-        self.loadLUTFromInputValue()
+        try self.loadLUTFromInputValue()
     }
     
     override public func execute(renderer:GraphRenderer,
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.inputFilePathParam.valueDidChange
         {
-            self.loadLUTFromInputValue()
+            try self.loadLUTFromInputValue()
         }
 
         if self.imageInputPorts().first?.valueDidChange == true
         {
             if let inTex = self.inputImageTexture(at: 0),
-               let inTex2 = self.texture,
-               let outImage = renderer.newImage(withWidth: inTex.width, height: inTex.height)
+               let inTex2 = self.texture
             {
+                let outImage = try renderer.newImage(withWidth: inTex.width, height: inTex.height)
+
                 self.postMaterial.set(inTex, index: FragmentTextureIndex.Custom0)
                 self.postMaterial.set(inTex2, index: FragmentTextureIndex.Custom1)
                 
@@ -96,17 +98,29 @@ public class LUTProcessorNode : BaseImageNode
         }        
      }
     
-    private func loadLUTFromInputValue()
+    private func loadLUTFromInputValue() throws
     {
         if let path = self.inputFilePathParam.value,
            path.isEmpty == false && self.url != URL(string: path)
         {
-            self.url = URL(string: path)
-            
-            if FileManager.default.fileExists(atPath: self.url!.standardizedFileURL.path(percentEncoded: false) )
+            guard let url = URL(string: path) else
             {
-                self.texture = Self.loadLUT(url: self.url!, device: self.context.device)
+                throw FabricError(.execution(.fileNotFound),
+                                  severity: .recoverable,
+                                  message: "LUT file path is invalid: \(path)")
             }
+
+            self.url = url
+
+            guard FileManager.default.fileExists(atPath: url.standardizedFileURL.path(percentEncoded: false)) else
+            {
+                self.texture = nil
+                throw FabricError(.execution(.fileNotFound),
+                                  severity: .recoverable,
+                                  message: "LUT file not found: \(url.path)")
+            }
+
+            self.texture = try Self.loadLUT(url: url, device: self.context.device)
         }
         else
         {
@@ -162,15 +176,15 @@ public class LUTProcessorNode : BaseImageNode
         let expectedEntries = lutSize * lutSize * lutSize
         if lutData.count != expectedEntries * 4
         { // 4 floats per entry (RGBA)
-            throw NSError(domain: "CubeLUTLoader", code: 1, userInfo: [
-                NSLocalizedDescriptionKey: "Invalid LUT data size: expected \(expectedEntries), got \(lutData.count / 4)"
-            ])
+            throw FabricError(.execution(.syntax),
+                              severity: .recoverable,
+                              message: "Invalid LUT data size: expected \(expectedEntries), got \(lutData.count / 4)")
         }
         
         return (lutData, lutSize)
     }
 
-    static func create3DLUTTexture(device: MTLDevice, lutData: [Float], lutSize: Int) -> MTLTexture?
+    static func create3DLUTTexture(device: MTLDevice, lutData: [Float], lutSize: Int) throws -> MTLTexture
     {
         let descriptor = MTLTextureDescriptor()
         descriptor.textureType = .type3D
@@ -181,7 +195,9 @@ public class LUTProcessorNode : BaseImageNode
         descriptor.usage = .shaderRead
 
         guard let texture = device.makeTexture(descriptor: descriptor) else {
-            return nil
+            throw FabricError(.execution(.outOfMemory),
+                              severity: .recoverable,
+                              message: "Could not allocate \(lutSize)x\(lutSize)x\(lutSize) LUT texture")
         }
 
         // Assume lutData contains the 3D LUT in flattened RGBA format
@@ -200,18 +216,24 @@ public class LUTProcessorNode : BaseImageNode
     }
 
    
-    static func loadLUT(url:URL, device:MTLDevice) -> MTLTexture?
+    static func loadLUT(url:URL, device:MTLDevice) throws -> MTLTexture
     {
         do
         {
             let (lutData, lutSize) = try Self.loadCubeLUT(fileURL: url)
-            return Self.create3DLUTTexture(device: device, lutData: lutData, lutSize: lutSize)
+            return try Self.create3DLUTTexture(device: device, lutData: lutData, lutSize: lutSize)
         }
         catch
         {
-            print("Unable to load LUT:\(url.lastPathComponent) \(error.localizedDescription)")
+            if let fabricError = error as? any FabricErrorProtocol
+            {
+                throw fabricError
+            }
+
+            throw FabricError(.execution(.failed),
+                              severity: .recoverable,
+                              message: "Unable to load LUT: \(url.lastPathComponent)",
+                              underlyingError: error)
         }
-        
-        return nil
     }
 }

--- a/Fabric/Nodes/Image/Distort/KeypointDistortNode.swift
+++ b/Fabric/Nodes/Image/Distort/KeypointDistortNode.swift
@@ -73,6 +73,7 @@ public class KeypointDistortNode: BaseImageNode {
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         
         // If counts are diff, update backing
@@ -105,9 +106,10 @@ public class KeypointDistortNode: BaseImageNode {
         
         if self.imageInputPorts().first?.valueDidChange == true
         {
-            if let inTex = self.inputImageTexture(at: 0),
-               let outImage = renderer.newImage(withWidth: inTex.width, height: inTex.height)
+            if let inTex = self.inputImageTexture(at: 0)
             {
+                let outImage = try renderer.newImage(withWidth: inTex.width, height: inTex.height)
+
                 let minCount = min (self.refKeyPointStructBuffer.count, self.disKeyPointStructBuffer.count)
                 self.countBuffer.update(data: [UInt32(minCount)] )
                 

--- a/Fabric/Nodes/Image/ImageDimensions.swift
+++ b/Fabric/Nodes/Image/ImageDimensions.swift
@@ -93,6 +93,7 @@ public final class ImageDimensions: Node
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard self.inputImage.valueDidChange else { return }
 

--- a/Fabric/Nodes/Image/ImageProviderNode.swift
+++ b/Fabric/Nodes/Image/ImageProviderNode.swift
@@ -53,7 +53,7 @@ public class ImageProviderNode : Node, NodeFileLoadingProtocol
 
         super.init(context: context)
   
-        self.loadTextureFromInputValue()
+        try? self.loadTextureFromInputValue()
     }
     
     public required init(context: Satin.Context, fileURL: URL) throws
@@ -61,7 +61,7 @@ public class ImageProviderNode : Node, NodeFileLoadingProtocol
         self.textureLoader = MTKTextureLoader(device: context.device)
         super.init(context: context)
         self.setFileURL(fileURL)
-        self.loadTextureFromInputValue()
+        try self.loadTextureFromInputValue()
     }
     
     
@@ -76,17 +76,18 @@ public class ImageProviderNode : Node, NodeFileLoadingProtocol
 
         try super.init(from:decoder)
 
-        self.loadTextureFromInputValue()
+        try self.loadTextureFromInputValue()
     }
 
     override public func execute(renderer:GraphRenderer,
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.inputFilePathParam.valueDidChange
         {
-            self.loadTextureFromInputValue()
+            try self.loadTextureFromInputValue()
             
             if let texture = self.texture
             {
@@ -100,32 +101,49 @@ public class ImageProviderNode : Node, NodeFileLoadingProtocol
         }
      }
     
-    private func loadTextureFromInputValue()
+    private func loadTextureFromInputValue() throws
     {
         if let path = self.inputFilePathParam.value,
            path.isEmpty == false && self.url != URL(string: path)
         {
-            self.url = URL(string: path)
-
-            if FileManager.default.fileExists(atPath: self.url!.standardizedFileURL.path(percentEncoded: false) )
+            guard let url = URL(string: path) else
             {
-                
-                self.texture = try! self.textureLoader.newTexture(URL: self.url!, options: [
+                throw FabricError(.execution(.fileNotFound),
+                                  severity: .recoverable,
+                                  message: "Image file path is invalid: \(path)")
+            }
+
+            self.url = url
+
+            guard FileManager.default.fileExists(atPath: url.standardizedFileURL.path(percentEncoded: false)) else
+            {
+                self.texture = nil
+                throw FabricError(.execution(.fileNotFound),
+                                  severity: .recoverable,
+                                  message: "Image file not found: \(url.path)")
+            }
+
+            do
+            {
+                self.texture = try self.textureLoader.newTexture(URL: url, options: [
                     .generateMipmaps : true,
                     .allocateMipmaps : true,
                     .textureStorageMode : NSNumber( value: MTLStorageMode.shared.rawValue),
                     .SRGB : true,
                     .origin: MTKTextureLoader.Origin.topLeft,
                 ])
-                    
-                    //.newTexture(url: self.url!, options: [:])
-//                self.texture = loadHDR(device: self.context.device, url: self.url! )
             }
-            else
+            catch
             {
                 self.texture = nil
-                print("wtf")
+                throw FabricError(.execution(.failed),
+                                  severity: .recoverable,
+                                  message: "Could not load image file: \(url.path)",
+                                  underlyingError: error)
             }
+
+            //.newTexture(url: self.url!, options: [:])
+//                self.texture = loadHDR(device: self.context.device, url: self.url! )
         }
     }
 }

--- a/Fabric/Nodes/Image/ImageResampleNode.swift
+++ b/Fabric/Nodes/Image/ImageResampleNode.swift
@@ -168,6 +168,7 @@ public final class ImageResampleNode: Node
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard
             inputImage.valueDidChange
@@ -193,24 +194,24 @@ public final class ImageResampleNode: Node
             return
         }
 
-        guard
-            let destinationImage = renderer.newImage(
-                withWidth: outputWidth,
-                height: outputHeight,
-                format: sourceTexture.pixelFormat
-            ),
-            let computeEncoder = commandBuffer.makeComputeCommandEncoder()
-        else {
-            outputImage.send(nil)
-            return
+        let destinationImage = try renderer.newImage(
+            withWidth: outputWidth,
+            height: outputHeight,
+            format: sourceTexture.pixelFormat
+        )
+
+        guard let computeEncoder = commandBuffer.makeComputeCommandEncoder() else
+        {
+            throw FabricError(.execution(.gpu),
+                              severity: .recoverable,
+                              message: "Could not create Image Resample compute encoder")
         }
 
         destinationImage.texture.label = "Image Resample \(outputWidth)×\(outputHeight)"
         computeEncoder.label = "Image Resample – \(method.rawValue)"
 
-        let didEncode: Bool
         if method.usesSeparableFiltering {
-            didEncode = encodeSeparableResampling(
+            try encodeSeparableResampling(
                 method: method,
                 sourceTexture: sourceTexture,
                 destinationTexture: destinationImage.texture,
@@ -219,7 +220,7 @@ public final class ImageResampleNode: Node
             )
         }
         else {
-            didEncode = encodeDirectResampling(
+            try encodeDirectResampling(
                 method: method,
                 sourceTexture: sourceTexture,
                 destinationTexture: destinationImage.texture,
@@ -228,10 +229,6 @@ public final class ImageResampleNode: Node
         }
 
         computeEncoder.endEncoding()
-        guard didEncode else {
-            outputImage.send(nil)
-            return
-        }
 
         destinationImage.isFlipped = sourceImage.isFlipped
         outputImage.send(destinationImage)
@@ -246,10 +243,15 @@ public final class ImageResampleNode: Node
     private func encodeDirectResampling(method: ResamplingMethod,
                                         sourceTexture: MTLTexture,
                                         destinationTexture: MTLTexture,
-                                        computeEncoder: MTLComputeCommandEncoder) -> Bool
+                                        computeEncoder: MTLComputeCommandEncoder) throws
     {
         let pipeline = method == .nearest ? nearestPipeline : bilinearPipeline
-        guard let pipeline else { return false }
+        guard let pipeline else
+        {
+            throw FabricError(.execution(.gpu),
+                              severity: .recoverable,
+                              message: "Image Resample \(method.rawValue) compute pipeline is unavailable")
+        }
 
         computeEncoder.setComputePipelineState(pipeline)
         computeEncoder.setTexture(sourceTexture, index: 0)
@@ -260,16 +262,20 @@ public final class ImageResampleNode: Node
             width: destinationTexture.width,
             height: destinationTexture.height
         )
-        return true
     }
 
     private func encodeSeparableResampling(method: ResamplingMethod,
                                            sourceTexture: MTLTexture,
                                            destinationTexture: MTLTexture,
                                            renderer: GraphRenderer,
-                                           computeEncoder: MTLComputeCommandEncoder) -> Bool
+                                           computeEncoder: MTLComputeCommandEncoder) throws
     {
-        guard let horizontalPipeline, let verticalPipeline else { return false }
+        guard let horizontalPipeline, let verticalPipeline else
+        {
+            throw FabricError(.execution(.gpu),
+                              severity: .recoverable,
+                              message: "Image Resample separable compute pipelines are unavailable")
+        }
 
         var uniforms = ResamplingUniforms(method: method.shaderValue)
         computeEncoder.setBytes(
@@ -285,7 +291,7 @@ public final class ImageResampleNode: Node
                 pipeline: verticalPipeline,
                 computeEncoder: computeEncoder
             )
-            return true
+            return
         }
 
         if sourceTexture.height == destinationTexture.height {
@@ -295,16 +301,14 @@ public final class ImageResampleNode: Node
                 pipeline: horizontalPipeline,
                 computeEncoder: computeEncoder
             )
-            return true
+            return
         }
 
-        guard let intermediateImage = renderer.newImage(
+        let intermediateImage = try renderer.newImage(
             withWidth: destinationTexture.width,
             height: sourceTexture.height,
             format: sourceTexture.pixelFormat
-        ) else {
-            return false
-        }
+        )
         intermediateImage.texture.label = "Image Resample Horizontal Intermediate"
 
         encodeHorizontalPass(
@@ -320,7 +324,6 @@ public final class ImageResampleNode: Node
             pipeline: verticalPipeline,
             computeEncoder: computeEncoder
         )
-        return true
     }
 
     private func encodeHorizontalPass(sourceTexture: MTLTexture,

--- a/Fabric/Nodes/Image/LiveCode/LiveImageNode.swift
+++ b/Fabric/Nodes/Image/LiveCode/LiveImageNode.swift
@@ -34,6 +34,7 @@ public class LiveImageNode: BaseImageNode
     private(set) var shaderSource: String = LiveImageNode.defaultShaderSource()
     private var workspaceURL: URL?
     private var shaderFileURL: URL?
+    private var workspaceError: (any Error)?
 
     required init(context: Context, fileURL: URL) throws {
         try super.init(context: context, fileURL: fileURL)
@@ -90,7 +91,7 @@ public class LiveImageNode: BaseImageNode
             self.recompileAndResyncPorts()
         }
         catch {
-            print("LiveEffect failed to write shader source: \(error.localizedDescription)")
+            self.workspaceError = error
         }
     }
 
@@ -115,9 +116,10 @@ public class LiveImageNode: BaseImageNode
             try self.shaderSource.write(to: self.shaderFileURL!, atomically: true, encoding: .utf8)
             self.retargetMaterial(to: self.shaderFileURL!)
             self.recompileAndResyncPorts(shouldSynchronizePorts: shouldSynchronizePorts)
+            self.workspaceError = nil
         }
         catch {
-            print("LiveEffect workspace setup failed: \(error.localizedDescription)")
+            self.workspaceError = error
         }
     }
 
@@ -175,6 +177,33 @@ public class LiveImageNode: BaseImageNode
                 self.postSetupSynchronizePorts(allowReplace: false)
             }
         }
+    }
+
+    public override func execute(renderer: GraphRenderer,
+                                 executionInfo: GraphExecutionInfo,
+                                 renderPassDescriptor: MTLRenderPassDescriptor,
+                                 commandBuffer: MTLCommandBuffer)
+    throws
+    {
+        if let workspaceError
+        {
+            throw FabricError(.execution(.failed),
+                              severity: .recoverable,
+                              message: "Live Image workspace is unavailable",
+                              underlyingError: workspaceError)
+        }
+
+        if let shaderError = self.currentShaderErrorDescription()
+        {
+            throw FabricError(.execution(.syntax),
+                              severity: .recoverable,
+                              message: shaderError)
+        }
+
+        try super.execute(renderer: renderer,
+                          executionInfo: executionInfo,
+                          renderPassDescriptor: renderPassDescriptor,
+                          commandBuffer: commandBuffer)
     }
 
     private func syncDynamicParameterPortsFromMaterial() {

--- a/Fabric/Nodes/Image/Mask/ForegroundMaskNode.swift
+++ b/Fabric/Nodes/Image/Mask/ForegroundMaskNode.swift
@@ -82,6 +82,7 @@ public class ForegroundMaskNode: Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         
         if self.inputTexturePort.valueDidChange

--- a/Fabric/Nodes/Image/Mask/PersonSegmentationMaskNode.swift
+++ b/Fabric/Nodes/Image/Mask/PersonSegmentationMaskNode.swift
@@ -82,6 +82,7 @@ public class PersonSegmentationMaskNode: Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         
         if self.inputTexturePort.valueDidChange

--- a/Fabric/Nodes/Image/Mix/BlendNode.swift
+++ b/Fabric/Nodes/Image/Mix/BlendNode.swift
@@ -87,7 +87,7 @@ public class BlendNode: BaseImageNode
     override public func execute(renderer:GraphRenderer,
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
-                                 commandBuffer: MTLCommandBuffer)
+                                 commandBuffer: MTLCommandBuffer) throws
     {
         if self.inputMode.valueDidChange,
            let modeName = self.inputMode.value,
@@ -96,6 +96,6 @@ public class BlendNode: BaseImageNode
             self.setFileURL(url)
         }
 
-        super.execute(renderer: renderer, executionInfo: executionInfo, renderPassDescriptor: renderPassDescriptor, commandBuffer: commandBuffer)
+        try super.execute(renderer: renderer, executionInfo: executionInfo, renderPassDescriptor: renderPassDescriptor, commandBuffer: commandBuffer)
     }
 }

--- a/Fabric/Nodes/Image/Mix/BlendNode.swift
+++ b/Fabric/Nodes/Image/Mix/BlendNode.swift
@@ -25,8 +25,30 @@ public class BlendNode: BaseImageNode
     override public class var defaultImageInputCountHint: Int? { 2 }
 
     required init(context: Context) {
-        let url = Bundle.module.url(forResource: "Additive", withExtension: "metal", subdirectory: "EffectsTwoChannel/Mix")!
-        try! super.init(context: context, fileURL: url)
+        guard let url = Bundle.module.url(forResource: "Additive", withExtension: "metal", subdirectory: "EffectsTwoChannel/Mix") else
+        {
+            fatalError("Missing bundled Additive blend shader.")
+        }
+
+        do
+        {
+            try super.init(context: context, fileURL: url)
+        }
+        catch
+        {
+            fatalError("Could not initialize Blend node: \(error.localizedDescription)")
+        }
+    }
+
+    public override class func initWithContext(context: Context) throws -> Node {
+        guard let url = Bundle.module.url(forResource: "Additive", withExtension: "metal", subdirectory: "EffectsTwoChannel/Mix") else
+        {
+            throw FabricError(.loading(.resourceNotFound),
+                              severity: .fatal,
+                              message: "Missing bundled Additive blend shader.")
+        }
+
+        return try Self(context: context, fileURL: url)
     }
 
     required init(context: Context, fileURL: URL) throws {

--- a/Fabric/Nodes/Image/MovieProviderNode.swift
+++ b/Fabric/Nodes/Image/MovieProviderNode.swift
@@ -355,10 +355,11 @@ public class MovieProviderNode : Node, NodeFileLoadingProtocol
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.inputFilePathParam.valueDidChange
         {
-            loadAssetFromInputValue()
+            try loadAssetFromInputValue()
         }
 
         if self.inputPlayingParam.valueDidChange || self.inputRateParam.valueDidChange
@@ -397,16 +398,17 @@ public class MovieProviderNode : Node, NodeFileLoadingProtocol
         self.sendPlaybackInfo()
 
 #if FABRIC_HAP_ENABLED
-        if self.executeHapPath(renderer: renderer, hostTime: time) { return }
+        if try self.executeHapPath(renderer: renderer, hostTime: time) { return }
 #endif
 
         let itemTime = self.playerItemVideoOutput.itemTime(forHostTime: time)
 
         if self.playerItemVideoOutput.hasNewPixelBuffer(forItemTime: itemTime)
         {
-            if let pixelBuffer = self.playerItemVideoOutput.copyPixelBuffer(forItemTime: itemTime, itemTimeForDisplay: nil),
-               let image = renderer.newImage(fromPixelBuffer: pixelBuffer)
+            if let pixelBuffer = self.playerItemVideoOutput.copyPixelBuffer(forItemTime: itemTime, itemTimeForDisplay: nil)
             {
+                let image = try renderer.newImage(fromPixelBuffer: pixelBuffer)
+
                 self.outputTexturePort.send( image )
             }
         }
@@ -418,9 +420,10 @@ public class MovieProviderNode : Node, NodeFileLoadingProtocol
             // until playback resumes or another seek lands.
             self.needsEmitAfterSeek = false
             let pausedTime = item.currentTime()
-            if let pixelBuffer = self.playerItemVideoOutput.copyPixelBuffer(forItemTime: pausedTime, itemTimeForDisplay: nil),
-               let image = renderer.newImage(fromPixelBuffer: pixelBuffer)
+            if let pixelBuffer = self.playerItemVideoOutput.copyPixelBuffer(forItemTime: pausedTime, itemTimeForDisplay: nil)
             {
+                let image = try renderer.newImage(fromPixelBuffer: pixelBuffer)
+
                 self.outputTexturePort.send( image )
             }
         }
@@ -494,7 +497,7 @@ public class MovieProviderNode : Node, NodeFileLoadingProtocol
 #endif
     }
 
-    private func loadAssetFromInputValue()
+    private func loadAssetFromInputValue() throws
     {
         guard let path = self.inputFilePathParam.value,
               path.isEmpty == false
@@ -504,15 +507,22 @@ public class MovieProviderNode : Node, NodeFileLoadingProtocol
             return
         }
 
-        if self.url != URL(string: path)
+        guard let inputURL = URL(string: path) else
         {
-            self.url = URL(string: path)
+            self.unloadCurrentAsset()
+            throw FabricError(.execution(.fileNotFound),
+                              severity: .recoverable,
+                              message: "Movie file path is invalid: \(path)")
+        }
 
-            if let url,
-                FileManager.default.fileExists(atPath: url.standardizedFileURL.path(percentEncoded: false) )
+        if self.url != inputURL
+        {
+            self.url = inputURL
+
+            if FileManager.default.fileExists(atPath: inputURL.standardizedFileURL.path(percentEncoded: false))
             {
                 self.unloadCurrentAsset()
-                self.url = url
+                self.url = inputURL
 
 #if FABRIC_HAP_ENABLED
                 // New asset's clock is independent of the previous
@@ -526,21 +536,21 @@ public class MovieProviderNode : Node, NodeFileLoadingProtocol
                 self.didLogDXTSubBlockPadding = false
 #endif
 
-                self.asset = AVURLAsset(url: url, options: [AVURLAssetPreferPreciseDurationAndTimingKey: true])
+                self.asset = AVURLAsset(url: inputURL, options: [AVURLAssetPreferPreciseDurationAndTimingKey: true])
 
 
                 let playerItem = AVPlayerItem(asset: self.asset!, automaticallyLoadedAssetKeys: ["tracks", "metadata", "duration"])
 
                 playerItem.preferredForwardBufferDuration = 0.5
 #if FABRIC_HAP_ENABLED
-                if !self.attachHapOutput(to: playerItem, url: url)
+                if !self.attachHapOutput(to: playerItem, url: inputURL)
                 {
                     playerItem.add(self.playerItemVideoOutput)
-                    print("MovieProviderNode: AVPlayerItemVideoOutput path engaged for \"\(url.lastPathComponent)\"")
+                    print("MovieProviderNode: AVPlayerItemVideoOutput path engaged for \"\(inputURL.lastPathComponent)\"")
                 }
 #else
                 playerItem.add(self.playerItemVideoOutput)
-                print("MovieProviderNode: AVPlayerItemVideoOutput path engaged for \"\(url.lastPathComponent)\"")
+                print("MovieProviderNode: AVPlayerItemVideoOutput path engaged for \"\(inputURL.lastPathComponent)\"")
 #endif
 
                 self.observer = NotificationCenter.default.addObserver(forName: AVPlayerItem.didPlayToEndTimeNotification,
@@ -561,9 +571,10 @@ public class MovieProviderNode : Node, NodeFileLoadingProtocol
             }
             else
             {
-                let invalidURL = self.url
                 self.unloadCurrentAsset()
-                Self.log.error("Movie file not found at \(invalidURL?.path() ?? "<nil>", privacy: .public)")
+                throw FabricError(.execution(.fileNotFound),
+                                  severity: .recoverable,
+                                  message: "Movie file not found: \(inputURL.path)")
             }
         }
     }
@@ -585,7 +596,7 @@ public class MovieProviderNode : Node, NodeFileLoadingProtocol
     ///   - RGB fallback (HapY / HapM / HapH / HapA): decoder emits
     ///     RGBA bytes; copy into a CVPixelBuffer like the standard
     ///     AVPlayerItemVideoOutput path.
-    private func executeHapPath(renderer: GraphRenderer, hostTime: CFTimeInterval) -> Bool
+    private func executeHapPath(renderer: GraphRenderer, hostTime: CFTimeInterval) throws -> Bool
     {
         guard let hapOutput = self.hapOutput
         else { return false }
@@ -629,9 +640,10 @@ public class MovieProviderNode : Node, NodeFileLoadingProtocol
             self.outputTexturePort.send( image )
             emitted = true
         }
-        else if let pixelBuffer = Self.makePixelBuffer(fromHapFrame: frame),
-                let image = renderer.newImage(fromPixelBuffer: pixelBuffer)
+        else if let pixelBuffer = Self.makePixelBuffer(fromHapFrame: frame)
         {
+            let image = try renderer.newImage(fromPixelBuffer: pixelBuffer)
+
             self.outputTexturePort.send( image )
             emitted = true
         }

--- a/Fabric/Nodes/Image/ScreenCaptureProviderNode.swift
+++ b/Fabric/Nodes/Image/ScreenCaptureProviderNode.swift
@@ -107,6 +107,7 @@ public class ScreenCaptureProviderNode: Node
     }
 
     override public func stopExecution(renderer: GraphRenderer)
+    throws
     {
         self.stopStreamAndClear()
     }
@@ -122,15 +123,17 @@ public class ScreenCaptureProviderNode: Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.inputCaptureType.valueDidChange || self.inputCaptureSource.valueDidChange
         {
             self.scheduleRefreshAndReconfigure()
         }
 
-        if let pixelBuffer = streamOutputHandler.consumeLatestPixelBuffer(),
-           let image = renderer.newImage(fromPixelBuffer: pixelBuffer)
+        if let pixelBuffer = streamOutputHandler.consumeLatestPixelBuffer()
         {
+            let image = try renderer.newImage(fromPixelBuffer: pixelBuffer)
+
             self.outputTexturePort.send(image)
         }
     }

--- a/Fabric/Nodes/Image/SyphonClientNode.swift
+++ b/Fabric/Nodes/Image/SyphonClientNode.swift
@@ -45,6 +45,7 @@ public class SyphonClientNode : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.inputServerName.valueDidChange || self.inputServerAppName.valueDidChange,
            let inputServerName = self.inputServerName.value,

--- a/Fabric/Nodes/Image/SyphonServerNode.swift
+++ b/Fabric/Nodes/Image/SyphonServerNode.swift
@@ -61,6 +61,7 @@ public class SyphonServerNode : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.inputServerName.valueDidChange,
            let name = self.inputServerName.value

--- a/Fabric/Nodes/Image/TestCardProviderNode.swift
+++ b/Fabric/Nodes/Image/TestCardProviderNode.swift
@@ -159,14 +159,26 @@ public class TestCardProviderNode: Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         let width = max(1, self.inputWidth.value ?? 1920)
         let height = max(1, self.inputHeight.value ?? 1080)
 
-        guard let pipeline = self.computePipeline,
-              let outImage = renderer.newImage(withWidth: width, height: height),
-              let computeEncoder = commandBuffer.makeComputeCommandEncoder()
-        else { return }
+        guard let pipeline = self.computePipeline else
+        {
+            throw FabricError(.execution(.gpu),
+                              severity: .recoverable,
+                              message: "Test Card compute pipeline is unavailable")
+        }
+
+        let outImage = try renderer.newImage(withWidth: width, height: height)
+
+        guard let computeEncoder = commandBuffer.makeComputeCommandEncoder() else
+        {
+            throw FabricError(.execution(.gpu),
+                              severity: .recoverable,
+                              message: "Could not create Test Card compute encoder")
+        }
 
         let showText = self.inputText.value ?? true
         let textString = self.inputTextString.value ?? "Fabric"

--- a/Fabric/Nodes/Image/TextureCropNode.swift
+++ b/Fabric/Nodes/Image/TextureCropNode.swift
@@ -36,6 +36,7 @@ public class TextureCropNode: Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard let sourceImage = inputTexture.value else { return }
 
@@ -45,7 +46,7 @@ public class TextureCropNode: Node
         let w = max(1, min(inputCropWidth.value ?? 1920, srcTex.width - x))
         let h = max(1, min(inputCropHeight.value ?? 1080, srcTex.height - y))
 
-        guard let outImage = renderer.newImage(withWidth: w, height: h, format: sourceImage.texture.pixelFormat) else { return }
+        let outImage = try renderer.newImage(withWidth: w, height: h, format: sourceImage.texture.pixelFormat)
         // For flipped sources (e.g. Syphon/OpenGL with bottom-left origin),
         // the visual top of the image is stored at the bottom of texture
         // memory. Invert the Y coordinate so crop regions specified in
@@ -54,7 +55,12 @@ public class TextureCropNode: Node
             y = max(0, srcTex.height - y - h)
         }
 
-        guard let encoder = commandBuffer.makeBlitCommandEncoder() else { return }
+        guard let encoder = commandBuffer.makeBlitCommandEncoder() else
+        {
+            throw FabricError(.execution(.gpu),
+                              severity: .recoverable,
+                              message: "Could not create Texture Crop blit encoder")
+        }
         encoder.copy(
             from: srcTex,
             sourceSlice: 0, sourceLevel: 0,

--- a/Fabric/Nodes/NodeRegistry.swift
+++ b/Fabric/Nodes/NodeRegistry.swift
@@ -28,14 +28,14 @@ public class NodeRegistry
         try loadPluginsIfNeeded()
     }
 
-    public func nodeClass(for nodeName: String) -> (Node.Type)?
+    public func nodeClass(pluginID: String, nodeID: String) -> (Node.Type)?
     {
-        if let legacyClass = self.legacyNodeClassLookup[nodeName]
+        if let legacyClass = self.legacyNodeClassLookup[PluginQualifiedNodeID(pluginID: pluginID, nodeID: nodeID)]
         {
             return legacyClass
         }
 
-        return PluginLoader.shared.nodeClass(for: nodeName)
+        return PluginLoader.shared.nodeClass(pluginID: pluginID, nodeID: nodeID)
     }
 
     /// Returns the first drop-target node class whose `supportedContentTypes`
@@ -71,18 +71,48 @@ public class NodeRegistry
 
     private var nodeFileLoadingClasses: [(any NodeFileLoadingProtocol.Type)]
     {
-        PluginLoader.shared.pluginNodeClasses.values.compactMap { entry in
-            entry.nodeClass as? any NodeFileLoadingProtocol.Type
+        PluginLoader.shared.pluginNodeClasses.values.compactMap { nodeClass in
+            nodeClass as? any NodeFileLoadingProtocol.Type
         }
     }
 
-    private lazy var legacyNodeClassLookup: [String: Node.Type] = {
-        var result: [String: Node.Type] = [:]
+    public func qualifiedNodeID(for nodeClass: Node.Type) -> PluginQualifiedNodeID?
+    {
+        PluginLoader.shared.qualifiedNodeID(for: nodeClass)
+    }
+
+    public func validatePluginRequirements(_ requirements: [PluginRequirement]) throws
+    {
+        for requirement in requirements
+        {
+            guard let pluginInfo = PluginLoader.shared.loadedPlugins[requirement.id] else
+            {
+                throw FabricError(.loading(.pluginNotFound),
+                                  severity: .fatal,
+                                  message: "Required plugin '\(requirement.id)' is not loaded")
+            }
+
+            guard Self.version(pluginInfo.version, isAtLeast: requirement.version) else
+            {
+                throw FabricError(.loading(.pluginLoadFailed),
+                                  severity: .fatal,
+                                  message: "Required plugin '\(requirement.id)' needs version \(requirement.version ?? ""), but loaded version is \(pluginInfo.version ?? "unknown")")
+            }
+        }
+    }
+
+    private lazy var legacyNodeClassLookup: [PluginQualifiedNodeID: Node.Type] = {
+        var result: [PluginQualifiedNodeID: Node.Type] = [:]
+
+        func registerCoreAlias(_ nodeID: String, _ nodeClass: Node.Type)
+        {
+            result[PluginQualifiedNodeID(pluginID: PluginLoader.coreNodesPluginID, nodeID: nodeID)] = nodeClass
+        }
 
         // Legacy class-name aliases: old saved graphs used SatinGeometry in generic type params.
         // Both module-qualified and bare forms are covered since Swift's output can vary.
-        result["PassThroughNode<SatinGeometry>"] = PassThroughNode<Geometry>.self
-        result["PassThroughNode<Satin.SatinGeometry>"] = PassThroughNode<Geometry>.self
+        registerCoreAlias("PassThroughNode<SatinGeometry>", PassThroughNode<Geometry>.self)
+        registerCoreAlias("PassThroughNode<Satin.SatinGeometry>", PassThroughNode<Geometry>.self)
 
         // Structural array nodes were previously generic; old docs decode to type-agnostic versions.
         let agnosticSuffixes = [
@@ -99,14 +129,14 @@ public class NodeRegistry
 
         for suffix in agnosticSuffixes
         {
-            result["ArrayQueueNode<\(suffix)>"] = ArrayQueueNode.self
-            result["ArrayFirstValueNode<\(suffix)>"] = ArrayFirstValueNode.self
-            result["ArrayLastValueNode<\(suffix)>"] = ArrayLastValueNode.self
-            result["ArrayIndexValueNode<\(suffix)>"] = ArrayIndexValueNode.self
-            result["ArrayCountNode<\(suffix)>"] = ArrayCountNode.self
-            result["ArrayAppendNode<\(suffix)>"] = ArrayAppendNode.self
-            result["ArrayReplaceValueAtIndexNode<\(suffix)>"] = ArrayReplaceValueAtIndexNode.self
-            result["ArraySplitAtIndexNode<\(suffix)>"] = ArraySplitAtIndexNode.self
+            registerCoreAlias("ArrayQueueNode<\(suffix)>", ArrayQueueNode.self)
+            registerCoreAlias("ArrayFirstValueNode<\(suffix)>", ArrayFirstValueNode.self)
+            registerCoreAlias("ArrayLastValueNode<\(suffix)>", ArrayLastValueNode.self)
+            registerCoreAlias("ArrayIndexValueNode<\(suffix)>", ArrayIndexValueNode.self)
+            registerCoreAlias("ArrayCountNode<\(suffix)>", ArrayCountNode.self)
+            registerCoreAlias("ArrayAppendNode<\(suffix)>", ArrayAppendNode.self)
+            registerCoreAlias("ArrayReplaceValueAtIndexNode<\(suffix)>", ArrayReplaceValueAtIndexNode.self)
+            registerCoreAlias("ArraySplitAtIndexNode<\(suffix)>", ArraySplitAtIndexNode.self)
         }
 
         // Vector compose/decompose nodes were previously generic; old docs map to consolidated versions.
@@ -114,14 +144,35 @@ public class NodeRegistry
 
         for suffix in vectorSuffixes
         {
-            result["ComposeVectorNode<\(suffix)>"] = ComposeVectorNode.self
-            result["DecomposeVectorNode<\(suffix)>"] = DecomposeVectorNode.self
-            result["ComposeVectorArrayNode<\(suffix)>"] = ComposeVectorArrayNode.self
-            result["DecomposeVectorArrayNode<\(suffix)>"] = DecomposeVectorArrayNode.self
+            registerCoreAlias("ComposeVectorNode<\(suffix)>", ComposeVectorNode.self)
+            registerCoreAlias("DecomposeVectorNode<\(suffix)>", DecomposeVectorNode.self)
+            registerCoreAlias("ComposeVectorArrayNode<\(suffix)>", ComposeVectorArrayNode.self)
+            registerCoreAlias("DecomposeVectorArrayNode<\(suffix)>", DecomposeVectorArrayNode.self)
         }
 
         return result
     }()
+
+    private static func version(_ loadedVersion: String?, isAtLeast requiredVersion: String?) -> Bool
+    {
+        guard let requiredVersion else { return true }
+        guard let loadedVersion else { return false }
+
+        let loadedComponents = loadedVersion.split(separator: ".").map { Int(String($0)) ?? 0 }
+        let requiredComponents = requiredVersion.split(separator: ".").map { Int(String($0)) ?? 0 }
+        let count = max(loadedComponents.count, requiredComponents.count)
+
+        for index in 0..<count
+        {
+            let loaded = index < loadedComponents.count ? loadedComponents[index] : 0
+            let required = index < requiredComponents.count ? requiredComponents[index] : 0
+
+            if loaded > required { return true }
+            if loaded < required { return false }
+        }
+
+        return true
+    }
 
     private func loadPluginsIfNeeded() throws
     {

--- a/Fabric/Nodes/NodeRegistry.swift
+++ b/Fabric/Nodes/NodeRegistry.swift
@@ -11,16 +11,25 @@ import UniformTypeIdentifiers
 
 public class NodeRegistry
 {
-    public static let shared = NodeRegistry()
+    private static let sharedResult = Result { try NodeRegistry() }
 
     private let pluginLoadLock = NSRecursiveLock()
 
-    init() {}
+    public static var shared: NodeRegistry
+    {
+        get throws
+        {
+            try sharedResult.get()
+        }
+    }
+
+    init() throws
+    {
+        try loadPluginsIfNeeded()
+    }
 
     public func nodeClass(for nodeName: String) -> (Node.Type)?
     {
-        self.loadPluginsIfNeeded()
-
         if let legacyClass = self.legacyNodeClassLookup[nodeName]
         {
             return legacyClass
@@ -35,8 +44,6 @@ public class NodeRegistry
     /// `ImageProviderNode` whose list includes `.image`.
     public func dropTargetNodeClass(for contentType: UTType) -> (any NodeFileLoadingProtocol.Type)?
     {
-        self.loadPluginsIfNeeded()
-
         for dropNodeClass in self.nodeFileLoadingClasses
         {
             if dropNodeClass.supportedContentTypes.contains(where: { contentType.conforms(to: $0) })
@@ -50,18 +57,15 @@ public class NodeRegistry
 
     /// All UTTypes accepted by drop-target nodes, for use with drop destination handlers.
     public lazy private(set) var allSupportedDropTypes: [UTType] = {
-        self.loadPluginsIfNeeded()
         return self.nodeFileLoadingClasses.flatMap { $0.supportedContentTypes }
     }()
 
     public lazy private(set) var availableNodes: [NodeClassWrapper] = {
-        self.loadPluginsIfNeeded()
         return PluginLoader.shared.pluginNodeWrappers
     }()
 
     public var pluginLoadErrors: [PluginLoadError]
     {
-        self.loadPluginsIfNeeded()
         return PluginLoader.shared.loadErrors
     }
 
@@ -119,11 +123,11 @@ public class NodeRegistry
         return result
     }()
 
-    private func loadPluginsIfNeeded()
+    private func loadPluginsIfNeeded() throws
     {
         pluginLoadLock.lock()
         defer { pluginLoadLock.unlock() }
 
-        PluginLoader.shared.loadAllPlugins()
+        try PluginLoader.shared.loadAllPlugins()
     }
 }

--- a/Fabric/Nodes/NodeRegistry.swift
+++ b/Fabric/Nodes/NodeRegistry.swift
@@ -4,32 +4,29 @@
 //
 //  Created by Anton Marini on 4/26/25.
 //
-import simd
+
 import Foundation
 import Satin
 import UniformTypeIdentifiers
 
-public class NodeRegistry {
-
+public class NodeRegistry
+{
     public static let shared = NodeRegistry()
 
-    init() {
-        // Swift `lazy var` initialization is not thread-safe. Force-build
-        // the render-path lookup tables here so `shared`'s one-time init
-        // (which has dispatch_once semantics) is the only writer;
-        // concurrent readers — e.g. two graphs building nodes on their
-        // own render queues — then only ever see initialized storage.
-        // `availableNodes`/`allSupportedDropTypes` stay lazy: they scan
-        // bundle shaders and every node class's static metadata, and are
-        // only read from the main-thread UI. Forcing them here deadlocks
-        // when the first registry access is on a render queue the main
-        // thread is blocked waiting on.
-        _ = self.nodesClassLookup
-        _ = self.nodeFileLoadingClasses
-    }
+    private let pluginLoadLock = NSRecursiveLock()
 
-    public func nodeClass(for nodeName: String) -> (Node.Type)? {
-        return self.nodesClassLookup[nodeName]
+    init() {}
+
+    public func nodeClass(for nodeName: String) -> (Node.Type)?
+    {
+        self.loadPluginsIfNeeded()
+
+        if let legacyClass = self.legacyNodeClassLookup[nodeName]
+        {
+            return legacyClass
+        }
+
+        return PluginLoader.shared.nodeClass(for: nodeName)
     }
 
     /// Returns the first drop-target node class whose `supportedContentTypes`
@@ -38,468 +35,95 @@ public class NodeRegistry {
     /// `ImageProviderNode` whose list includes `.image`.
     public func dropTargetNodeClass(for contentType: UTType) -> (any NodeFileLoadingProtocol.Type)?
     {
+        self.loadPluginsIfNeeded()
+
         for dropNodeClass in self.nodeFileLoadingClasses
         {
-            if dropNodeClass.supportedContentTypes.contains(where: { contentType.conforms(to: $0) } )
+            if dropNodeClass.supportedContentTypes.contains(where: { contentType.conforms(to: $0) })
             {
                 return dropNodeClass
             }
         }
+
         return nil
     }
-    
+
     /// All UTTypes accepted by drop-target nodes, for use with drop destination handlers.
     public lazy private(set) var allSupportedDropTypes: [UTType] = {
-        let dropClasses = self.nodeFileLoadingClasses
-        return dropClasses.flatMap ( { $0.supportedContentTypes } )
-    }()
-    
-    
-    public lazy private(set) var availableNodes:[NodeClassWrapper] = {
-        self.nodesClasses.map( { NodeClassWrapper(nodeClass: $0) } ) + self.dynamicEffectNodes
+        self.loadPluginsIfNeeded()
+        return self.nodeFileLoadingClasses.flatMap { $0.supportedContentTypes }
     }()
 
-    private lazy var nodesClassLookup: [String: Node.Type] =  {
-        var result = self.nodesClasses.reduce(into: [String: Node.Type]()) { result, nodeClass in
-            result[String(describing: nodeClass)] = nodeClass
+    public lazy private(set) var availableNodes: [NodeClassWrapper] = {
+        self.loadPluginsIfNeeded()
+        return PluginLoader.shared.pluginNodeWrappers
+    }()
+
+    public var pluginLoadErrors: [PluginLoadError]
+    {
+        self.loadPluginsIfNeeded()
+        return PluginLoader.shared.loadErrors
+    }
+
+    private var nodeFileLoadingClasses: [(any NodeFileLoadingProtocol.Type)]
+    {
+        PluginLoader.shared.pluginNodeClasses.values.compactMap { entry in
+            entry.nodeClass as? any NodeFileLoadingProtocol.Type
         }
+    }
+
+    private lazy var legacyNodeClassLookup: [String: Node.Type] = {
+        var result: [String: Node.Type] = [:]
+
         // Legacy class-name aliases: old saved graphs used SatinGeometry in generic type params.
         // Both module-qualified and bare forms are covered since Swift's output can vary.
         result["PassThroughNode<SatinGeometry>"] = PassThroughNode<Geometry>.self
         result["PassThroughNode<Satin.SatinGeometry>"] = PassThroughNode<Geometry>.self
 
         // Structural array nodes were previously generic; old docs decode to type-agnostic versions.
-        let agnosticSuffixes = ["Bool", "Int", "Float", "String",
-                                "simd_float2", "simd_float3", "simd_float4", "simd_float4x4",
-                                "FabricImage"]
-        for suffix in agnosticSuffixes {
-            result["ArrayQueueNode<\(suffix)>"]               = ArrayQueueNode.self
-            result["ArrayFirstValueNode<\(suffix)>"]          = ArrayFirstValueNode.self
-            result["ArrayLastValueNode<\(suffix)>"]           = ArrayLastValueNode.self
-            result["ArrayIndexValueNode<\(suffix)>"]          = ArrayIndexValueNode.self
-            result["ArrayCountNode<\(suffix)>"]               = ArrayCountNode.self
-            result["ArrayAppendNode<\(suffix)>"]              = ArrayAppendNode.self
+        let agnosticSuffixes = [
+            "Bool",
+            "Int",
+            "Float",
+            "String",
+            "simd_float2",
+            "simd_float3",
+            "simd_float4",
+            "simd_float4x4",
+            "FabricImage",
+        ]
+
+        for suffix in agnosticSuffixes
+        {
+            result["ArrayQueueNode<\(suffix)>"] = ArrayQueueNode.self
+            result["ArrayFirstValueNode<\(suffix)>"] = ArrayFirstValueNode.self
+            result["ArrayLastValueNode<\(suffix)>"] = ArrayLastValueNode.self
+            result["ArrayIndexValueNode<\(suffix)>"] = ArrayIndexValueNode.self
+            result["ArrayCountNode<\(suffix)>"] = ArrayCountNode.self
+            result["ArrayAppendNode<\(suffix)>"] = ArrayAppendNode.self
             result["ArrayReplaceValueAtIndexNode<\(suffix)>"] = ArrayReplaceValueAtIndexNode.self
-            result["ArraySplitAtIndexNode<\(suffix)>"]        = ArraySplitAtIndexNode.self
+            result["ArraySplitAtIndexNode<\(suffix)>"] = ArraySplitAtIndexNode.self
         }
 
         // Vector compose/decompose nodes were previously generic; old docs map to consolidated versions.
         let vectorSuffixes = ["simd_float2", "simd_float3", "simd_float4"]
-        for suffix in vectorSuffixes {
-            result["ComposeVectorNode<\(suffix)>"]       = ComposeVectorNode.self
-            result["DecomposeVectorNode<\(suffix)>"]     = DecomposeVectorNode.self
-            result["ComposeVectorArrayNode<\(suffix)>"]  = ComposeVectorArrayNode.self
+
+        for suffix in vectorSuffixes
+        {
+            result["ComposeVectorNode<\(suffix)>"] = ComposeVectorNode.self
+            result["DecomposeVectorNode<\(suffix)>"] = DecomposeVectorNode.self
+            result["ComposeVectorArrayNode<\(suffix)>"] = ComposeVectorArrayNode.self
             result["DecomposeVectorArrayNode<\(suffix)>"] = DecomposeVectorArrayNode.self
         }
 
         return result
     }()
-    
-    private lazy var nodeFileLoadingClasses: [(any NodeFileLoadingProtocol.Type)] =  {
-        self.nodesClasses.compactMap( { $0 as? any NodeFileLoadingProtocol.Type } )
-    }()
-    
-    private var nodesClasses: [Node.Type] {
-        self.cameraNodeClasses
-        + self.lightNodeClasses
-        + self.objectNodeClasses
-        + self.geometryNodeClasses
-        + self.materialNodeClasses
-        + self.textureNodeClasses
-        + self.parameterNodeClasses
-        + self.ioNodeClasses
-        + self.macroNodeClasses
-        + self.utilityClasses
-    }
-    
-    private var cameraNodeClasses: [Node.Type] = [
-         PerspectiveCameraNode.self,
-         OrthographicCameraNode.self,
-    ]
-    
-    private var lightNodeClasses: [Node.Type] = [
-        DirectionalLightNode.self,
-        PointLightNode.self,
-        SpotLightNode.self,
-    ]
-    
-    private var objectNodeClasses: [Node.Type] = [
-        // Objects / Rendering
-        MeshNode.self,
-        ModelMeshNode.self,
-        InstancedMeshNode.self,
-        InstancedModelMeshNode.self,
-        EnvironmentSkyboxNode.self,
-        ImageMeshNode.self,
-    ]
-    
-    private var geometryNodeClasses: [Node.Type] = [ // Geometry
-        PassThroughNode<Geometry>.self,
-        PlaneGeometryNode.self,
-        PerspectiveQuadGeometryNode.self,
-        RoundRectGeometryNode.self,
-        TriangleGeometryNode.self,
-        CircleGeometryNode.self,
-        ArcGeometryNode.self,
-        ConeGeometryNode.self,
-        BoxGeometryNode.self,
-        RoundBoxGeometryNode.self,
-        SphereGeometryNode.self,
-        IcoSphereGeometryNode.self,
-        CapsuleGeometryNode.self,
-        TubeGeometryNode.self,
-        TorusGeometryNode.self,
-        CycloramaGeometryNode.self,
-//        SkyboxGeometryNode.self,
-        TesselatedTextGeometryNode.self,
-        ExtrudedTextGeometryNode.self,
-        PixelArrayToGeometryNode.self,
-        SuperShapeGeometryNode.self,
-        MobiusStripGeometryNode.self,
-        HelicoidGeometryNode.self,
-        SuperellipsoidGeometryNode.self,
-        KleinBottleGeometryNode.self,
-        CatenoidGeometryNode.self,
-        ParaboloidGeometryNode.self,
-        EnneperSurfaceGeometryNode.self,
-        PseudosphereGeometryNode.self,
-        DupinCyclideGeometryNode.self,
-        RomanSurfaceGeometryNode.self,
-        CrossCapGeometryNode.self,
-        BourSurfaceGeometryNode.self,
-        BreatherSurfaceGeometryNode.self,
-        DiniSurfaceGeometryNode.self,
-        MathExpressionParametricGeometryNode.self,
-    ]
-        
-    private var materialNodeClasses:[Node.Type] = [
-        // Materials
-        PassThroughNode<Material>.self,
-        BasicColorMaterialNode.self,
-        UVMaterialNode.self,
-        BasicTextureMaterialNode.self,
-        BasicDiffuseMaterialNode.self,
-//        SkyboxMaterialNode.self,
-        DepthMaterialNode.self,
-        //ShadowMaterialNode.self,
-        StandardMaterialNode.self,
-        PBRMaterialNode.self,
-        DisplacementMaterialNode.self,
-    ]
-    
-    private var textureNodeClasses:[Node.Type] {
-        var classes: [Node.Type] = [
-            PassThroughNode<FabricImage>.self,
-            MovieProviderNode.self,
-            CameraProviderNode.self,
-            ImageProviderNode.self,
-            TestCardProviderNode.self,
-        ]
-        #if os(macOS)
-        classes.append(ScreenCaptureProviderNode.self)
-        #endif
-        #if FABRIC_SYPHON_ENABLED
-        classes.append(contentsOf: [
-            SyphonClientNode.self,
-            SyphonServerNode.self,
-        ])
-        #endif
-        classes.append(contentsOf: [
-            LiveImageNode.self,
-            DepthOfFieldNode.self,
-            GaussianBlurNode.self,
-            GaussianBlurChannelsNode.self,
-            MotionBlurNode.self,
-            PostProcessMotionBlurNode.self,
-            ZoomBlurNode.self,
-            ForegroundMaskNode.self,
-            PersonSegmentationMaskNode.self,
-            FacePoseAnalysisNode.self,
-            HandPoseAnalysisNode.self,
-            LucasKanadeOpticalFlowNode.self,
-            DCTNode.self,
-            InverseDCTNode.self,
-            LocalVLMNode.self,
-            ContourPathNode.self,
-            MetalFXSpatialUpsample2xNode.self,
-            KeypointDistortNode.self,
-            LUTProcessorNode.self,
-            BlendNode.self,
-            TextureCropNode.self,
-            ImageResampleNode.self,
-        ])
-        return classes
-    }
 
-    // Sub Patch Iterator, Replicate etc
-    private var macroNodeClasses:[Node.Type] = [
-        SubgraphNode.self,
-        DeferredSubgraphNode.self,
-        IteratorNode.self,
-        IteratorInfoNode.self,
-        EnvironmentNode.self,
-    ]
-    
-    private var dynamicEffectNodes:[NodeClassWrapper]
+    private func loadPluginsIfNeeded()
     {
-        let bundle = Bundle.module
+        pluginLoadLock.lock()
+        defer { pluginLoadLock.unlock() }
 
-        var nodes:[NodeClassWrapper] = []
-
-        for imageEffectType in Node.NodeType.ImageType.allCases
-        {
-            let singleChannelEffects = "Effects/\(imageEffectType.rawValue)"
-            let twoChannelEffects = "EffectsTwoChannel/\(imageEffectType.rawValue)"
-            let threeChannelEffects = "EffectsThreeChannel/\(imageEffectType.rawValue)"
-            
-            let computeSubdir = "Compute/\(imageEffectType.rawValue)"
-            
-            if
-               let singleChannelEffects = bundle.urls(forResourcesWithExtension: "metal", subdirectory:singleChannelEffects),
-               let twoChannelEffects = bundle.urls(forResourcesWithExtension: "metal", subdirectory:twoChannelEffects),
-               let threeChannelEffects = bundle.urls(forResourcesWithExtension: "metal", subdirectory:threeChannelEffects),
-               let singleChannelComputeEffects = bundle.urls(forResourcesWithExtension: "metal", subdirectory:computeSubdir)
-            {
-                for fileURL in singleChannelEffects
-                {
-                    let desc = self.shaderDescription(from: fileURL) ?? BaseImageNode.nodeDescription
-                    let node = NodeClassWrapper(nodeClass: BaseImageNode.self,
-                                                nodeType: .Image(imageType: imageEffectType),
-                                                fileURL: fileURL,
-                                                nodeName:self.fileURLToName(fileURL: fileURL),
-                                                nodeDescription: desc)
-                    nodes.append( node )
-                }
-
-                for fileURL in twoChannelEffects
-                {
-                    let desc = self.shaderDescription(from: fileURL) ?? BaseImageNode.nodeDescription
-                    let node = NodeClassWrapper(nodeClass: BaseImageNode.self,
-                                                nodeType: .Image(imageType: imageEffectType),
-                                                fileURL: fileURL,
-                                                nodeName:self.fileURLToName(fileURL: fileURL),
-                                                nodeDescription: desc)
-                    nodes.append( node )
-                }
-
-                for fileURL in threeChannelEffects
-                {
-                    let desc = self.shaderDescription(from: fileURL) ?? BaseImageNode.nodeDescription
-                    let node = NodeClassWrapper(nodeClass: BaseImageNode.self,
-                                                nodeType: .Image(imageType: imageEffectType),
-                                                fileURL: fileURL,
-                                                nodeName:self.fileURLToName(fileURL: fileURL),
-                                                nodeDescription: desc)
-                    nodes.append( node )
-                }
-
-                for fileURL in singleChannelComputeEffects
-                {
-                    let desc = self.shaderDescription(from: fileURL) ?? BaseTextureComputeProcessorNode.nodeDescription
-                    let node = NodeClassWrapper(nodeClass: BaseTextureComputeProcessorNode.self,
-                                                nodeType: .Image(imageType: imageEffectType),
-                                                fileURL: fileURL,
-                                                nodeName:self.fileURLToName(fileURL: fileURL),
-                                                nodeDescription: desc)
-                    nodes.append( node )
-                }
-            }
-        }
-        
-        // Not quite a localizedStandardCompare but whatever
-        nodes.sort { a, b in
-            
-            return a.nodeName < b.nodeName
-        }
-        return nodes
-    }
-    
-    private func fileURLToName(fileURL:URL) -> String {
-        let nodeName =  fileURL.deletingPathExtension().lastPathComponent.replacing("ImageNode", with: "")
-
-        return nodeName.titleCase
-    }
-
-    /// Parse a `// description: ...` comment from a shader file's first few lines.
-    private func shaderDescription(from fileURL: URL) -> String? {
-        guard let data = try? Data(contentsOf: fileURL, options: .mappedIfSafe),
-              let source = String(data: data, encoding: .utf8) else { return nil }
-        // Scan only the first 20 lines for efficiency
-        for line in source.split(separator: "\n", maxSplits: 20, omittingEmptySubsequences: false) {
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
-            if trimmed.hasPrefix("// description:") {
-                let desc = trimmed.dropFirst("// description:".count).trimmingCharacters(in: .whitespaces)
-                return desc.isEmpty ? nil : desc
-            }
-        }
-        return nil
-    }
-    
-    private var parameterNodeClasses: [Node.Type] = [
-        // Numeric, type-agnostic value operations.
-        DistanceNode.self,
-        EasingNode.self,
-        TweenNode.self,
-        RepeatNode.self,
-        RippleRepeatNode.self,
-        PairwiseDistanceArrayNode.self,
-        ArrayRangeInterpolateNode.self,
-        ArrayResampleTypeAgnosticNode.self,
-
-        // Boolean.
-        PassThroughNode<Bool>.self,
-        BooleanLogicNode.self,
-
-        // Number and index.
-        PassThroughNode<Float>.self,
-        PassThroughNode<Int>.self,
-        CurrentTimeNode.self,
-        SystemTimeNode.self,
-        TimestampNode.self,
-        TimelineNode.self,
-        NumberUnaryOperator.self,
-        NumberBinaryOperator.self,
-        NumberLogicOperator.self,
-        NumberRoundNode.self,
-        NumberClampNode.self,
-        NumberRemapNode.self,
-        NumberIntegralNode.self,
-        NumberSmoothNode.self,
-        MathExpressionNode.self,
-        GradientNoiseNode.self,
-        AudioSpectrumNode.self,
-
-        // Vector: scalar/vector operations first, vector-array operations last.
-        PassThroughNode<simd_float2>.self,
-        PassThroughNode<simd_float3>.self,
-        PassThroughNode<simd_float4>.self,
-        ComposeVectorNode.self,
-        DecomposeVectorNode.self,
-        ComposeVectorArrayNode.self,
-        DecomposeVectorArrayNode.self,
-
-        // Orientation: single orientation operations first, orientation-array operations last.
-        PassThroughNode<simd_quatf>.self,
-        ComposeOrientationNode.self,
-        DecomposeOrientationNode.self,
-        ComposeOrientationArrayNode.self,
-        DecomposeOrientationArrayNode.self,
-
-        // Transform: single transform operations first, transform-array operations last.
-        PassThroughNode<simd_float4x4>.self,
-        ComposeTransformNode.self,
-        DecomposeTransformNode.self,
-        TranslateTransformNode.self,
-        RotateTransformNode.self,
-        ScaleTransformNode.self,
-        TransposeTransformNode.self,
-        InvertTransformNode.self,
-        ComposeTransformArrayNode.self,
-        DecomposeTransformArrayNode.self,
-        GeometryToTransformArrayNode.self,
-
-        // Color.
-        ColorPassThroughNode.self,
-        MakeColorNode.self,
-
-        // String.
-        PassThroughNode<String>.self,
-        StringTrimNode.self,
-        StringLengthNode.self,
-        StringRangeNode.self,
-        StringWrapNode.self,
-        StringCaseNode.self,
-        StringComparisonNode.self,
-        StringFormatterNode.self,
-        StringScannerNode.self,
-        StringJoinNode.self,
-        StringSplitNode.self,
-        StringDifferenceNode.self,
-        TimestampFormatterNode.self,
-        TimecodeFormatterNode.self,
-//        ConvertToStringNode.self,
-        LocalLLMNode.self,
-        DirectoryScannerNode.self,
-        TextFileLoaderNode.self,
-
-        // Dictionary.
-        PassThroughNode<Dictionary<String, PortValue>>.self,
-        PassThroughNode<Dictionary<String, Bool>>.self,
-        PassThroughNode<Dictionary<String, Int>>.self,
-        PassThroughNode<Dictionary<String, Float>>.self,
-        PassThroughNode<Dictionary<String, String>>.self,
-        PassThroughNode<Dictionary<String, simd_float2>>.self,
-        PassThroughNode<Dictionary<String, simd_float3>>.self,
-        PassThroughNode<Dictionary<String, simd_float4>>.self,
-        PassThroughNode<Dictionary<String, simd_quatf>>.self,
-        PassThroughNode<Dictionary<String, simd_float4x4>>.self,
-        PassThroughNode<Dictionary<String, Geometry>>.self,
-        PassThroughNode<Dictionary<String, Material>>.self,
-        PassThroughNode<Dictionary<String, FabricImage>>.self,
-        ComposeDictionaryNode.self,
-        DecomposeDictionaryNode.self,
-        DictionarySetValueForKeyNode.self,
-        DictionaryValueForKeyNode.self,
-        DictionaryCountNode.self,
-        DictionaryHasKeyNode.self,
-        DictionaryRemoveKeyNode.self,
-        DictionaryMergeNode.self,
-        DictionaryFromJSONStringNode.self,
-
-        // Array: generic structure nodes, then more specialized array generators/processors.
-        ArrayCountNode.self,
-        ArrayFirstValueNode.self,
-        ArrayLastValueNode.self,
-        ArrayIndexValueNode.self,
-        ArrayAppendNode.self,
-        ArrayReplaceValueAtIndexNode.self,
-        ArraySplitAtIndexNode.self,
-        ArraySubarrayNode.self,
-        ArrayQueueNode.self,
-        ArrayReverseNode.self,
-        ArrayShuffleNode.self,
-        LinePointsNode.self,
-        RingPointsNode.self,
-        GridPointsNode.self,
-        PolyLineSimplifyNode.self,
-    ]
-    
-    private var ioNodeClasses: [Node.Type] {
-        var classes: [Node.Type] = [
-            OSCReceiveNode.self,
-        ]
-        #if os(macOS)
-        classes.append(HIDNode.self)
-        #endif
-        classes.append(contentsOf: [
-            GameControllerNode.self,
-            MIDIInputNode.self,
-        ])
-        return classes
-    }
-
-    private var utilityClasses: [Node.Type] {
-        var classes: [Node.Type] = [
-            LogNode.self,
-            JavaScriptNode.self,
-            CursorNode.self,
-        ]
-        #if os(macOS)
-        classes.append(KeyboardNode.self)
-        #endif
-        classes.append(contentsOf: [
-            RenderInfoNode.self,
-            ImageDimensions.self,
-            PixelsToUnitsNode.self,
-            UnitsoPixelsNode.self,
-
-            SignalNode.self,
-            SwitchNode.self,
-            GateNode.self,
-            MatrixSwitchNode.self,
-
-            SampleAndHoldNode.self,
-        ])
-        return classes
+        PluginLoader.shared.loadAllPlugins()
     }
 }

--- a/Fabric/Nodes/Object/Camera/OrthographicCameraNode.swift
+++ b/Fabric/Nodes/Object/Camera/OrthographicCameraNode.swift
@@ -37,9 +37,9 @@ public class OrthographicCameraNode : ObjectNode<OrthographicCamera>
     
     private lazy var camera = OrthographicCamera(context:self.context, left: -1, right: 1, bottom: -1, top: 1, near: 0.01, far: 500.0)
 
-    override public func startExecution(renderer:GraphRenderer)
+    override public func startExecution(renderer:GraphRenderer) throws
     {
-        super.startExecution(renderer: renderer)
+        try super.startExecution(renderer: renderer)
         
         self.inputPosition.value = .init(repeating: 5.0)
         
@@ -77,4 +77,3 @@ public class OrthographicCameraNode : ObjectNode<OrthographicCamera>
         self.camera.right = aspect / 2.0
     }
 }
-

--- a/Fabric/Nodes/Object/Camera/OrthographicCameraNode.swift
+++ b/Fabric/Nodes/Object/Camera/OrthographicCameraNode.swift
@@ -65,6 +65,7 @@ public class OrthographicCameraNode : ObjectNode<OrthographicCamera>
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         let _ = self.evaluate(object: self.object, atTime: executionInfo.timing.time)
     }

--- a/Fabric/Nodes/Object/Camera/PerspectiveCameraNode.swift
+++ b/Fabric/Nodes/Object/Camera/PerspectiveCameraNode.swift
@@ -63,6 +63,7 @@ public class PerspectiveCameraNode : ObjectNode<PerspectiveCamera>
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         let _ = self.evaluate(object: self.camera, atTime: executionInfo.timing.time)
     }

--- a/Fabric/Nodes/Object/Camera/PerspectiveCameraNode.swift
+++ b/Fabric/Nodes/Object/Camera/PerspectiveCameraNode.swift
@@ -37,9 +37,9 @@ public class PerspectiveCameraNode : ObjectNode<PerspectiveCamera>
     
     private lazy var camera = PerspectiveCamera(context:self.context, position: .init(repeating: 5.0), near: 0.01, far: 500.0, fov: 30)
 
-    override public func startExecution(renderer:GraphRenderer)
+    override public func startExecution(renderer:GraphRenderer) throws
     {
-        super.startExecution(renderer: renderer)
+        try super.startExecution(renderer: renderer)
                 
         self.camera.lookAt(target: self.inputLookAt.value ?? .zero)
         self.camera.position = self.inputPosition.value ?? .zero
@@ -73,4 +73,3 @@ public class PerspectiveCameraNode : ObjectNode<PerspectiveCamera>
     }
   
 }
-

--- a/Fabric/Nodes/Object/Lights/DirectionalLightNode.swift
+++ b/Fabric/Nodes/Object/Lights/DirectionalLightNode.swift
@@ -48,6 +48,7 @@ public class DirectionalLightNode : ObjectNode<DirectionalLight>
     private lazy var light: DirectionalLight = DirectionalLight(context:self.context, color: [1.0, 1.0, 1.0], intensity: 1.0)
   
     override public func startExecution(renderer:GraphRenderer)
+    throws
     {
         self.setupDefaultLight( )
     }
@@ -119,6 +120,7 @@ public class DirectionalLightNode : ObjectNode<DirectionalLight>
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         let _ = self.evaluate(object: self.light, atTime: executionInfo.timing.time)
     }

--- a/Fabric/Nodes/Object/Lights/PointLightNode.swift
+++ b/Fabric/Nodes/Object/Lights/PointLightNode.swift
@@ -50,6 +50,7 @@ public class PointLightNode : ObjectNode<PointLight>
     private lazy var light: PointLight =  PointLight(context:self.context, color: simd_float3(1.0, 1.0, 1.0), radius: 150.0)
 
     override public func startExecution(renderer:GraphRenderer)
+    throws
     {
         self.setupDefaultLight( )
     }
@@ -128,6 +129,7 @@ public class PointLightNode : ObjectNode<PointLight>
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         let _ = self.evaluate(object: self.light, atTime: executionInfo.timing.time)
     }

--- a/Fabric/Nodes/Object/Lights/SpotLightNode.swift
+++ b/Fabric/Nodes/Object/Lights/SpotLightNode.swift
@@ -69,6 +69,7 @@ public class SpotLightNode : ObjectNode<SpotLight>
     )
 
     override public func startExecution(renderer:GraphRenderer)
+    throws
     {
         self.setupDefaultLight()
     }
@@ -187,6 +188,7 @@ public class SpotLightNode : ObjectNode<SpotLight>
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         let _ = self.evaluate(object: self.light, atTime: executionInfo.timing.time)
     }

--- a/Fabric/Nodes/Object/Renderables/ImageMeshNode.swift
+++ b/Fabric/Nodes/Object/Renderables/ImageMeshNode.swift
@@ -78,6 +78,7 @@ class ImageMeshNode: BaseRenderableNode<Mesh>
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.inputImage.valueDidChange
         {

--- a/Fabric/Nodes/Object/Renderables/InstancedMeshNode.swift
+++ b/Fabric/Nodes/Object/Renderables/InstancedMeshNode.swift
@@ -99,6 +99,7 @@ public class InstancedMeshNode : BaseRenderableNode<InstancedMesh>
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if (self.inputGeometry.valueDidChange
             || self.inputMaterial.valueDidChange)

--- a/Fabric/Nodes/Object/Renderables/InstancedModelMeshNode.swift
+++ b/Fabric/Nodes/Object/Renderables/InstancedModelMeshNode.swift
@@ -68,7 +68,7 @@ public class InstancedModelMeshNode : InstancedMeshNode
 
         try super.init(from: decoder)
         
-        self.loadModelFromInputValue()
+        try self.loadModelFromInputValue()
     }
     
     override public func evaluate(object: Object?, atTime: TimeInterval) -> Bool
@@ -100,11 +100,12 @@ public class InstancedModelMeshNode : InstancedMeshNode
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
                 
         if self.inputFilePathParam.valueDidChange
         {
-            self.loadModelFromInputValue()
+            try self.loadModelFromInputValue()
         }
 
         if let model = self.model
@@ -128,16 +129,24 @@ public class InstancedModelMeshNode : InstancedMeshNode
         }
     }
     
-    private func loadModelFromInputValue()
+    private func loadModelFromInputValue() throws
     {
         if let path = self.inputFilePathParam.value,
            path.isEmpty == false && self.url != URL(string: path)
         {
-            self.url = URL(string: path)
-
-            if FileManager.default.fileExists(atPath: self.url!.standardizedFileURL.path(percentEncoded: false) )
+            guard let url = URL(string: path) else
             {
-                let unflattenedModelObject = loadAsset(url:self.url!, context: self.context, textureLoader: self.textureLoader)
+                self.model = nil
+                throw FabricError(.execution(.fileNotFound),
+                                  severity: .recoverable,
+                                  message: "Model file path is invalid: \(path)")
+            }
+
+            self.url = url
+
+            if FileManager.default.fileExists(atPath: url.standardizedFileURL.path(percentEncoded: false))
+            {
+                let unflattenedModelObject = loadAsset(url: url, context: self.context, textureLoader: self.textureLoader)
                 
                 if let unflattenedModelObject
                 {
@@ -164,6 +173,13 @@ public class InstancedModelMeshNode : InstancedMeshNode
                     
                     self.model = object
                 }
+                else
+                {
+                    self.model = nil
+                    throw FabricError(.execution(.failed),
+                                      severity: .recoverable,
+                                      message: "Could not load instanced model file: \(url.path)")
+                }
                 
                 
                 self.updateLightingOnSubmeshes()
@@ -173,7 +189,9 @@ public class InstancedModelMeshNode : InstancedMeshNode
             else
             {
                 self.model = nil
-                print("wtf")
+                throw FabricError(.execution(.fileNotFound),
+                                  severity: .recoverable,
+                                  message: "Model file not found: \(url.path)")
             }
         }
     }

--- a/Fabric/Nodes/Object/Renderables/MeshNode.swift
+++ b/Fabric/Nodes/Object/Renderables/MeshNode.swift
@@ -103,6 +103,7 @@ public class MeshNode : BaseRenderableNode<Mesh>
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if
             (self.inputGeometry.valueDidChange

--- a/Fabric/Nodes/Object/Renderables/ModelMeshNode.swift
+++ b/Fabric/Nodes/Object/Renderables/ModelMeshNode.swift
@@ -68,7 +68,7 @@ public class ModelMeshNode : MeshNode
 
         try super.init(from: decoder)
         
-        self.loadModelFromInputValue()
+        try self.loadModelFromInputValue()
     }
     
     override public func evaluate(object: Object?, atTime: TimeInterval) -> Bool
@@ -100,11 +100,12 @@ public class ModelMeshNode : MeshNode
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         
         if self.inputFilePathParam.valueDidChange
         {
-            self.loadModelFromInputValue()
+            try self.loadModelFromInputValue()
         }
 
         if let model = self.model
@@ -113,16 +114,24 @@ public class ModelMeshNode : MeshNode
         }
     }
     
-    internal func loadModelFromInputValue()
+    internal func loadModelFromInputValue() throws
     {
         if let path = self.inputFilePathParam.value,
            path.isEmpty == false && self.url != URL(string: path)
         {
-            self.url = URL(string: path)
-
-            if FileManager.default.fileExists(atPath: self.url!.standardizedFileURL.path(percentEncoded: false) )
+            guard let url = URL(string: path) else
             {
-                let unflattenedModelObject = loadAsset(url:self.url!, context:self.context, textureLoader: self.textureLoader)
+                self.model = nil
+                throw FabricError(.execution(.fileNotFound),
+                                  severity: .recoverable,
+                                  message: "Model file path is invalid: \(path)")
+            }
+
+            self.url = url
+
+            if FileManager.default.fileExists(atPath: url.standardizedFileURL.path(percentEncoded: false))
+            {
+                let unflattenedModelObject = loadAsset(url: url, context:self.context, textureLoader: self.textureLoader)
                 
                 if let unflattenedModelObject
                 {
@@ -132,11 +141,20 @@ public class ModelMeshNode : MeshNode
 
                     let _ = self.evaluate(object: model, atTime: 0)
                 }
+                else
+                {
+                    self.model = nil
+                    throw FabricError(.execution(.failed),
+                                      severity: .recoverable,
+                                      message: "Could not load model file: \(url.path)")
+                }
             }
             else
             {
                 self.model = nil
-                print("wtf")
+                throw FabricError(.execution(.fileNotFound),
+                                  severity: .recoverable,
+                                  message: "Model file not found: \(url.path)")
             }
         }
     }

--- a/Fabric/Nodes/Object/SubGraph/DeferredSubgraphNode.swift
+++ b/Fabric/Nodes/Object/SubGraph/DeferredSubgraphNode.swift
@@ -242,35 +242,35 @@ public class DeferredSubgraphNode: SubgraphNode
         }
     }
     
-    override public func startExecution(renderer:GraphRenderer)
+    override public func startExecution(renderer:GraphRenderer) throws
     {
         if self.rendererNeedsSetup
         {
             self.setupRenderer()
         }
 
-        self.graphRenderer.startExecution(graph: self.subGraph)
+        try self.graphRenderer.startExecution(graph: self.subGraph)
     }
     
-    override public func stopExecution(renderer:GraphRenderer)
+    override public func stopExecution(renderer:GraphRenderer) throws
     {
-        self.graphRenderer.stopExecution(graph: self.subGraph)
+        try self.graphRenderer.stopExecution(graph: self.subGraph)
     }
 
-    override public func enableExecution(renderer:GraphRenderer)
+    override public func enableExecution(renderer:GraphRenderer) throws
     {
-        self.graphRenderer.enableExecution(graph: self.subGraph)
+        try self.graphRenderer.enableExecution(graph: self.subGraph)
     }
     
-    override public func disableExecution(renderer:GraphRenderer)
+    override public func disableExecution(renderer:GraphRenderer) throws
     {
-        self.graphRenderer.disableExecution(graph: self.subGraph)
+        try self.graphRenderer.disableExecution(graph: self.subGraph)
     }
     
     override public func execute(renderer:GraphRenderer,
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
-                                 commandBuffer: MTLCommandBuffer)
+                                 commandBuffer: MTLCommandBuffer) throws
     {
         if self.rendererNeedsSetup
         {
@@ -306,10 +306,10 @@ public class DeferredSubgraphNode: SubgraphNode
             rpd1.colorAttachments[0].texture = outputImage.texture
             
             
-            self.graphRenderer.executeAndDraw(graph: self.subGraph,
-                                              executionInfo: executionInfo,
-                                              renderPassDescriptor: rpd1,
-                                              commandBuffer: commandBuffer)
+            try self.graphRenderer.executeAndDraw(graph: self.subGraph,
+                                                  executionInfo: executionInfo,
+                                                  renderPassDescriptor: rpd1,
+                                                  commandBuffer: commandBuffer)
             
             self.outputColorTexture.send( outputImage )
         }

--- a/Fabric/Nodes/Object/SubGraph/DeferredSubgraphNode.swift
+++ b/Fabric/Nodes/Object/SubGraph/DeferredSubgraphNode.swift
@@ -301,22 +301,15 @@ public class DeferredSubgraphNode: SubgraphNode
         else { return }
 
             
-        if let outputImage = self.graphRenderer.newImage(withWidth: width, height: height)
-        {
-            rpd1.colorAttachments[0].texture = outputImage.texture
-            
-            
-            try self.graphRenderer.executeAndDraw(graph: self.subGraph,
-                                                  executionInfo: executionInfo,
-                                                  renderPassDescriptor: rpd1,
-                                                  commandBuffer: commandBuffer)
-            
-            self.outputColorTexture.send( outputImage )
-        }
-        else
-        {
-            self.outputColorTexture.send( nil )
-        }
+        let outputImage = try self.graphRenderer.newImage(withWidth: width, height: height)
+        rpd1.colorAttachments[0].texture = outputImage.texture
+
+        try self.graphRenderer.executeAndDraw(graph: self.subGraph,
+                                              executionInfo: executionInfo,
+                                              renderPassDescriptor: rpd1,
+                                              commandBuffer: commandBuffer)
+
+        self.outputColorTexture.send(outputImage)
         
         if let texture = self.graphRenderer.renderEncoder.depthTexture
         {

--- a/Fabric/Nodes/Object/SubGraph/DeferredSubgraphNode.swift
+++ b/Fabric/Nodes/Object/SubGraph/DeferredSubgraphNode.swift
@@ -110,11 +110,19 @@ public class DeferredSubgraphNode: SubgraphNode
     public required init(context: Context)
     {
         self.graphRenderer = GraphRenderer(context: context)
-        
+
         super.init(context: context)
         self.synchronizeDeferredConfiguration()
     }
-    
+
+    public override init(context: Context, subGraph: Graph)
+    {
+        self.graphRenderer = GraphRenderer(context: context)
+
+        super.init(context: context, subGraph: subGraph)
+        self.synchronizeDeferredConfiguration()
+    }
+
     public required init(from decoder: any Decoder) throws
     {
         guard let decodeContext = decoder.context else

--- a/Fabric/Nodes/Object/SubGraph/EnvironmentNode.swift
+++ b/Fabric/Nodes/Object/SubGraph/EnvironmentNode.swift
@@ -55,7 +55,7 @@ public class EnvironmentNode: SubgraphNode
     override public func execute(renderer:GraphRenderer,
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
-                                 commandBuffer: MTLCommandBuffer)
+                                 commandBuffer: MTLCommandBuffer) throws
     {
         if self.inputEnvironmentTexture.valueDidChange,
            let environmentTexture = self.inputEnvironmentTexture.value,
@@ -79,6 +79,6 @@ public class EnvironmentNode: SubgraphNode
 //        }
         
         // This calls forward for us...
-        super.execute(renderer: renderer, executionInfo: executionInfo, renderPassDescriptor: renderPassDescriptor, commandBuffer: commandBuffer)
+        try super.execute(renderer: renderer, executionInfo: executionInfo, renderPassDescriptor: renderPassDescriptor, commandBuffer: commandBuffer)
     }
 }

--- a/Fabric/Nodes/Object/SubGraph/Iterator/IteratorInfoNode.swift
+++ b/Fabric/Nodes/Object/SubGraph/Iterator/IteratorInfoNode.swift
@@ -67,6 +67,7 @@ public class IteratorInfoNode : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
 //        print("Iterator Info executing")
         if let iterationInfo = executionInfo.iterationInfo

--- a/Fabric/Nodes/Object/SubGraph/Iterator/IteratorNode.swift
+++ b/Fabric/Nodes/Object/SubGraph/Iterator/IteratorNode.swift
@@ -49,30 +49,30 @@ public class IteratorNode: SubgraphNode
         try super.init(from: decoder)
     }
     
-    override public func startExecution(renderer:GraphRenderer)
+    override public func startExecution(renderer:GraphRenderer) throws
     {
-        renderer.startExecution(graph: self.subGraph)
+        try renderer.startExecution(graph: self.subGraph)
     }
     
-    override public func stopExecution(renderer:GraphRenderer)
+    override public func stopExecution(renderer:GraphRenderer) throws
     {
-        renderer.stopExecution(graph: self.subGraph)
+        try renderer.stopExecution(graph: self.subGraph)
     }
 
-    override public func enableExecution(renderer:GraphRenderer)
+    override public func enableExecution(renderer:GraphRenderer) throws
     {
-        renderer.enableExecution(graph: self.subGraph)
+        try renderer.enableExecution(graph: self.subGraph)
     }
     
-    override public func disableExecution(renderer:GraphRenderer)
+    override public func disableExecution(renderer:GraphRenderer) throws
     {
-        renderer.disableExecution(graph: self.subGraph)
+        try renderer.disableExecution(graph: self.subGraph)
     }
     
     override public func execute(renderer:GraphRenderer,
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
-                                 commandBuffer: MTLCommandBuffer)
+                                 commandBuffer: MTLCommandBuffer) throws
     {
         let iterationCount = resolvedIterationCount()
         guard iterationCount > 0 else {
@@ -99,12 +99,12 @@ public class IteratorNode: SubgraphNode
                 renderer.invalidateFeedbackTopologyCaches(for: subGraph)
             }
 
-            renderer.execute(graph: subGraph,
-                             executionInfo: executionInfo,
-                             renderPassDescriptor: renderPassDescriptor,
-                             commandBuffer: commandBuffer,
-                             clearFlags: false,
-                             forceEvaluationForTheseNodes: subGraph.nodes)
+            try renderer.execute(graph: subGraph,
+                                 executionInfo: executionInfo,
+                                 renderPassDescriptor: renderPassDescriptor,
+                                 commandBuffer: commandBuffer,
+                                 clearFlags: false,
+                                 forceEvaluationForTheseNodes: subGraph.nodes)
 
             if needsSceneSync
             {

--- a/Fabric/Nodes/Object/SubGraph/SubgraphNode.swift
+++ b/Fabric/Nodes/Object/SubGraph/SubgraphNode.swift
@@ -274,24 +274,24 @@ public class SubgraphNode: BaseObjectNode
         super.markDirty()
     }
     
-    override public func startExecution(renderer:GraphRenderer)
+    override public func startExecution(renderer:GraphRenderer) throws
     {
-        renderer.startExecution(graph: self.subGraph)
+        try renderer.startExecution(graph: self.subGraph)
     }
     
-    override public func stopExecution(renderer:GraphRenderer)
+    override public func stopExecution(renderer:GraphRenderer) throws
     {
-        renderer.stopExecution(graph: self.subGraph)
+        try renderer.stopExecution(graph: self.subGraph)
     }
 
-    override public func enableExecution(renderer:GraphRenderer)
+    override public func enableExecution(renderer:GraphRenderer) throws
     {
-        renderer.enableExecution(graph: self.subGraph)
+        try renderer.enableExecution(graph: self.subGraph)
     }
     
-    override public func disableExecution(renderer:GraphRenderer)
+    override public func disableExecution(renderer:GraphRenderer) throws
     {
-        renderer.disableExecution(graph: self.subGraph)
+        try renderer.disableExecution(graph: self.subGraph)
     }
     
     public func forwardPortValues(force:Bool = false)
@@ -307,13 +307,13 @@ public class SubgraphNode: BaseObjectNode
     override  public func execute(renderer:GraphRenderer,
                                   executionInfo:GraphExecutionInfo,
                                   renderPassDescriptor: MTLRenderPassDescriptor,
-                                  commandBuffer: MTLCommandBuffer)    {
+                                  commandBuffer: MTLCommandBuffer) throws    {
         
-        renderer.execute(graph: self.subGraph,
-                         executionInfo: executionInfo,
-                         renderPassDescriptor: renderPassDescriptor,
-                         commandBuffer: commandBuffer,
-                         clearFlags: false)
+        try renderer.execute(graph: self.subGraph,
+                             executionInfo: executionInfo,
+                             renderPassDescriptor: renderPassDescriptor,
+                             commandBuffer: commandBuffer,
+                             clearFlags: false)
         
         self.forwardPortValues(force:true)
     }

--- a/Fabric/Nodes/Object/SubGraph/SubgraphNode.swift
+++ b/Fabric/Nodes/Object/SubGraph/SubgraphNode.swift
@@ -18,7 +18,7 @@ open class SubgraphNode: BaseObjectNode
     override open class var nodeTimeMode: Node.TimeMode { .TimeBase }
     override open class var nodeDescription: String { "A Sub Graph of Nodes, useful for organizing or encapsulation"}
 
-    let subGraph:Graph
+    public private(set) var subGraph:Graph
 
     /// ProxyPorts wrapping the sub graph's published ports.
     /// Each proxy has node = self (the SubgraphNode) and published = false.
@@ -178,7 +178,18 @@ open class SubgraphNode: BaseObjectNode
         self.wireSubGraphCallback()
         self.rebuildProxyPorts()
     }
-    
+
+    /// Wrap an existing graph as this node's sub graph, for embedders that
+    /// decode a graph separately and then nest it.
+    public init(context: Context, subGraph: Graph)
+    {
+        self.subGraph = subGraph
+
+        super.init(context: context)
+        self.wireSubGraphCallback()
+        self.rebuildProxyPorts()
+    }
+
     enum CodingKeys : String, CodingKey
     {
         case subGraph

--- a/Fabric/Nodes/Object/SubGraph/SubgraphNode.swift
+++ b/Fabric/Nodes/Object/SubGraph/SubgraphNode.swift
@@ -10,13 +10,13 @@ import Satin
 import simd
 import Metal
 
-public class SubgraphNode: BaseObjectNode
+open class SubgraphNode: BaseObjectNode
 {
-    override public class var name:String { "Sub Graph" }
-    override public class var nodeType:Node.NodeType { Node.NodeType.Subgraph }
-    override public class var nodeExecutionMode: Node.ExecutionMode { .Consumer } // TODO: ??
-    override public class var nodeTimeMode: Node.TimeMode { .TimeBase }
-    override public class var nodeDescription: String { "A Sub Graph of Nodes, useful for organizing or encapsulation"}
+    override open class var name:String { "Sub Graph" }
+    override open class var nodeType:Node.NodeType { Node.NodeType.Subgraph }
+    override open class var nodeExecutionMode: Node.ExecutionMode { .Consumer } // TODO: ??
+    override open class var nodeTimeMode: Node.TimeMode { .TimeBase }
+    override open class var nodeDescription: String { "A Sub Graph of Nodes, useful for organizing or encapsulation"}
 
     let subGraph:Graph
 
@@ -26,11 +26,11 @@ public class SubgraphNode: BaseObjectNode
     /// Lazily rebuilt when the sub graph's published ports change.
     private var proxyPorts: [Port] = []
 
-    override public var ports:[Port] { self.proxyPorts + super.ports }
+    override open var ports:[Port] { self.proxyPorts + super.ports }
 
     /// Rebuild proxy ports from the sub graph's current published ports.
     /// Called via callback when the sub graph's published ports change.
-    public func rebuildProxyPorts()
+    open func rebuildProxyPorts()
     {
         self.invalidatePortCaches()
 
@@ -134,7 +134,7 @@ public class SubgraphNode: BaseObjectNode
         }
     }
 
-    override public var nodeExecutionMode:ExecutionMode
+    override open var nodeExecutionMode:ExecutionMode
     {
         let publishedInputPorts = self.proxyPorts.filter { $0.kind == .Inlet }
         let publishedOutputPorts = self.proxyPorts.filter { $0.kind == .Outlet }
@@ -161,12 +161,12 @@ public class SubgraphNode: BaseObjectNode
         return Self.nodeExecutionMode
     }
 
-    override public func getObject() -> Object?
+    override open func getObject() -> Object?
     {
         return self.object
     }
-    
-    public var object:Object? {
+
+    open var object:Object? {
         self.subGraph.scene
     }
     
@@ -185,7 +185,7 @@ public class SubgraphNode: BaseObjectNode
         case proxyPorts
     }
     
-    public override func encode(to encoder:Encoder) throws
+    open override func encode(to encoder:Encoder) throws
     {
         var container = encoder.container(keyedBy: CodingKeys.self)
         
@@ -251,10 +251,10 @@ public class SubgraphNode: BaseObjectNode
      
     // Ensure we always render!
 //    override public var isDirty:Bool { get {  true /*self.subGraph.needsExecution*/  } set { } }
-    override public var isDirty:Bool { get {  self.subGraph.needsExecution  } set { } }
+    override open var isDirty:Bool { get {  self.subGraph.needsExecution  } set { } }
 
 
-    override public func markClean()
+    override open func markClean()
     {
         for node in self.subGraph.nodes
         {
@@ -264,7 +264,7 @@ public class SubgraphNode: BaseObjectNode
         super.markClean()
     }
          
-    override public func markDirty()
+    override open func markDirty()
     {
         for node in self.subGraph.nodes
         {
@@ -274,27 +274,27 @@ public class SubgraphNode: BaseObjectNode
         super.markDirty()
     }
     
-    override public func startExecution(renderer:GraphRenderer) throws
+    override open func startExecution(renderer:GraphRenderer) throws
     {
         try renderer.startExecution(graph: self.subGraph)
     }
-    
-    override public func stopExecution(renderer:GraphRenderer) throws
+
+    override open func stopExecution(renderer:GraphRenderer) throws
     {
         try renderer.stopExecution(graph: self.subGraph)
     }
 
-    override public func enableExecution(renderer:GraphRenderer) throws
+    override open func enableExecution(renderer:GraphRenderer) throws
     {
         try renderer.enableExecution(graph: self.subGraph)
     }
-    
-    override public func disableExecution(renderer:GraphRenderer) throws
+
+    override open func disableExecution(renderer:GraphRenderer) throws
     {
         try renderer.disableExecution(graph: self.subGraph)
     }
-    
-    public func forwardPortValues(force:Bool = false)
+
+    open func forwardPortValues(force:Bool = false)
     {
         // Forward outlet values from inner ports to proxy ports so the
         // parent graph receives sub graph outputs.
@@ -304,7 +304,7 @@ public class SubgraphNode: BaseObjectNode
         }
     }
     
-    override  public func execute(renderer:GraphRenderer,
+    override open func execute(renderer:GraphRenderer,
                                   executionInfo:GraphExecutionInfo,
                                   renderPassDescriptor: MTLRenderPassDescriptor,
                                   commandBuffer: MTLCommandBuffer) throws    {

--- a/Fabric/Nodes/Parameters/Array/Array Basics/ArrayAppendNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Array Basics/ArrayAppendNode.swift
@@ -38,6 +38,7 @@ public class ArrayAppendNode: TypeAgnosticNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard let inputPortA: Port = findPort(named: "inputArrayA"),
               let inputPortB: Port = findPort(named: "inputArrayB"),

--- a/Fabric/Nodes/Parameters/Array/Array Basics/ArrayCountNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Array Basics/ArrayCountNode.swift
@@ -45,6 +45,7 @@ public class ArrayCountNode: TypeAgnosticNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard let inputPort: Port = findPort(named: "inputPort") else { return }
         guard inputPort.valueDidChange else { return }

--- a/Fabric/Nodes/Parameters/Array/Array Basics/ArrayFirstValueNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Array Basics/ArrayFirstValueNode.swift
@@ -37,6 +37,7 @@ public class ArrayFirstValueNode: TypeAgnosticNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard let inputPort:  Port = findPort(named: "inputPort"),
               let outputPort: Port = findPort(named: "outputPort") else { return }

--- a/Fabric/Nodes/Parameters/Array/Array Basics/ArrayIndexValueNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Array Basics/ArrayIndexValueNode.swift
@@ -46,6 +46,7 @@ public class ArrayIndexValueNode: TypeAgnosticNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard let inputPort:  Port = findPort(named: "inputPort"),
               let outputPort: Port = findPort(named: "outputPort") else { return }

--- a/Fabric/Nodes/Parameters/Array/Array Basics/ArrayLastValueNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Array Basics/ArrayLastValueNode.swift
@@ -37,6 +37,7 @@ public class ArrayLastValueNode: TypeAgnosticNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard let inputPort:  Port = findPort(named: "inputPort"),
               let outputPort: Port = findPort(named: "outputPort") else { return }

--- a/Fabric/Nodes/Parameters/Array/Array Basics/ArrayQueueNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Array Basics/ArrayQueueNode.swift
@@ -57,6 +57,7 @@ public class ArrayQueueNode: TypeAgnosticNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard let inputPort:  Port = findPort(named: "inputPort"),
               let outputPort: Port = findPort(named: "outputPort") else { return }

--- a/Fabric/Nodes/Parameters/Array/Array Basics/ArrayReplaceValueAtIndexNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Array Basics/ArrayReplaceValueAtIndexNode.swift
@@ -47,6 +47,7 @@ public class ArrayReplaceValueAtIndexNode: TypeAgnosticNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard let inputPort:  Port = findPort(named: "inputPort"),
               let inputValue: Port = findPort(named: "inputValue"),

--- a/Fabric/Nodes/Parameters/Array/Array Basics/ArrayReverseNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Array Basics/ArrayReverseNode.swift
@@ -37,6 +37,7 @@ public class ArrayReverseNode: TypeAgnosticNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard let inputPort:  Port = findPort(named: "inputPort"),
               let outputPort: Port = findPort(named: "outputPort") else { return }

--- a/Fabric/Nodes/Parameters/Array/Array Basics/ArrayShuffleNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Array Basics/ArrayShuffleNode.swift
@@ -46,6 +46,7 @@ public class ArrayShuffleNode: TypeAgnosticNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard let inputPort:  Port = findPort(named: "inputPort"),
               let outputPort: Port = findPort(named: "outputPort") else { return }

--- a/Fabric/Nodes/Parameters/Array/Array Basics/ArraySplitAtIndexNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Array Basics/ArraySplitAtIndexNode.swift
@@ -47,6 +47,7 @@ public class ArraySplitAtIndexNode: TypeAgnosticNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard let inputPort:    Port = findPort(named: "inputPort"),
               let outputBefore: Port = findPort(named: "outputBefore"),

--- a/Fabric/Nodes/Parameters/Array/Array Basics/ArraySubarrayNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Array Basics/ArraySubarrayNode.swift
@@ -48,6 +48,7 @@ public class ArraySubarrayNode: TypeAgnosticNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard let inputPort:  Port = findPort(named: "inputPort"),
               let outputPort: Port = findPort(named: "outputPort") else { return }

--- a/Fabric/Nodes/Parameters/Array/GeometryToTransformArrayNode.swift
+++ b/Fabric/Nodes/Parameters/Array/GeometryToTransformArrayNode.swift
@@ -88,6 +88,7 @@ public class GeometryToTransformArrayNode : StrategyNode
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         // This is subtle: the geometry POINTER can stay identical while its
         // backing buffer changes, so we re-extract every frame rather than

--- a/Fabric/Nodes/Parameters/Array/GridPointsNode.swift
+++ b/Fabric/Nodes/Parameters/Array/GridPointsNode.swift
@@ -41,6 +41,7 @@ public class GridPointsNode : Node
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard self.inputColumns.valueDidChange
             || self.inputRows.valueDidChange

--- a/Fabric/Nodes/Parameters/Array/LinePointsNode.swift
+++ b/Fabric/Nodes/Parameters/Array/LinePointsNode.swift
@@ -37,6 +37,7 @@ public class LinePointsNode : Node
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard self.inputCount.valueDidChange
             || self.inputSpread.valueDidChange

--- a/Fabric/Nodes/Parameters/Array/Numerics/Array Composition/ComposeOrientationArrayNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Numerics/Array Composition/ComposeOrientationArrayNode.swift
@@ -74,6 +74,7 @@ public class ComposeOrientationArrayNode: StrategyNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard let outputOrientations: NodePort<ContiguousArray<simd_float4>> = findPort(named: "outputOrientations") else { return }
 

--- a/Fabric/Nodes/Parameters/Array/Numerics/Array Composition/ComposeVectorArrayNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Numerics/Array Composition/ComposeVectorArrayNode.swift
@@ -66,6 +66,7 @@ public class ComposeVectorArrayNode: StrategyNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard let vt: VectorType = strategyOption() else { return }
 

--- a/Fabric/Nodes/Parameters/Array/Numerics/Array Decomposition/DecomposeOrientationArrayNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Numerics/Array Decomposition/DecomposeOrientationArrayNode.swift
@@ -65,6 +65,7 @@ public class DecomposeOrientationArrayNode: StrategyNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard let inputOrientations: NodePort<ContiguousArray<simd_float4>> = findPort(named: "inputOrientations"),
               inputOrientations.valueDidChange

--- a/Fabric/Nodes/Parameters/Array/Numerics/Array Decomposition/DecomposeTransformArrayNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Numerics/Array Decomposition/DecomposeTransformArrayNode.swift
@@ -67,6 +67,7 @@ public class DecomposeTransformArrayNode: StrategyNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard let inputTransforms: NodePort<ContiguousArray<simd_float4x4>> = findPort(named: "inputTransforms"),
               inputTransforms.valueDidChange

--- a/Fabric/Nodes/Parameters/Array/Numerics/Array Decomposition/DecomposeVectorArrayNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Numerics/Array Decomposition/DecomposeVectorArrayNode.swift
@@ -66,6 +66,7 @@ public class DecomposeVectorArrayNode: StrategyNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard let vt: VectorType = strategyOption() else { return }
 

--- a/Fabric/Nodes/Parameters/Array/Numerics/Array Interpolation/ArrayFromRippledValueNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Numerics/Array Interpolation/ArrayFromRippledValueNode.swift
@@ -44,7 +44,8 @@ public class ArrayFromRippledValueNode<Value : PortValueRepresentable & DefaultP
     public var inputDelaySecs: ParameterPort<Float> { port(named: "inputDelaySecs") }
     public var outputArray: NodePort<ContiguousArray<Value>> { port(named: "outputArray") }
 
-    override public func startExecution(renderer: GraphRenderer) {
+    override public func startExecution(renderer: GraphRenderer) throws
+    {
         self.history.removeAll()
         self.oldest = nil
         self.lastTime = nil
@@ -54,6 +55,7 @@ public class ArrayFromRippledValueNode<Value : PortValueRepresentable & DefaultP
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         let now = executionInfo.timing.time
 

--- a/Fabric/Nodes/Parameters/Array/Numerics/Array Interpolation/ArrayRangeInterpolationNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Numerics/Array Interpolation/ArrayRangeInterpolationNode.swift
@@ -39,6 +39,7 @@ public class ArrayRangeInterpolationNode<Value: PortValueRepresentable & Lerpabl
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard self.inputFrom.valueDidChange
            || self.inputTo.valueDidChange

--- a/Fabric/Nodes/Parameters/Array/Numerics/Array Interpolation/ArrayResampleNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Numerics/Array Interpolation/ArrayResampleNode.swift
@@ -35,6 +35,7 @@ public class ArrayResampleNode<Value: PortValueRepresentable & Lerpable>: Node
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard self.inputArray.valueDidChange || self.inputCount.valueDidChange else { return }
         guard let source = self.inputArray.value, !source.isEmpty,

--- a/Fabric/Nodes/Parameters/Array/Numerics/Array Tweening/OrientationArrayTweenNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Numerics/Array Tweening/OrientationArrayTweenNode.swift
@@ -48,6 +48,7 @@ public class OrientationArrayTweenNode : Node
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         let time = executionInfo.timing.time
 

--- a/Fabric/Nodes/Parameters/Array/Numerics/Array Tweening/VectorArrayTweenNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Numerics/Array Tweening/VectorArrayTweenNode.swift
@@ -44,6 +44,7 @@ public class VectorArrayTweenNode<Value> : Node where Value: PortValueRepresenta
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         let time = executionInfo.timing.time
 

--- a/Fabric/Nodes/Parameters/Array/Numerics/ComposeTransformArrayNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Numerics/ComposeTransformArrayNode.swift
@@ -67,6 +67,7 @@ public class ComposeTransformArrayNode: StrategyNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard let outputTransforms: NodePort<ContiguousArray<simd_float4x4>> = findPort(named: "outputTransforms") else { return }
 

--- a/Fabric/Nodes/Parameters/Array/Numerics/PolyLineSimplifyNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Numerics/PolyLineSimplifyNode.swift
@@ -40,6 +40,7 @@ public class PolyLineSimplifyNode: Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.inputPort.valueDidChange || self.inputTolerance.valueDidChange,
            let tolerance = self.inputTolerance.value

--- a/Fabric/Nodes/Parameters/Array/RepeatValueNode.swift
+++ b/Fabric/Nodes/Parameters/Array/RepeatValueNode.swift
@@ -37,6 +37,7 @@ public class RepeatValueNode<Value : PortValueRepresentable & DefaultParameterPr
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard self.inputValue.valueDidChange || self.inputCount.valueDidChange else { return }
         guard let value = self.inputValue.value, let rawCount = self.inputCount.value else { return }

--- a/Fabric/Nodes/Parameters/Array/RingPointsNode.swift
+++ b/Fabric/Nodes/Parameters/Array/RingPointsNode.swift
@@ -41,6 +41,7 @@ public class RingPointsNode : Node
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard self.inputCount.valueDidChange
             || self.inputRadius.valueDidChange

--- a/Fabric/Nodes/Parameters/Boolean/BooleanLogicNode.swift
+++ b/Fabric/Nodes/Parameters/Boolean/BooleanLogicNode.swift
@@ -38,9 +38,9 @@ public class BooleanLogicNode : Node
     
     private var op = LogicOperator.Equals
     
-    override public func startExecution(renderer:GraphRenderer)
+    override public func startExecution(renderer:GraphRenderer) throws
     {
-        super.startExecution(renderer: renderer)
+        try super.startExecution(renderer: renderer)
         
         if let stringParam = self.inputParam.parameter as? StringParameter
         {

--- a/Fabric/Nodes/Parameters/Boolean/BooleanLogicNode.swift
+++ b/Fabric/Nodes/Parameters/Boolean/BooleanLogicNode.swift
@@ -52,6 +52,7 @@ public class BooleanLogicNode : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.inputParam.valueDidChange,
            let param = self.inputParam.value,

--- a/Fabric/Nodes/Parameters/Color/ColorPassThroughNode.swift
+++ b/Fabric/Nodes/Parameters/Color/ColorPassThroughNode.swift
@@ -41,6 +41,7 @@ public class ColorPassThroughNode: Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.input.valueDidChange
         {

--- a/Fabric/Nodes/Parameters/Color/ColorTweenNode.swift
+++ b/Fabric/Nodes/Parameters/Color/ColorTweenNode.swift
@@ -93,6 +93,7 @@ public class ColorTweenNode : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         let time = executionInfo.timing.time
 

--- a/Fabric/Nodes/Parameters/Color/MakeColorNode.swift
+++ b/Fabric/Nodes/Parameters/Color/MakeColorNode.swift
@@ -44,6 +44,7 @@ public class MakeColorNode: Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.inputR.valueDidChange || self.inputG.valueDidChange || self.inputB.valueDidChange || self.inputA.valueDidChange,
            let r = self.inputR.value,

--- a/Fabric/Nodes/Parameters/Dictionary/ComposeDictionaryNode.swift
+++ b/Fabric/Nodes/Parameters/Dictionary/ComposeDictionaryNode.swift
@@ -47,6 +47,7 @@ public final class ComposeDictionaryNode: DictionaryTypeAgnosticNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard let inputKeys: Port = findPort(named: "inputKeys"),
               let inputValues: Port = findPort(named: "inputValues"),

--- a/Fabric/Nodes/Parameters/Dictionary/DecomposeDictionaryNode.swift
+++ b/Fabric/Nodes/Parameters/Dictionary/DecomposeDictionaryNode.swift
@@ -47,6 +47,7 @@ public final class DecomposeDictionaryNode: DictionaryTypeAgnosticNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard let inputDictionary: Port = findPort(named: "inputDictionary"),
               let outputKeys: Port = findPort(named: "outputKeys"),

--- a/Fabric/Nodes/Parameters/Dictionary/DictionaryCountNode.swift
+++ b/Fabric/Nodes/Parameters/Dictionary/DictionaryCountNode.swift
@@ -33,6 +33,7 @@ public final class DictionaryCountNode: DictionaryTypeAgnosticNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard let inputDictionary: Port = findPort(named: "inputDictionary"),
               let outputCount: Port = findPort(named: "outputCount"),

--- a/Fabric/Nodes/Parameters/Dictionary/DictionaryFromJSONStringNode.swift
+++ b/Fabric/Nodes/Parameters/Dictionary/DictionaryFromJSONStringNode.swift
@@ -34,6 +34,7 @@ public final class DictionaryFromJSONStringNode: Node
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard inputJSONString.valueDidChange else { return }
         let source = inputJSONString.value ?? ""

--- a/Fabric/Nodes/Parameters/Dictionary/DictionaryHasKeyNode.swift
+++ b/Fabric/Nodes/Parameters/Dictionary/DictionaryHasKeyNode.swift
@@ -42,6 +42,7 @@ public final class DictionaryHasKeyNode: DictionaryTypeAgnosticNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard let inputDictionary: Port = findPort(named: "inputDictionary"),
               let outputContainsKey: Port = findPort(named: "outputContainsKey"),

--- a/Fabric/Nodes/Parameters/Dictionary/DictionaryMergeNode.swift
+++ b/Fabric/Nodes/Parameters/Dictionary/DictionaryMergeNode.swift
@@ -41,6 +41,7 @@ public final class DictionaryMergeNode: DictionaryTypeAgnosticNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard let inputDictionaryA: Port = findPort(named: "inputDictionaryA"),
               let inputDictionaryB: Port = findPort(named: "inputDictionaryB"),

--- a/Fabric/Nodes/Parameters/Dictionary/DictionaryRemoveKeyNode.swift
+++ b/Fabric/Nodes/Parameters/Dictionary/DictionaryRemoveKeyNode.swift
@@ -44,6 +44,7 @@ public final class DictionaryRemoveKeyNode: DictionaryTypeAgnosticNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard let inputDictionary: Port = findPort(named: "inputDictionary"),
               let outputDictionary: Port = findPort(named: "outputDictionary"),

--- a/Fabric/Nodes/Parameters/Dictionary/DictionarySetValueForKeyNode.swift
+++ b/Fabric/Nodes/Parameters/Dictionary/DictionarySetValueForKeyNode.swift
@@ -56,6 +56,7 @@ public final class DictionarySetValueForKeyNode: DictionaryTypeAgnosticNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard let inputDictionary: Port = findPort(named: "inputDictionary"),
               let inputValue: Port = findPort(named: "inputValue"),

--- a/Fabric/Nodes/Parameters/Dictionary/DictionaryValueForKeyNode.swift
+++ b/Fabric/Nodes/Parameters/Dictionary/DictionaryValueForKeyNode.swift
@@ -44,6 +44,7 @@ public final class DictionaryValueForKeyNode: DictionaryTypeAgnosticNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard let inputDictionary: Port = findPort(named: "inputDictionary"),
               let outputValue: Port = findPort(named: "outputValue"),

--- a/Fabric/Nodes/Parameters/IO/AudioSpectrumNode.swift
+++ b/Fabric/Nodes/Parameters/IO/AudioSpectrumNode.swift
@@ -408,8 +408,8 @@ public class AudioSpectrumNode : Node
         return AVCaptureDevice.default(for: .audio)
     }
 
-    override public func startExecution(renderer:GraphRenderer) {
-        super.startExecution(renderer:renderer)
+    override public func startExecution(renderer:GraphRenderer) throws {
+        try super.startExecution(renderer:renderer)
 
         switch AVCaptureDevice.authorizationStatus(for: .audio) {
             case .authorized:
@@ -434,18 +434,18 @@ public class AudioSpectrumNode : Node
         }
     }
     
-    override public func stopExecution(renderer:GraphRenderer)
+    override public func stopExecution(renderer:GraphRenderer) throws
     {
-        super.stopExecution(renderer:renderer)
+        try super.stopExecution(renderer:renderer)
         if self.captureSession.isRunning
         {
             self.captureSession.stopRunning()
         }
     }
 
-    override public func disableExecution(renderer:GraphRenderer)
+    override public func disableExecution(renderer:GraphRenderer) throws
     {
-        super.disableExecution(renderer:renderer)
+        try super.disableExecution(renderer:renderer)
         if self.captureSession.isRunning{
             self.captureSession.stopRunning()
         }

--- a/Fabric/Nodes/Parameters/IO/AudioSpectrumNode.swift
+++ b/Fabric/Nodes/Parameters/IO/AudioSpectrumNode.swift
@@ -455,6 +455,7 @@ public class AudioSpectrumNode : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.inputAudioDevice.valueDidChange
         {

--- a/Fabric/Nodes/Parameters/IO/GameControllerNode.swift
+++ b/Fabric/Nodes/Parameters/IO/GameControllerNode.swift
@@ -219,6 +219,7 @@ public class GameControllerNode: Node
     // MARK: - Lifecycle
 
     public override func enableExecution(renderer:GraphRenderer)
+    throws
     {
         setupNotifications()
         refreshControllers()
@@ -236,6 +237,7 @@ public class GameControllerNode: Node
     }
 
     public override func disableExecution(renderer:GraphRenderer)
+    throws
     {
         NotificationCenter.default.removeObserver(self)
         currentController = nil
@@ -464,6 +466,7 @@ public class GameControllerNode: Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         // Send axis values
         for (name, value) in axisValues

--- a/Fabric/Nodes/Parameters/IO/HIDNode.swift
+++ b/Fabric/Nodes/Parameters/IO/HIDNode.swift
@@ -666,11 +666,13 @@ public class HIDNode: Node
     // MARK: - Lifecycle
 
     public override func enableExecution(renderer:GraphRenderer)
+    throws
     {
         setupHIDManager()
     }
 
     public override func disableExecution(renderer:GraphRenderer)
+    throws
     {
         if let deviceID = selectedDeviceID
         {
@@ -729,6 +731,7 @@ public class HIDNode: Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         for element in deviceElements
         {

--- a/Fabric/Nodes/Parameters/IO/MIDIInputNode.swift
+++ b/Fabric/Nodes/Parameters/IO/MIDIInputNode.swift
@@ -460,16 +460,18 @@ public class MIDIInputNode: Node
     // MARK: - Lifecycle
 
     public override func enableExecution(renderer: GraphRenderer)
+    throws
     {
-        setupMIDIManager()
+        try setupMIDIManager()
     }
 
     public override func disableExecution(renderer: GraphRenderer)
+    throws
     {
         midiManager = nil
     }
 
-    private func setupMIDIManager()
+    private func setupMIDIManager() throws
     {
         do
         {
@@ -493,7 +495,10 @@ public class MIDIInputNode: Node
         }
         catch
         {
-            print("[MIDI] Failed to start manager: \(error)")
+            throw FabricError(.execution(.failed),
+                              severity: .recoverable,
+                              message: "Failed to start MIDI manager",
+                              underlyingError: error)
         }
     }
 
@@ -863,6 +868,7 @@ public class MIDIInputNode: Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         for input in configuredInputs
         {

--- a/Fabric/Nodes/Parameters/IO/MIDIInputNode.swift
+++ b/Fabric/Nodes/Parameters/IO/MIDIInputNode.swift
@@ -510,7 +510,7 @@ public class MIDIInputNode: Node
             MIDIInputInfo(
                 id: endpoint.uniqueID.description,
                 name: endpoint.displayName,
-                manufacturer: endpoint.manufacturer
+                manufacturer: endpoint.manufacturer.value
             )
         }
 

--- a/Fabric/Nodes/Parameters/IO/OSCReceiveNode.swift
+++ b/Fabric/Nodes/Parameters/IO/OSCReceiveNode.swift
@@ -244,7 +244,7 @@ public class OSCReceiveNode: Node
             if isListening
             {
                 stopListening()
-                startListening()
+                try? startListening()
             }
             _settingsModelStorage?.listenPort = listenPort
         }
@@ -309,7 +309,7 @@ public class OSCReceiveNode: Node
             self.isListening = node.isListening
         }
 
-        func startListening() { node?.startListening(); isListening = node?.isListening ?? false }
+        func startListening() { try? node?.startListening(); isListening = node?.isListening ?? false }
         func stopListening() { node?.stopListening(); isListening = false }
         func addAddressBinding() { node?.addAddressBinding() }
         func removeAddressBinding(id: UUID) { node?.removeAddressBinding(id: id) }
@@ -320,11 +320,13 @@ public class OSCReceiveNode: Node
     // MARK: - Lifecycle
 
     public override func enableExecution(renderer: GraphRenderer)
+    throws
     {
-        startListening()
+        try startListening()
     }
 
     public override func disableExecution(renderer: GraphRenderer)
+    throws
     {
         stopListening()
     }
@@ -335,6 +337,7 @@ public class OSCReceiveNode: Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         // Send latest values to ports
         for binding in addressBindings
@@ -378,7 +381,7 @@ public class OSCReceiveNode: Node
 
     // MARK: - OSC Server Management
 
-    fileprivate func startListening()
+    fileprivate func startListening() throws
     {
         guard !isListening else { return }
 
@@ -394,9 +397,12 @@ public class OSCReceiveNode: Node
         }
         catch
         {
-            print("Failed to start OSC server: \(error)")
             isListening = false
             _settingsModelStorage?.isListening = false
+            throw FabricError(.execution(.failed),
+                              severity: .recoverable,
+                              message: "Failed to start OSC server on port \(listenPort)",
+                              underlyingError: error)
         }
     }
 

--- a/Fabric/Nodes/Parameters/Number/CurrentTimeNode.swift
+++ b/Fabric/Nodes/Parameters/Number/CurrentTimeNode.swift
@@ -35,7 +35,8 @@ public class CurrentTimeNode : Node
     public var inputNumber:ParameterPort<Float> { port(named: "inputNumber") }
     public var outputNumber:NodePort<Float> { port(named: "outputNumber") }
     
-    override public func startExecution(renderer: GraphRenderer) {
+    override public func startExecution(renderer: GraphRenderer) throws
+    {
         self.startTime = CACurrentMediaTime()
     }
 
@@ -43,6 +44,7 @@ public class CurrentTimeNode : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         self.outputNumber.send( Float(executionInfo.timing.time - startTime) )
     }

--- a/Fabric/Nodes/Parameters/Number/GradientNoiseNode.swift
+++ b/Fabric/Nodes/Parameters/Number/GradientNoiseNode.swift
@@ -45,6 +45,7 @@ public class GradientNoiseNode : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         //self.fbm.frequency_scaled(by: Double(self.inputFrequency.value) )
         if self.inputFrequency.valueDidChange,

--- a/Fabric/Nodes/Parameters/Number/MathExpressionNode.swift
+++ b/Fabric/Nodes/Parameters/Number/MathExpressionNode.swift
@@ -494,8 +494,15 @@ public class MathExpressionNode: Node
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
-        guard let compiled = self.compiled, compiled.isValid else { return }
+        guard let compiled = self.compiled, compiled.isValid else
+        {
+            let message = self.compiled?.diagnostics.first(where: { $0.severity == .error })?.message ?? "Math expression is invalid."
+            throw FabricError(.execution(.syntax),
+                              severity: .recoverable,
+                              message: message)
+        }
 
         let inlets = self.inputPorts()
         let inputsChanged = inlets.contains { $0.valueDidChange }
@@ -525,7 +532,16 @@ public class MathExpressionNode: Node
         {
             // .missingInput (input not propagated yet), .indexOutOfBounds,
             // .limitExceeded, .notCompiled — skip this frame's emit.
-            return
+            let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            if message.localizedStandardContains("missing")
+            {
+                return
+            }
+
+            throw FabricError(.execution(.syntax),
+                              severity: .recoverable,
+                              message: message,
+                              underlyingError: error)
         }
 
         for (index, output) in self.portInterface.outputs.enumerated()

--- a/Fabric/Nodes/Parameters/Number/NumberBinaryOperator.swift
+++ b/Fabric/Nodes/Parameters/Number/NumberBinaryOperator.swift
@@ -53,6 +53,7 @@ public class NumberBinaryOperator : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.inputParam.valueDidChange,
            let param = self.inputParam.value,

--- a/Fabric/Nodes/Parameters/Number/NumberBinaryOperator.swift
+++ b/Fabric/Nodes/Parameters/Number/NumberBinaryOperator.swift
@@ -39,9 +39,9 @@ public class NumberBinaryOperator : Node
     
     private var mathOperator = BinaryMathOperator.Add
     
-    override public func startExecution(renderer:GraphRenderer)
+    override public func startExecution(renderer:GraphRenderer) throws
     {
-        super.startExecution(renderer: renderer)
+        try super.startExecution(renderer: renderer)
         
         if let stringParam = self.inputParam.parameter as? StringParameter
         {

--- a/Fabric/Nodes/Parameters/Number/NumberClampNode.swift
+++ b/Fabric/Nodes/Parameters/Number/NumberClampNode.swift
@@ -45,6 +45,7 @@ public class NumberClampNode : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.inputNumber.valueDidChange || self.inputMinNumber.valueDidChange || self.inputMaxNumber.valueDidChange
         {

--- a/Fabric/Nodes/Parameters/Number/NumberIntegralNode.swift
+++ b/Fabric/Nodes/Parameters/Number/NumberIntegralNode.swift
@@ -42,6 +42,7 @@ public class NumberIntegralNode : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         self.state += (self.inputNumber.value ?? 0.0) * Float(executionInfo.timing.deltaTime)
         

--- a/Fabric/Nodes/Parameters/Number/NumberLogicOperator.swift
+++ b/Fabric/Nodes/Parameters/Number/NumberLogicOperator.swift
@@ -39,9 +39,9 @@ public class NumberLogicOperator : Node
     
     private var mathOperator = BinaryMathLogicOperator.Equals
     
-    override public func startExecution(renderer:GraphRenderer)
+    override public func startExecution(renderer:GraphRenderer) throws
     {
-        super.startExecution(renderer: renderer)
+        try super.startExecution(renderer: renderer)
         
         if let stringParam = self.inputParam.parameter as? StringParameter
         {

--- a/Fabric/Nodes/Parameters/Number/NumberLogicOperator.swift
+++ b/Fabric/Nodes/Parameters/Number/NumberLogicOperator.swift
@@ -53,6 +53,7 @@ public class NumberLogicOperator : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.inputParam.valueDidChange,
            let param = self.inputParam.value,

--- a/Fabric/Nodes/Parameters/Number/NumberRemapNode.swift
+++ b/Fabric/Nodes/Parameters/Number/NumberRemapNode.swift
@@ -46,6 +46,7 @@ public class NumberRemapNode : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.inputNumber.valueDidChange ||
             self.inputMinNumber.valueDidChange ||

--- a/Fabric/Nodes/Parameters/Number/NumberRoundNode.swift
+++ b/Fabric/Nodes/Parameters/Number/NumberRoundNode.swift
@@ -43,6 +43,7 @@ public class NumberRoundNode : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.inputNumber.valueDidChange || self.inputRoundMethod.valueDidChange
         {

--- a/Fabric/Nodes/Parameters/Number/NumberTweenAnimationNode.swift
+++ b/Fabric/Nodes/Parameters/Number/NumberTweenAnimationNode.swift
@@ -47,6 +47,7 @@ public class NumberTweenNode : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         let time = executionInfo.timing.time
 

--- a/Fabric/Nodes/Parameters/Number/NumberTweenNode.swift
+++ b/Fabric/Nodes/Parameters/Number/NumberTweenNode.swift
@@ -40,6 +40,7 @@ public class NumberEaseNode : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.inputNumber.valueDidChange,
            let param = self.inputParam.value,

--- a/Fabric/Nodes/Parameters/Number/NumberUnaryOperator.swift
+++ b/Fabric/Nodes/Parameters/Number/NumberUnaryOperator.swift
@@ -44,6 +44,7 @@ public class NumberUnaryOperator : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if  self.inputParam.valueDidChange,
             let param = self.inputParam.value,

--- a/Fabric/Nodes/Parameters/Number/Smooth/NumberSmoothNode.swift
+++ b/Fabric/Nodes/Parameters/Number/Smooth/NumberSmoothNode.swift
@@ -44,6 +44,7 @@ public class NumberSmoothNode : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.inputFrequency.valueDidChange,
            let inputFrequency = self.inputFrequency.value

--- a/Fabric/Nodes/Parameters/Number/SystemTimeNode.swift
+++ b/Fabric/Nodes/Parameters/Number/SystemTimeNode.swift
@@ -38,7 +38,8 @@ public class SystemTimeNode : Node
     public var inputNumber:ParameterPort<Float> { port(named: "inputNumber") }
     public var outputNumber:NodePort<Float> { port(named: "outputNumber") }
     
-    override public func startExecution(renderer: GraphRenderer) {
+    override public func startExecution(renderer: GraphRenderer) throws
+    {
         self.startTime = Date.timeIntervalSinceReferenceDate// context.timing.systemTime
     }
     
@@ -46,6 +47,7 @@ public class SystemTimeNode : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         self.outputNumber.send( Float(executionInfo.timing.systemTime - startTime) )
     }

--- a/Fabric/Nodes/Parameters/Number/TimelineNode.swift
+++ b/Fabric/Nodes/Parameters/Number/TimelineNode.swift
@@ -951,6 +951,7 @@ public class TimelineNode: Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         let time = self.inputTime.value ?? Float(executionInfo.timing.time)
 

--- a/Fabric/Nodes/Parameters/Number/TimestampNode.swift
+++ b/Fabric/Nodes/Parameters/Number/TimestampNode.swift
@@ -32,6 +32,7 @@ public class TimestampNode: Node {
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         let timestamp = Date().timeIntervalSince1970
         outputSeconds.send(Int(timestamp))

--- a/Fabric/Nodes/Parameters/Numeric/ArrayRangeInterpolateNode.swift
+++ b/Fabric/Nodes/Parameters/Numeric/ArrayRangeInterpolateNode.swift
@@ -41,6 +41,7 @@ public final class ArrayRangeInterpolateNode: NumericTypeAgnosticNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if specializeFromConnectedPort(named: "inputFrom") || specializeFromConnectedPort(named: "inputTo") { return }
         guard let inputFrom: Port = findPort(named: "inputFrom"),

--- a/Fabric/Nodes/Parameters/Numeric/ArrayResampleTypeAgnosticNode.swift
+++ b/Fabric/Nodes/Parameters/Numeric/ArrayResampleTypeAgnosticNode.swift
@@ -37,6 +37,7 @@ public final class ArrayResampleTypeAgnosticNode: NumericTypeAgnosticNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if specializeFromConnectedPort(named: "inputArray") { return }
         guard let inputArray: Port = findPort(named: "inputArray"),

--- a/Fabric/Nodes/Parameters/Numeric/DistanceNode.swift
+++ b/Fabric/Nodes/Parameters/Numeric/DistanceNode.swift
@@ -40,6 +40,7 @@ public final class DistanceNode: NumericTypeAgnosticNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if specializeFromConnectedPort(named: "inputA") || specializeFromConnectedPort(named: "inputB") { return }
         guard let inputA: Port = findPort(named: "inputA"),

--- a/Fabric/Nodes/Parameters/Numeric/EasingNode.swift
+++ b/Fabric/Nodes/Parameters/Numeric/EasingNode.swift
@@ -40,6 +40,7 @@ public final class EasingNode: NumericTypeAgnosticNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if specializeFromConnectedPort(named: "inputFrom") || specializeFromConnectedPort(named: "inputTo") { return }
         guard let inputFrom: Port = findPort(named: "inputFrom"),

--- a/Fabric/Nodes/Parameters/Numeric/PairwiseDistanceArrayNode.swift
+++ b/Fabric/Nodes/Parameters/Numeric/PairwiseDistanceArrayNode.swift
@@ -40,6 +40,7 @@ public final class PairwiseDistanceArrayNode: NumericTypeAgnosticNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if specializeFromConnectedPort(named: "inputA") || specializeFromConnectedPort(named: "inputB") { return }
         guard let inputA: Port = findPort(named: "inputA"),

--- a/Fabric/Nodes/Parameters/Numeric/RepeatNode.swift
+++ b/Fabric/Nodes/Parameters/Numeric/RepeatNode.swift
@@ -38,6 +38,7 @@ public final class RepeatNode: NumericTypeAgnosticNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if specializeFromConnectedPort(named: "inputValue") { return }
         guard let inputValue: Port = findPort(named: "inputValue"),

--- a/Fabric/Nodes/Parameters/Numeric/RippleRepeatNode.swift
+++ b/Fabric/Nodes/Parameters/Numeric/RippleRepeatNode.swift
@@ -47,6 +47,7 @@ public final class RippleRepeatNode: NumericTypeAgnosticNode
     }
 
     override public func startExecution(renderer: GraphRenderer)
+    throws
     {
         history.removeAll()
         oldest = nil
@@ -57,6 +58,7 @@ public final class RippleRepeatNode: NumericTypeAgnosticNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if specializeFromConnectedPort(named: "inputValue") { return }
         guard let inputValue: Port = findPort(named: "inputValue"),

--- a/Fabric/Nodes/Parameters/Numeric/TweenNode.swift
+++ b/Fabric/Nodes/Parameters/Numeric/TweenNode.swift
@@ -50,6 +50,7 @@ public final class TweenNode: NumericTypeAgnosticNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if specializeFromConnectedPort(named: "inputTarget") { return }
         guard let inputTarget: Port = findPort(named: "inputTarget"),

--- a/Fabric/Nodes/Parameters/Orientation/ComposeOrientationNode.swift
+++ b/Fabric/Nodes/Parameters/Orientation/ComposeOrientationNode.swift
@@ -76,6 +76,7 @@ public class ComposeOrientationNode: StrategyNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard let outputOrientation: NodePort<simd_float4> = findPort(named: "outputOrientation") else { return }
 

--- a/Fabric/Nodes/Parameters/Orientation/DecomposeOrientationNode.swift
+++ b/Fabric/Nodes/Parameters/Orientation/DecomposeOrientationNode.swift
@@ -65,6 +65,7 @@ public class DecomposeOrientationNode: StrategyNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard let inputOrientation: NodePort<simd_float4> = findPort(named: "inputOrientation"),
               inputOrientation.valueDidChange,

--- a/Fabric/Nodes/Parameters/Orientation/OrientationTweenNode.swift
+++ b/Fabric/Nodes/Parameters/Orientation/OrientationTweenNode.swift
@@ -52,6 +52,7 @@ public class OrientationTweenNode : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         let time = executionInfo.timing.time
 

--- a/Fabric/Nodes/Parameters/PassThroughNode.swift
+++ b/Fabric/Nodes/Parameters/PassThroughNode.swift
@@ -113,6 +113,7 @@ public class PassThroughNode<T: PortValueRepresentable>: Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         switch self.nodeExecutionMode
         {

--- a/Fabric/Nodes/Parameters/String/DirectoryScannerNode.swift
+++ b/Fabric/Nodes/Parameters/String/DirectoryScannerNode.swift
@@ -40,6 +40,7 @@ public class DirectoryScannerNode: Node {
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         let rescanTriggered: Bool
         if let rescan = inputRescan.value, inputRescan.valueDidChange {
@@ -52,23 +53,40 @@ public class DirectoryScannerNode: Node {
         if inputPath.valueDidChange || inputExtension.valueDidChange || rescanTriggered,
            let path = inputPath.value,
            !path.isEmpty {
-            scanDirectory(path: path)
+            try scanDirectory(path: path)
         }
     }
 
-    private func scanDirectory(path: String) {
-        guard let url = URL(string: path) else { return }
+    private func scanDirectory(path: String) throws {
+        guard let url = URL(string: path) else
+        {
+            throw FabricError(.execution(.fileNotFound),
+                              severity: .recoverable,
+                              message: "Directory path is invalid: \(path)")
+        }
+
         let dirPath = url.standardizedFileURL.path(percentEncoded: false)
         let fileManager = FileManager.default
 
         var isDirectory: ObjCBool = false
         guard fileManager.fileExists(atPath: dirPath, isDirectory: &isDirectory),
               isDirectory.boolValue else {
-            return
+            throw FabricError(.execution(.fileNotFound),
+                              severity: .recoverable,
+                              message: "Directory not found: \(dirPath)")
         }
 
-        guard let contents = try? fileManager.contentsOfDirectory(atPath: dirPath) else {
-            return
+        let contents: [String]
+        do
+        {
+            contents = try fileManager.contentsOfDirectory(atPath: dirPath)
+        }
+        catch
+        {
+            throw FabricError(.execution(.failed),
+                              severity: .recoverable,
+                              message: "Could not scan directory: \(dirPath)",
+                              underlyingError: error)
         }
 
         let ext = inputExtension.value ?? ""

--- a/Fabric/Nodes/Parameters/String/LLM/LocalLLMNode.swift
+++ b/Fabric/Nodes/Parameters/String/LLM/LocalLLMNode.swift
@@ -75,6 +75,7 @@ public class LocalLLMNode : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.inputModel.valueDidChange,
            let name = self.inputModel.value,

--- a/Fabric/Nodes/Parameters/String/StringCaseNode.swift
+++ b/Fabric/Nodes/Parameters/String/StringCaseNode.swift
@@ -36,6 +36,7 @@ public class StringCaseNode: Node {
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if inputCase.valueDidChange,
            let param = inputCase.value,

--- a/Fabric/Nodes/Parameters/String/StringComparisonNode.swift
+++ b/Fabric/Nodes/Parameters/String/StringComparisonNode.swift
@@ -38,6 +38,7 @@ public class StringComparisonNode: Node {
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if inputOperator.valueDidChange,
            let param = inputOperator.value,

--- a/Fabric/Nodes/Parameters/String/StringDifferenceNode.swift
+++ b/Fabric/Nodes/Parameters/String/StringDifferenceNode.swift
@@ -40,6 +40,7 @@ public class StringDifferenceNode : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.inputPort.valueDidChange || self.input2Port.valueDidChange
         {

--- a/Fabric/Nodes/Parameters/String/StringFormatterNode.swift
+++ b/Fabric/Nodes/Parameters/String/StringFormatterNode.swift
@@ -170,6 +170,7 @@ public class StringFormatterNode: Node {
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         let inputs = self.inputPorts()
         let anyChanged = inputs.compactMap(\.valueDidChange).contains(true)

--- a/Fabric/Nodes/Parameters/String/StringJoinNode.swift
+++ b/Fabric/Nodes/Parameters/String/StringJoinNode.swift
@@ -40,6 +40,7 @@ public class StringJoinNode : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.inputPort.valueDidChange || self.separatorPort.valueDidChange
         {

--- a/Fabric/Nodes/Parameters/String/StringLengthNode.swift
+++ b/Fabric/Nodes/Parameters/String/StringLengthNode.swift
@@ -38,6 +38,7 @@ public class StringLengthNode : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.inputPort.valueDidChange
         {

--- a/Fabric/Nodes/Parameters/String/StringRange.swift
+++ b/Fabric/Nodes/Parameters/String/StringRange.swift
@@ -43,6 +43,7 @@ public class StringRangeNode : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.inputPort.valueDidChange || self.inputRangeFrom.valueDidChange || self.inputRangeTo.valueDidChange
         {

--- a/Fabric/Nodes/Parameters/String/StringScannerNode.swift
+++ b/Fabric/Nodes/Parameters/String/StringScannerNode.swift
@@ -123,6 +123,7 @@ public class StringScannerNode: Node {
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard inputString.valueDidChange,
               let input = inputString.value,

--- a/Fabric/Nodes/Parameters/String/StringSplitNode.swift
+++ b/Fabric/Nodes/Parameters/String/StringSplitNode.swift
@@ -34,6 +34,7 @@ public class StringSplitNode: Node {
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if inputPort.valueDidChange || inputSeparator.valueDidChange,
            let string = inputPort.value,

--- a/Fabric/Nodes/Parameters/String/StringTrimNode.swift
+++ b/Fabric/Nodes/Parameters/String/StringTrimNode.swift
@@ -39,6 +39,7 @@ public class StringTrimNode : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.inputPort.valueDidChange
         {

--- a/Fabric/Nodes/Parameters/String/StringWrap.swift
+++ b/Fabric/Nodes/Parameters/String/StringWrap.swift
@@ -40,6 +40,7 @@ public class StringWrapNode: Node {
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if inputMode.valueDidChange,
            let param = inputMode.value,

--- a/Fabric/Nodes/Parameters/String/TextFileLoaderNode.swift
+++ b/Fabric/Nodes/Parameters/String/TextFileLoaderNode.swift
@@ -58,10 +58,11 @@ public final class TextFileLoaderNode : Node, NodeFileLoadingProtocol
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.inputFilePathParam.valueDidChange
         {
-            self.loadStringFromURL()
+            try self.loadStringFromURL()
             
             if let string = self.string
             {
@@ -75,18 +76,40 @@ public final class TextFileLoaderNode : Node, NodeFileLoadingProtocol
         }
     }
     
-    private func loadStringFromURL()
+    private func loadStringFromURL() throws
     {
         if let path = self.inputFilePathParam.value,
            path.isEmpty == false && self.url != URL(string: path)
         {
-            self.url = URL(string: path)
-            
-            if FileManager.default.fileExists(atPath: self.url!.standardizedFileURL.path(percentEncoded: false) )
+            guard let url = URL(string: path) else
             {
-                self.string = try? String(contentsOfFile: self.url!.path, encoding: .utf8)
+                throw FabricError(.execution(.fileNotFound),
+                                  severity: .recoverable,
+                                  message: "Text file path is invalid: \(path)")
+            }
+
+            self.url = url
+
+            guard FileManager.default.fileExists(atPath: url.standardizedFileURL.path(percentEncoded: false)) else
+            {
+                self.string = nil
+                throw FabricError(.execution(.fileNotFound),
+                                  severity: .recoverable,
+                                  message: "Text file not found: \(url.path)")
+            }
+
+            do
+            {
+                self.string = try String(contentsOfFile: url.path, encoding: .utf8)
+            }
+            catch
+            {
+                self.string = nil
+                throw FabricError(.execution(.failed),
+                                  severity: .recoverable,
+                                  message: "Could not load text file: \(url.path)",
+                                  underlyingError: error)
             }
         }
-        
     }
 }

--- a/Fabric/Nodes/Parameters/String/TimecodeFormatterNode.swift
+++ b/Fabric/Nodes/Parameters/String/TimecodeFormatterNode.swift
@@ -34,6 +34,7 @@ public class TimecodeFormatterNode: Node {
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if inputTime.valueDidChange || inputFPS.valueDidChange,
            let time = inputTime.value,

--- a/Fabric/Nodes/Parameters/String/TimestampFormatterNode.swift
+++ b/Fabric/Nodes/Parameters/String/TimestampFormatterNode.swift
@@ -36,6 +36,7 @@ public class TimestampFormatterNode: Node {
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if inputFormat.valueDidChange,
            let format = inputFormat.value {

--- a/Fabric/Nodes/Parameters/Transform/ComposeTransformNode.swift
+++ b/Fabric/Nodes/Parameters/Transform/ComposeTransformNode.swift
@@ -67,6 +67,7 @@ public class ComposeTransformNode: StrategyNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard let outputTransform: NodePort<simd_float4x4> = findPort(named: "outputTransform") else { return }
 

--- a/Fabric/Nodes/Parameters/Transform/DecomposeTransformNode.swift
+++ b/Fabric/Nodes/Parameters/Transform/DecomposeTransformNode.swift
@@ -67,6 +67,7 @@ public class DecomposeTransformNode: StrategyNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard let inputTransform: NodePort<simd_float4x4> = findPort(named: "inputTransform"),
               inputTransform.valueDidChange,

--- a/Fabric/Nodes/Parameters/Transform/InvertTransformNode.swift
+++ b/Fabric/Nodes/Parameters/Transform/InvertTransformNode.swift
@@ -38,6 +38,7 @@ public class InvertTransformNode : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.inputTranslation.valueDidChange || self.inputTransform.valueDidChange,
            let inputTransform = self.inputTransform.value

--- a/Fabric/Nodes/Parameters/Transform/RotateTransformNode.swift
+++ b/Fabric/Nodes/Parameters/Transform/RotateTransformNode.swift
@@ -39,6 +39,7 @@ public class RotateTransformNode : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.inputRotation.valueDidChange || self.inputTransform.valueDidChange,
            let inputTransform = self.inputTransform.value,

--- a/Fabric/Nodes/Parameters/Transform/ScaleTransformNode.swift
+++ b/Fabric/Nodes/Parameters/Transform/ScaleTransformNode.swift
@@ -39,6 +39,7 @@ public class ScaleTransformNode : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.inputScale.valueDidChange || self.inputTransform.valueDidChange,
            let inputTransform = self.inputTransform.value,

--- a/Fabric/Nodes/Parameters/Transform/TranslateTransformNode.swift
+++ b/Fabric/Nodes/Parameters/Transform/TranslateTransformNode.swift
@@ -39,6 +39,7 @@ public class TranslateTransformNode : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.inputTranslation.valueDidChange || self.inputTransform.valueDidChange,
            let inputTransform = self.inputTransform.value,

--- a/Fabric/Nodes/Parameters/Transform/TransposeTransformNode.swift
+++ b/Fabric/Nodes/Parameters/Transform/TransposeTransformNode.swift
@@ -38,6 +38,7 @@ public class TransposeTransformNode : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.inputTranslation.valueDidChange || self.inputTransform.valueDidChange,
            let inputTransform = self.inputTransform.value

--- a/Fabric/Nodes/Parameters/Vector/ComposeVectorNode.swift
+++ b/Fabric/Nodes/Parameters/Vector/ComposeVectorNode.swift
@@ -65,6 +65,7 @@ public class ComposeVectorNode: StrategyNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard let vt: VectorType = strategyOption() else { return }
 

--- a/Fabric/Nodes/Parameters/Vector/DecomposeVectorNode.swift
+++ b/Fabric/Nodes/Parameters/Vector/DecomposeVectorNode.swift
@@ -65,6 +65,7 @@ public class DecomposeVectorNode: StrategyNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard let vt: VectorType = strategyOption() else { return }
 

--- a/Fabric/Nodes/Parameters/Vector/Vector2DistanceNode.swift
+++ b/Fabric/Nodes/Parameters/Vector/Vector2DistanceNode.swift
@@ -70,6 +70,7 @@ public class Vector2Distance : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.inputMetricParam.valueDidChange,
            let inputMetric = self.inputMetricParam.value

--- a/Fabric/Nodes/Parameters/Vector/Vector3DistanceNode.swift
+++ b/Fabric/Nodes/Parameters/Vector/Vector3DistanceNode.swift
@@ -70,6 +70,7 @@ public class Vector3Distance : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.inputMetricParam.valueDidChange,
            let inputMetric = self.inputMetricParam.value

--- a/Fabric/Nodes/Parameters/Vector/Vector4DistanceNode.swift
+++ b/Fabric/Nodes/Parameters/Vector/Vector4DistanceNode.swift
@@ -70,6 +70,7 @@ public class Vector4Distance : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.inputMetricParam.valueDidChange,
            let inputMetric = self.inputMetricParam.value

--- a/Fabric/Nodes/Parameters/Vector/VectorTweenNode.swift
+++ b/Fabric/Nodes/Parameters/Vector/VectorTweenNode.swift
@@ -46,6 +46,7 @@ public class VectorTweenNode<Value> : Node where Value: PortValueRepresentable &
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         let time = executionInfo.timing.time
 

--- a/Fabric/Nodes/Plugin/FabricCoreNodesPlugin.swift
+++ b/Fabric/Nodes/Plugin/FabricCoreNodesPlugin.swift
@@ -1,0 +1,379 @@
+//
+//  FabricCoreNodesPlugin.swift
+//  Fabric
+//
+//  Created by Anton Marini on 7/24/26.
+//
+
+import Foundation
+import Satin
+import simd
+
+/// Embedded plugin that provides Fabric's built-in nodes.
+///
+/// This is intentionally loaded by `PluginLoader` before external bundles so
+/// built-in nodes dogfood the same registry path as third-party nodes.
+public final class FabricCoreNodesPlugin: NSObject, FabricPlugin
+{
+    public static let pluginID = "graphics.fabric.CoreNodes"
+
+    public static func pluginDidLoad(bundle: Bundle) {}
+    public static func pluginWillUnload() {}
+
+    public static func additionalNodeClasses() -> [Node.Type]
+    {
+        cameraNodeClasses
+        + lightNodeClasses
+        + objectNodeClasses
+        + geometryNodeClasses
+        + materialNodeClasses
+        + textureNodeClasses
+        + parameterNodeClasses
+        + ioNodeClasses
+        + macroNodeClasses
+        + utilityClasses
+    }
+
+    public static func dynamicNodeWrappers() -> [NodeClassWrapper]
+    {
+        let bundle = Bundle.module
+        var nodes: [NodeClassWrapper] = []
+
+        for imageEffectType in Node.NodeType.ImageType.allCases
+        {
+            let singleChannelEffects = "Effects/\(imageEffectType.rawValue)"
+            let twoChannelEffects = "EffectsTwoChannel/\(imageEffectType.rawValue)"
+            let threeChannelEffects = "EffectsThreeChannel/\(imageEffectType.rawValue)"
+            let computeSubdir = "Compute/\(imageEffectType.rawValue)"
+
+            guard let singleChannelEffects = bundle.urls(forResourcesWithExtension: "metal", subdirectory: singleChannelEffects),
+                  let twoChannelEffects = bundle.urls(forResourcesWithExtension: "metal", subdirectory: twoChannelEffects),
+                  let threeChannelEffects = bundle.urls(forResourcesWithExtension: "metal", subdirectory: threeChannelEffects),
+                  let singleChannelComputeEffects = bundle.urls(forResourcesWithExtension: "metal", subdirectory: computeSubdir)
+            else
+            {
+                continue
+            }
+
+            for fileURL in singleChannelEffects + twoChannelEffects + threeChannelEffects
+            {
+                nodes.append(NodeClassWrapper(nodeClass: BaseImageNode.self,
+                                              nodeType: .Image(imageType: imageEffectType),
+                                              fileURL: fileURL,
+                                              nodeName: fileURLToName(fileURL: fileURL),
+                                              nodeDescription: shaderDescription(from: fileURL) ?? BaseImageNode.nodeDescription,
+                                              pluginBundleID: pluginID))
+            }
+
+            for fileURL in singleChannelComputeEffects
+            {
+                nodes.append(NodeClassWrapper(nodeClass: BaseTextureComputeProcessorNode.self,
+                                              nodeType: .Image(imageType: imageEffectType),
+                                              fileURL: fileURL,
+                                              nodeName: fileURLToName(fileURL: fileURL),
+                                              nodeDescription: shaderDescription(from: fileURL) ?? BaseTextureComputeProcessorNode.nodeDescription,
+                                              pluginBundleID: pluginID))
+            }
+        }
+
+        return nodes.sorted { $0.nodeName < $1.nodeName }
+    }
+
+    private static func fileURLToName(fileURL: URL) -> String
+    {
+        let nodeName = fileURL.deletingPathExtension().lastPathComponent.replacing("ImageNode", with: "")
+        return nodeName.titleCase
+    }
+
+    private static func shaderDescription(from fileURL: URL) -> String?
+    {
+        guard let data = try? Data(contentsOf: fileURL, options: .mappedIfSafe),
+              let source = String(data: data, encoding: .utf8)
+        else
+        {
+            return nil
+        }
+
+        for line in source.split(separator: "\n", maxSplits: 20, omittingEmptySubsequences: false)
+        {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard trimmed.hasPrefix("// description:") else { continue }
+
+            let description = trimmed.dropFirst("// description:".count).trimmingCharacters(in: .whitespaces)
+            return description.isEmpty ? nil : description
+        }
+
+        return nil
+    }
+
+    private static let cameraNodeClasses: [Node.Type] = [
+        PerspectiveCameraNode.self,
+        OrthographicCameraNode.self,
+    ]
+
+    private static let lightNodeClasses: [Node.Type] = [
+        DirectionalLightNode.self,
+        PointLightNode.self,
+        SpotLightNode.self,
+    ]
+
+    private static let objectNodeClasses: [Node.Type] = [
+        MeshNode.self,
+        ModelMeshNode.self,
+        InstancedMeshNode.self,
+        InstancedModelMeshNode.self,
+        EnvironmentSkyboxNode.self,
+        ImageMeshNode.self,
+    ]
+
+    private static let geometryNodeClasses: [Node.Type] = [
+        PassThroughNode<Geometry>.self,
+        PlaneGeometryNode.self,
+        PerspectiveQuadGeometryNode.self,
+        RoundRectGeometryNode.self,
+        TriangleGeometryNode.self,
+        CircleGeometryNode.self,
+        ArcGeometryNode.self,
+        ConeGeometryNode.self,
+        BoxGeometryNode.self,
+        RoundBoxGeometryNode.self,
+        SphereGeometryNode.self,
+        IcoSphereGeometryNode.self,
+        CapsuleGeometryNode.self,
+        TubeGeometryNode.self,
+        TorusGeometryNode.self,
+        CycloramaGeometryNode.self,
+        TesselatedTextGeometryNode.self,
+        ExtrudedTextGeometryNode.self,
+        PixelArrayToGeometryNode.self,
+        SuperShapeGeometryNode.self,
+        MobiusStripGeometryNode.self,
+        HelicoidGeometryNode.self,
+        SuperellipsoidGeometryNode.self,
+        KleinBottleGeometryNode.self,
+        CatenoidGeometryNode.self,
+        ParaboloidGeometryNode.self,
+        EnneperSurfaceGeometryNode.self,
+        PseudosphereGeometryNode.self,
+        DupinCyclideGeometryNode.self,
+        RomanSurfaceGeometryNode.self,
+        CrossCapGeometryNode.self,
+        BourSurfaceGeometryNode.self,
+        BreatherSurfaceGeometryNode.self,
+        DiniSurfaceGeometryNode.self,
+        MathExpressionParametricGeometryNode.self,
+    ]
+
+    private static let materialNodeClasses: [Node.Type] = [
+        PassThroughNode<Material>.self,
+        BasicColorMaterialNode.self,
+        UVMaterialNode.self,
+        BasicTextureMaterialNode.self,
+        BasicDiffuseMaterialNode.self,
+        DepthMaterialNode.self,
+        StandardMaterialNode.self,
+        PBRMaterialNode.self,
+        DisplacementMaterialNode.self,
+    ]
+
+    private static var textureNodeClasses: [Node.Type]
+    {
+        var classes: [Node.Type] = [
+            PassThroughNode<FabricImage>.self,
+            MovieProviderNode.self,
+            CameraProviderNode.self,
+            ImageProviderNode.self,
+            TestCardProviderNode.self,
+        ]
+        #if os(macOS)
+        classes.append(ScreenCaptureProviderNode.self)
+        #endif
+        #if FABRIC_SYPHON_ENABLED
+        classes.append(contentsOf: [
+            SyphonClientNode.self,
+            SyphonServerNode.self,
+        ])
+        #endif
+        classes.append(contentsOf: [
+            LiveImageNode.self,
+            DepthOfFieldNode.self,
+            GaussianBlurNode.self,
+            GaussianBlurChannelsNode.self,
+            MotionBlurNode.self,
+            PostProcessMotionBlurNode.self,
+            ZoomBlurNode.self,
+            ForegroundMaskNode.self,
+            PersonSegmentationMaskNode.self,
+            FacePoseAnalysisNode.self,
+            HandPoseAnalysisNode.self,
+            LucasKanadeOpticalFlowNode.self,
+            DCTNode.self,
+            InverseDCTNode.self,
+            LocalVLMNode.self,
+            ContourPathNode.self,
+            MetalFXSpatialUpsample2xNode.self,
+            KeypointDistortNode.self,
+            LUTProcessorNode.self,
+            BlendNode.self,
+            TextureCropNode.self,
+            ImageResampleNode.self,
+        ])
+        return classes
+    }
+
+    private static let macroNodeClasses: [Node.Type] = [
+        SubgraphNode.self,
+        DeferredSubgraphNode.self,
+        IteratorNode.self,
+        IteratorInfoNode.self,
+        EnvironmentNode.self,
+    ]
+
+    private static let parameterNodeClasses: [Node.Type] = [
+        DistanceNode.self,
+        EasingNode.self,
+        TweenNode.self,
+        RepeatNode.self,
+        RippleRepeatNode.self,
+        PairwiseDistanceArrayNode.self,
+        ArrayRangeInterpolateNode.self,
+        ArrayResampleTypeAgnosticNode.self,
+        PassThroughNode<Bool>.self,
+        BooleanLogicNode.self,
+        PassThroughNode<Float>.self,
+        PassThroughNode<Int>.self,
+        CurrentTimeNode.self,
+        SystemTimeNode.self,
+        TimestampNode.self,
+        TimelineNode.self,
+        NumberUnaryOperator.self,
+        NumberBinaryOperator.self,
+        NumberLogicOperator.self,
+        NumberRoundNode.self,
+        NumberClampNode.self,
+        NumberRemapNode.self,
+        NumberIntegralNode.self,
+        NumberSmoothNode.self,
+        MathExpressionNode.self,
+        GradientNoiseNode.self,
+        AudioSpectrumNode.self,
+        PassThroughNode<simd_float2>.self,
+        PassThroughNode<simd_float3>.self,
+        PassThroughNode<simd_float4>.self,
+        ComposeVectorNode.self,
+        DecomposeVectorNode.self,
+        ComposeVectorArrayNode.self,
+        DecomposeVectorArrayNode.self,
+        PassThroughNode<simd_quatf>.self,
+        ComposeOrientationNode.self,
+        DecomposeOrientationNode.self,
+        ComposeOrientationArrayNode.self,
+        DecomposeOrientationArrayNode.self,
+        PassThroughNode<simd_float4x4>.self,
+        ComposeTransformNode.self,
+        DecomposeTransformNode.self,
+        TranslateTransformNode.self,
+        RotateTransformNode.self,
+        ScaleTransformNode.self,
+        TransposeTransformNode.self,
+        InvertTransformNode.self,
+        ComposeTransformArrayNode.self,
+        DecomposeTransformArrayNode.self,
+        GeometryToTransformArrayNode.self,
+        ColorPassThroughNode.self,
+        MakeColorNode.self,
+        PassThroughNode<String>.self,
+        StringTrimNode.self,
+        StringLengthNode.self,
+        StringRangeNode.self,
+        StringWrapNode.self,
+        StringCaseNode.self,
+        StringComparisonNode.self,
+        StringFormatterNode.self,
+        StringScannerNode.self,
+        StringJoinNode.self,
+        StringSplitNode.self,
+        StringDifferenceNode.self,
+        TimestampFormatterNode.self,
+        TimecodeFormatterNode.self,
+        LocalLLMNode.self,
+        DirectoryScannerNode.self,
+        TextFileLoaderNode.self,
+        PassThroughNode<Dictionary<String, PortValue>>.self,
+        PassThroughNode<Dictionary<String, Bool>>.self,
+        PassThroughNode<Dictionary<String, Int>>.self,
+        PassThroughNode<Dictionary<String, Float>>.self,
+        PassThroughNode<Dictionary<String, String>>.self,
+        PassThroughNode<Dictionary<String, simd_float2>>.self,
+        PassThroughNode<Dictionary<String, simd_float3>>.self,
+        PassThroughNode<Dictionary<String, simd_float4>>.self,
+        PassThroughNode<Dictionary<String, simd_quatf>>.self,
+        PassThroughNode<Dictionary<String, simd_float4x4>>.self,
+        PassThroughNode<Dictionary<String, Geometry>>.self,
+        PassThroughNode<Dictionary<String, Material>>.self,
+        PassThroughNode<Dictionary<String, FabricImage>>.self,
+        ComposeDictionaryNode.self,
+        DecomposeDictionaryNode.self,
+        DictionarySetValueForKeyNode.self,
+        DictionaryValueForKeyNode.self,
+        DictionaryCountNode.self,
+        DictionaryHasKeyNode.self,
+        DictionaryRemoveKeyNode.self,
+        DictionaryMergeNode.self,
+        DictionaryFromJSONStringNode.self,
+        ArrayCountNode.self,
+        ArrayFirstValueNode.self,
+        ArrayLastValueNode.self,
+        ArrayIndexValueNode.self,
+        ArrayAppendNode.self,
+        ArrayReplaceValueAtIndexNode.self,
+        ArraySplitAtIndexNode.self,
+        ArraySubarrayNode.self,
+        ArrayQueueNode.self,
+        ArrayReverseNode.self,
+        ArrayShuffleNode.self,
+        LinePointsNode.self,
+        RingPointsNode.self,
+        GridPointsNode.self,
+        PolyLineSimplifyNode.self,
+    ]
+
+    private static var ioNodeClasses: [Node.Type]
+    {
+        var classes: [Node.Type] = [
+            OSCReceiveNode.self,
+        ]
+        #if os(macOS)
+        classes.append(HIDNode.self)
+        #endif
+        classes.append(contentsOf: [
+            GameControllerNode.self,
+            MIDIInputNode.self,
+        ])
+        return classes
+    }
+
+    private static var utilityClasses: [Node.Type]
+    {
+        var classes: [Node.Type] = [
+            LogNode.self,
+            JavaScriptNode.self,
+            CursorNode.self,
+        ]
+        #if os(macOS)
+        classes.append(KeyboardNode.self)
+        #endif
+        classes.append(contentsOf: [
+            RenderInfoNode.self,
+            ImageDimensions.self,
+            PixelsToUnitsNode.self,
+            UnitsoPixelsNode.self,
+            SignalNode.self,
+            SwitchNode.self,
+            GateNode.self,
+            MatrixSwitchNode.self,
+            SampleAndHoldNode.self,
+        ])
+        return classes
+    }
+}

--- a/Fabric/Nodes/Plugin/FabricPlugin.swift
+++ b/Fabric/Nodes/Plugin/FabricPlugin.swift
@@ -1,0 +1,35 @@
+//
+//  FabricPlugin.swift
+//  Fabric
+//
+//  Created by Anton Marini on 7/24/26.
+//
+
+import Foundation
+
+/// Optional lifecycle hooks for Fabric plugin bundles.
+///
+/// A plugin bundle can expose a principal class conforming to this protocol via
+/// `NSPrincipalClass` in its Info.plist. Node classes can also be declared
+/// directly in `FabricPluginNodeClasses`.
+public protocol FabricPlugin: AnyObject
+{
+    /// Called after Fabric successfully loads the plugin bundle.
+    static func pluginDidLoad(bundle: Bundle)
+
+    /// Called before Fabric unloads the plugin bundle.
+    static func pluginWillUnload()
+
+    /// Additional node classes provided by this plugin.
+    ///
+    /// This supports plugins that build their node list at runtime instead of
+    /// declaring every class in Info.plist.
+    static func additionalNodeClasses() -> [Node.Type]
+}
+
+public extension FabricPlugin
+{
+    static func pluginDidLoad(bundle: Bundle) {}
+    static func pluginWillUnload() {}
+    static func additionalNodeClasses() -> [Node.Type] { [] }
+}

--- a/Fabric/Nodes/Plugin/PluginIdentity.swift
+++ b/Fabric/Nodes/Plugin/PluginIdentity.swift
@@ -1,0 +1,39 @@
+//
+//  PluginIdentity.swift
+//  Fabric
+//
+//  Created by Anton Marini on 7/27/26.
+//
+
+import Foundation
+
+public struct PluginQualifiedNodeID: Codable, Hashable, Sendable, CustomStringConvertible
+{
+    public static let separator = "/"
+
+    public let pluginID: String
+    public let nodeID: String
+
+    public init(pluginID: String, nodeID: String)
+    {
+        self.pluginID = pluginID
+        self.nodeID = nodeID
+    }
+
+    public var description: String
+    {
+        "\(pluginID)\(Self.separator)\(nodeID)"
+    }
+}
+
+public struct PluginRequirement: Codable, Hashable, Sendable
+{
+    public let id: String
+    public let version: String?
+
+    public init(id: String, version: String? = nil)
+    {
+        self.id = id
+        self.version = version
+    }
+}

--- a/Fabric/Nodes/Plugin/PluginInfo.swift
+++ b/Fabric/Nodes/Plugin/PluginInfo.swift
@@ -1,0 +1,89 @@
+//
+//  PluginInfo.swift
+//  Fabric
+//
+//  Created by Anton Marini on 7/24/26.
+//
+
+import Foundation
+
+/// Metadata parsed from a Fabric plugin bundle's Info.plist.
+public struct PluginInfo
+{
+    public let id: String
+    public let name: String
+    public let displayName: String
+    public let version: String?
+    public let author: String?
+    public let description: String?
+    public let bundleURL: URL
+    public let apiVersion: Int
+    public let nodeClassNames: [String]
+    public let principalClassName: String?
+    public let bundle: Bundle
+
+    public init(id: String,
+                name: String,
+                displayName: String,
+                version: String? = nil,
+                author: String? = nil,
+                description: String? = nil,
+                bundleURL: URL,
+                apiVersion: Int,
+                nodeClassNames: [String],
+                principalClassName: String?,
+                bundle: Bundle)
+    {
+        self.id = id
+        self.name = name
+        self.displayName = displayName
+        self.version = version
+        self.author = author
+        self.description = description
+        self.bundleURL = bundleURL
+        self.apiVersion = apiVersion
+        self.nodeClassNames = nodeClassNames
+        self.principalClassName = principalClassName
+        self.bundle = bundle
+    }
+
+    public init(bundle: Bundle) throws
+    {
+        guard let bundleID = bundle.bundleIdentifier else
+        {
+            throw PluginLoadError.missingBundleIdentifier(bundleURL: bundle.bundleURL)
+        }
+
+        guard let infoDictionary = bundle.infoDictionary else
+        {
+            throw PluginLoadError.bundleLoadFailed(bundleURL: bundle.bundleURL, underlyingError: nil)
+        }
+
+        guard let apiVersion = infoDictionary["FabricPluginAPIVersion"] as? Int else
+        {
+            throw PluginLoadError.unsupportedAPIVersion(pluginID: bundleID,
+                                                        foundVersion: nil,
+                                                        supportedVersion: PluginLoader.currentAPIVersion)
+        }
+
+        let nodeClassNames = infoDictionary["FabricPluginNodeClasses"] as? [String] ?? []
+        let principalClassName = infoDictionary["NSPrincipalClass"] as? String
+
+        guard !nodeClassNames.isEmpty || principalClassName != nil else
+        {
+            throw PluginLoadError.noNodeClassesDeclared(pluginID: bundleID)
+        }
+
+        self.id = bundleID
+        self.name = infoDictionary["CFBundleName"] as? String ?? bundleID
+        self.displayName = infoDictionary["FabricPluginDisplayName"] as? String ?? self.name
+        self.version = infoDictionary["CFBundleShortVersionString"] as? String
+        self.author = infoDictionary["FabricPluginAuthor"] as? String
+        self.description = infoDictionary["FabricPluginDescription"] as? String
+        self.bundleURL = bundle.bundleURL
+        self.apiVersion = apiVersion
+        self.nodeClassNames = nodeClassNames
+        self.principalClassName = principalClassName
+        self.bundle = bundle
+    }
+}

--- a/Fabric/Nodes/Plugin/PluginLoadError.swift
+++ b/Fabric/Nodes/Plugin/PluginLoadError.swift
@@ -12,6 +12,8 @@ public enum PluginLoadError: FabricErrorProtocol
 {
     case bundleNotFound(bundleURL: URL)
     case bundleLoadFailed(bundleURL: URL, underlyingError: Error?)
+    case pluginDiscoveryFailed(underlyingError: Error)
+    case pluginDirectoryScanFailed(directoryURL: URL, underlyingError: Error)
     case missingBundleIdentifier(bundleURL: URL)
     case noNodeClassesDeclared(pluginID: String)
     case unsupportedAPIVersion(pluginID: String, foundVersion: Int?, supportedVersion: Int)
@@ -41,6 +43,10 @@ public enum PluginLoadError: FabricErrorProtocol
             {
                 "Failed to load plugin bundle at \(bundleURL.path)"
             }
+        case .pluginDiscoveryFailed(let underlyingError):
+            "Failed to discover plugins: \(underlyingError.localizedDescription)"
+        case .pluginDirectoryScanFailed(let directoryURL, let underlyingError):
+            "Failed to scan plugin directory at \(directoryURL.path): \(underlyingError.localizedDescription)"
         case .missingBundleIdentifier(let bundleURL):
             "Plugin bundle at \(bundleURL.path) is missing CFBundleIdentifier"
         case .noNodeClassesDeclared(let pluginID):

--- a/Fabric/Nodes/Plugin/PluginLoadError.swift
+++ b/Fabric/Nodes/Plugin/PluginLoadError.swift
@@ -1,0 +1,69 @@
+//
+//  PluginLoadError.swift
+//  Fabric
+//
+//  Created by Anton Marini on 7/24/26.
+//
+
+import Foundation
+
+/// Errors that can occur while discovering and loading Fabric plugin bundles.
+public enum PluginLoadError: FabricErrorProtocol
+{
+    case bundleNotFound(bundleURL: URL)
+    case bundleLoadFailed(bundleURL: URL, underlyingError: Error?)
+    case missingBundleIdentifier(bundleURL: URL)
+    case noNodeClassesDeclared(pluginID: String)
+    case unsupportedAPIVersion(pluginID: String, foundVersion: Int?, supportedVersion: Int)
+    case classNotFound(pluginID: String, className: String)
+    case classNotNodeSubclass(pluginID: String, className: String)
+    case principalClassLoadFailed(pluginID: String, className: String)
+    case duplicatePluginIdentifier(pluginID: String)
+    case duplicateNodeName(pluginID: String, nodeName: String, existingSource: String)
+
+    public var severity: FabricErrorSeverity
+    {
+        .recoverable
+    }
+
+    public var errorDescription: String?
+    {
+        switch self
+        {
+        case .bundleNotFound(let bundleURL):
+            "Plugin bundle was not found at \(bundleURL.path)"
+        case .bundleLoadFailed(let bundleURL, let underlyingError):
+            if let underlyingError
+            {
+                "Failed to load plugin bundle at \(bundleURL.path): \(underlyingError.localizedDescription)"
+            }
+            else
+            {
+                "Failed to load plugin bundle at \(bundleURL.path)"
+            }
+        case .missingBundleIdentifier(let bundleURL):
+            "Plugin bundle at \(bundleURL.path) is missing CFBundleIdentifier"
+        case .noNodeClassesDeclared(let pluginID):
+            "Plugin '\(pluginID)' does not declare node classes or a principal class"
+        case .unsupportedAPIVersion(let pluginID, let foundVersion, let supportedVersion):
+            if let foundVersion
+            {
+                "Plugin '\(pluginID)' targets API version \(foundVersion), but Fabric supports \(supportedVersion)"
+            }
+            else
+            {
+                "Plugin '\(pluginID)' is missing FabricPluginAPIVersion"
+            }
+        case .classNotFound(let pluginID, let className):
+            "Plugin '\(pluginID)' declares node class '\(className)', but that class could not be found"
+        case .classNotNodeSubclass(let pluginID, let className):
+            "Plugin '\(pluginID)' declares class '\(className)', but it is not a Node subclass"
+        case .principalClassLoadFailed(let pluginID, let className):
+            "Plugin '\(pluginID)' declares principal class '\(className)', but it could not be loaded"
+        case .duplicatePluginIdentifier(let pluginID):
+            "Plugin '\(pluginID)' is already loaded"
+        case .duplicateNodeName(let pluginID, let nodeName, let existingSource):
+            "Plugin '\(pluginID)' declares node '\(nodeName)', but that node already exists in \(existingSource)"
+        }
+    }
+}

--- a/Fabric/Nodes/Plugin/PluginLoader.swift
+++ b/Fabric/Nodes/Plugin/PluginLoader.swift
@@ -17,11 +17,11 @@ public final class PluginLoader
     public static let coreNodesPluginID = FabricCoreNodesPlugin.pluginID
 
     public private(set) var loadedPlugins: [String: PluginInfo] = [:]
-    public private(set) var pluginNodeClasses: [String: (nodeClass: Node.Type, pluginID: String)] = [:]
+    public private(set) var pluginNodeClasses: [PluginQualifiedNodeID: Node.Type] = [:]
     public private(set) var pluginNodeWrappers: [NodeClassWrapper] = []
     public private(set) var loadErrors: [PluginLoadError] = []
 
-    private var classNameAliases: [String: String] = [:]
+    private var nodeIDAliases: [PluginQualifiedNodeID: PluginQualifiedNodeID] = [:]
     private let logger = Logger(subsystem: "graphics.fabric", category: "PluginLoader")
     private var pluginsLoaded = false
     private let pluginLoadLock = NSRecursiveLock()
@@ -160,6 +160,15 @@ public final class PluginLoader
                                       existingNodeNames: [])
             }
 
+            try registerNodeClass(BaseImageNode.self,
+                                  pluginID: Self.coreNodesPluginID,
+                                  existingNodeNames: [],
+                                  includeWrapper: false)
+            try registerNodeClass(BaseTextureComputeProcessorNode.self,
+                                  pluginID: Self.coreNodesPluginID,
+                                  existingNodeNames: [],
+                                  includeWrapper: false)
+
             pluginNodeWrappers.append(contentsOf: FabricCoreNodesPlugin.dynamicNodeWrappers())
             loadedPlugins[Self.coreNodesPluginID] = pluginInfo
             logger.info("Loaded embedded Fabric core nodes plugin")
@@ -237,15 +246,21 @@ public final class PluginLoader
         logger.info("Loaded Fabric plugin '\(pluginInfo.displayName)' with \(nodeClasses.count) node class(es)")
     }
 
-    public func nodeClass(for nodeName: String) -> Node.Type?
+    public func nodeClass(pluginID: String, nodeID: String) -> Node.Type?
     {
-        let resolvedName = classNameAliases[nodeName] ?? nodeName
-        return pluginNodeClasses[resolvedName]?.nodeClass
+        let requestedID = PluginQualifiedNodeID(pluginID: pluginID, nodeID: nodeID)
+        let resolvedID = nodeIDAliases[requestedID] ?? requestedID
+        return pluginNodeClasses[resolvedID]
     }
 
-    public func resolveClassName(_ className: String) -> String
+    public func pluginID(for nodeClass: Node.Type) -> String?
     {
-        classNameAliases[className] ?? className
+        pluginNodeClasses.first { ObjectIdentifier($0.value) == ObjectIdentifier(nodeClass) }?.key.pluginID
+    }
+
+    public func qualifiedNodeID(for nodeClass: Node.Type) -> PluginQualifiedNodeID?
+    {
+        pluginNodeClasses.first { ObjectIdentifier($0.value) == ObjectIdentifier(nodeClass) }?.key
     }
 
     private func loadPrincipalClass(from pluginInfo: PluginInfo) throws -> FabricPlugin.Type?
@@ -277,50 +292,59 @@ public final class PluginLoader
 
     private func registerNodeClass(_ nodeClass: Node.Type,
                                    pluginID: String,
-                                   existingNodeNames: Set<String>) throws
+                                   existingNodeNames: Set<String>,
+                                   includeWrapper: Bool = true) throws
     {
         let lookupName = String(describing: nodeClass)
-        let displayName = nodeClass.name
+        let nodeID = Self.rootNodeID(from: lookupName)
+        let qualifiedNodeID = PluginQualifiedNodeID(pluginID: pluginID, nodeID: nodeID)
 
-        if let existingPlugin = pluginNodeClasses[lookupName]?.pluginID
+        if pluginNodeClasses[qualifiedNodeID] != nil
         {
             throw PluginLoadError.duplicateNodeName(pluginID: pluginID,
-                                                    nodeName: lookupName,
-                                                    existingSource: "plugin '\(existingPlugin)'")
+                                                    nodeName: nodeID,
+                                                    existingSource: "plugin '\(pluginID)'")
         }
 
-        if let existingWrapper = pluginNodeWrappers.first(where: { $0.nodeName == displayName })
+        if existingNodeNames.contains(qualifiedNodeID.description)
         {
             throw PluginLoadError.duplicateNodeName(pluginID: pluginID,
-                                                    nodeName: displayName,
-                                                    existingSource: "plugin '\(existingWrapper.pluginBundleID ?? "unknown")'")
-        }
-
-        if existingNodeNames.contains(lookupName) || existingNodeNames.contains(displayName)
-        {
-            throw PluginLoadError.duplicateNodeName(pluginID: pluginID,
-                                                    nodeName: displayName,
+                                                    nodeName: nodeID,
                                                     existingSource: "previously registered nodes")
         }
 
-        pluginNodeClasses[lookupName] = (nodeClass: nodeClass, pluginID: pluginID)
-        pluginNodeWrappers.append(NodeClassWrapper(nodeClass: nodeClass,
-                                                   nodeType: nodeClass.nodeType,
-                                                   pluginBundleID: pluginID))
+        pluginNodeClasses[qualifiedNodeID] = nodeClass
 
-        let unqualifiedName = String(lookupName.split(separator: ".").last ?? Substring(lookupName))
-        if unqualifiedName != lookupName
+        if includeWrapper
         {
-            classNameAliases[unqualifiedName] = lookupName
+            pluginNodeWrappers.append(NodeClassWrapper(nodeClass: nodeClass,
+                                                       nodeType: nodeClass.nodeType,
+                                                       pluginBundleID: pluginID))
         }
 
-        logger.debug("Registered node class '\(lookupName)' from plugin '\(pluginID)'")
+        if lookupName != nodeID
+        {
+            nodeIDAliases[PluginQualifiedNodeID(pluginID: pluginID, nodeID: lookupName)] = qualifiedNodeID
+        }
+
+        logger.debug("Registered node class '\(qualifiedNodeID.description)'")
     }
 
     private func currentRegisteredNodeNames() -> Set<String>
     {
-        Set(pluginNodeClasses.flatMap { nodeName, entry in
-            [nodeName, entry.nodeClass.name]
-        } + pluginNodeWrappers.map(\.nodeName))
+        Set(pluginNodeClasses.keys.map(\.description))
+    }
+
+    private static func rootNodeID(from className: String) -> String
+    {
+        if let genericStart = className.firstIndex(of: "<")
+        {
+            let baseName = className[..<genericStart]
+            let genericSuffix = className[genericStart...]
+            let rootBaseName = baseName.split(separator: ".").last ?? baseName[...]
+            return "\(rootBaseName)\(genericSuffix)"
+        }
+
+        return String(className.split(separator: ".").last ?? Substring(className))
     }
 }

--- a/Fabric/Nodes/Plugin/PluginLoader.swift
+++ b/Fabric/Nodes/Plugin/PluginLoader.swift
@@ -45,13 +45,13 @@ public final class PluginLoader
         }
 
         #if os(macOS)
-        directories.append(URL(filePath: "/Library/Application Support/Fabric/Plugins", directoryHint: .isDirectory))
+        directories.append(URL(filePath: "  ", directoryHint: .isDirectory))
         #endif
 
         return directories
     }
 
-    public func discoverPlugins() -> [URL]
+    public func discoverPlugins() throws -> [URL]
     {
         var pluginURLs: [URL] = []
         let fileManager = FileManager.default
@@ -69,14 +69,15 @@ public final class PluginLoader
             }
             catch
             {
-                logger.warning("Failed to scan plugin directory '\(directory.path)': \(error.localizedDescription)")
+                throw PluginLoadError.pluginDirectoryScanFailed(directoryURL: directory,
+                                                               underlyingError: error)
             }
         }
 
         return pluginURLs
     }
 
-    public func loadAllPlugins()
+    public func loadAllPlugins() throws
     {
         pluginLoadLock.lock()
         defer { pluginLoadLock.unlock() }
@@ -85,15 +86,25 @@ public final class PluginLoader
         pluginsLoaded = true
 
         loadErrors.removeAll()
-        loadEmbeddedCorePlugin()
-        loadDiscoveredPlugins()
+        do
+        {
+            try loadEmbeddedCorePlugin()
+            try loadDiscoveredPlugins()
+        }
+        catch
+        {
+            pluginsLoaded = false
+            throw error
+        }
     }
 
-    public func loadDiscoveredPlugins()
+    public func loadDiscoveredPlugins() throws
     {
         let existingNodeNames = currentRegisteredNodeNames()
 
-        let pluginURLs = discoverPlugins()
+        let pluginURLs: [URL]
+        pluginURLs = try discoverPlugins()
+
         logger.info("Found \(pluginURLs.count) Fabric plugin bundle(s)")
 
         for pluginURL in pluginURLs
@@ -106,17 +117,19 @@ public final class PluginLoader
             {
                 loadErrors.append(error)
                 logger.error("\(error.localizedDescription)")
+                throw error
             }
             catch
             {
                 let wrappedError = PluginLoadError.bundleLoadFailed(bundleURL: pluginURL, underlyingError: error)
                 loadErrors.append(wrappedError)
                 logger.error("\(wrappedError.localizedDescription)")
+                throw wrappedError
             }
         }
     }
 
-    private func loadEmbeddedCorePlugin()
+    private func loadEmbeddedCorePlugin() throws
     {
         guard loadedPlugins[Self.coreNodesPluginID] == nil else { return }
 
@@ -155,12 +168,14 @@ public final class PluginLoader
         {
             loadErrors.append(error)
             logger.error("\(error.localizedDescription)")
+            throw error
         }
         catch
         {
             let wrappedError = PluginLoadError.bundleLoadFailed(bundleURL: bundle.bundleURL, underlyingError: error)
             loadErrors.append(wrappedError)
             logger.error("\(wrappedError.localizedDescription)")
+            throw wrappedError
         }
     }
 

--- a/Fabric/Nodes/Plugin/PluginLoader.swift
+++ b/Fabric/Nodes/Plugin/PluginLoader.swift
@@ -45,7 +45,7 @@ public final class PluginLoader
         }
 
         #if os(macOS)
-        directories.append(URL(filePath: "  ", directoryHint: .isDirectory))
+        directories.append(URL(filePath: "/Library/Application Support/Fabric/Plugins", directoryHint: .isDirectory))
         #endif
 
         return directories

--- a/Fabric/Nodes/Plugin/PluginLoader.swift
+++ b/Fabric/Nodes/Plugin/PluginLoader.swift
@@ -1,0 +1,311 @@
+//
+//  PluginLoader.swift
+//  Fabric
+//
+//  Created by Anton Marini on 7/24/26.
+//
+
+import Foundation
+import os
+
+/// Loads Fabric's embedded core plugin plus optional external node plugin bundles.
+public final class PluginLoader
+{
+    public static let shared = PluginLoader()
+    public static let currentAPIVersion = 1
+    public static let pluginExtension = "fabricplugin"
+    public static let coreNodesPluginID = FabricCoreNodesPlugin.pluginID
+
+    public private(set) var loadedPlugins: [String: PluginInfo] = [:]
+    public private(set) var pluginNodeClasses: [String: (nodeClass: Node.Type, pluginID: String)] = [:]
+    public private(set) var pluginNodeWrappers: [NodeClassWrapper] = []
+    public private(set) var loadErrors: [PluginLoadError] = []
+
+    private var classNameAliases: [String: String] = [:]
+    private let logger = Logger(subsystem: "graphics.fabric", category: "PluginLoader")
+    private var pluginsLoaded = false
+    private let pluginLoadLock = NSRecursiveLock()
+
+    private init() {}
+
+    public func pluginSearchDirectories() -> [URL]
+    {
+        var directories: [URL] = []
+
+        if let builtInPlugInsURL = Bundle.main.builtInPlugInsURL
+        {
+            directories.append(builtInPlugInsURL)
+        }
+
+        if let appSupportURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+        {
+            directories.append(appSupportURL
+                .appending(path: "Fabric", directoryHint: .isDirectory)
+                .appending(path: "Plugins", directoryHint: .isDirectory))
+        }
+
+        #if os(macOS)
+        directories.append(URL(filePath: "/Library/Application Support/Fabric/Plugins", directoryHint: .isDirectory))
+        #endif
+
+        return directories
+    }
+
+    public func discoverPlugins() -> [URL]
+    {
+        var pluginURLs: [URL] = []
+        let fileManager = FileManager.default
+
+        for directory in pluginSearchDirectories()
+        {
+            guard fileManager.fileExists(atPath: directory.path) else { continue }
+
+            do
+            {
+                let contents = try fileManager.contentsOfDirectory(at: directory,
+                                                                    includingPropertiesForKeys: [.isDirectoryKey],
+                                                                    options: [.skipsHiddenFiles])
+                pluginURLs.append(contentsOf: contents.filter { $0.pathExtension == Self.pluginExtension })
+            }
+            catch
+            {
+                logger.warning("Failed to scan plugin directory '\(directory.path)': \(error.localizedDescription)")
+            }
+        }
+
+        return pluginURLs
+    }
+
+    public func loadAllPlugins()
+    {
+        pluginLoadLock.lock()
+        defer { pluginLoadLock.unlock() }
+
+        guard !pluginsLoaded else { return }
+        pluginsLoaded = true
+
+        loadErrors.removeAll()
+        loadEmbeddedCorePlugin()
+        loadDiscoveredPlugins()
+    }
+
+    public func loadDiscoveredPlugins()
+    {
+        let existingNodeNames = currentRegisteredNodeNames()
+
+        let pluginURLs = discoverPlugins()
+        logger.info("Found \(pluginURLs.count) Fabric plugin bundle(s)")
+
+        for pluginURL in pluginURLs
+        {
+            do
+            {
+                try loadPlugin(at: pluginURL, existingNodeNames: existingNodeNames)
+            }
+            catch let error as PluginLoadError
+            {
+                loadErrors.append(error)
+                logger.error("\(error.localizedDescription)")
+            }
+            catch
+            {
+                let wrappedError = PluginLoadError.bundleLoadFailed(bundleURL: pluginURL, underlyingError: error)
+                loadErrors.append(wrappedError)
+                logger.error("\(wrappedError.localizedDescription)")
+            }
+        }
+    }
+
+    private func loadEmbeddedCorePlugin()
+    {
+        guard loadedPlugins[Self.coreNodesPluginID] == nil else { return }
+
+        let bundle = Bundle.module
+        // Core nodes are compiled into Fabric so Swift Package consumers only
+        // need to depend on the Fabric product. Registration still flows
+        // through the same plugin loader path as external bundles.
+        let pluginInfo = PluginInfo(id: Self.coreNodesPluginID,
+                                    name: "FabricCoreNodes",
+                                    displayName: "Fabric Core Nodes",
+                                    version: nil,
+                                    author: "Fabric",
+                                    description: "Built-in Fabric nodes",
+                                    bundleURL: bundle.bundleURL,
+                                    apiVersion: Self.currentAPIVersion,
+                                    nodeClassNames: [],
+                                    principalClassName: String(describing: FabricCoreNodesPlugin.self),
+                                    bundle: bundle)
+
+        FabricCoreNodesPlugin.pluginDidLoad(bundle: bundle)
+
+        do
+        {
+            for nodeClass in FabricCoreNodesPlugin.additionalNodeClasses()
+            {
+                try registerNodeClass(nodeClass,
+                                      pluginID: Self.coreNodesPluginID,
+                                      existingNodeNames: [])
+            }
+
+            pluginNodeWrappers.append(contentsOf: FabricCoreNodesPlugin.dynamicNodeWrappers())
+            loadedPlugins[Self.coreNodesPluginID] = pluginInfo
+            logger.info("Loaded embedded Fabric core nodes plugin")
+        }
+        catch let error as PluginLoadError
+        {
+            loadErrors.append(error)
+            logger.error("\(error.localizedDescription)")
+        }
+        catch
+        {
+            let wrappedError = PluginLoadError.bundleLoadFailed(bundleURL: bundle.bundleURL, underlyingError: error)
+            loadErrors.append(wrappedError)
+            logger.error("\(wrappedError.localizedDescription)")
+        }
+    }
+
+    public func loadPlugin(at url: URL, existingNodeNames: Set<String>) throws
+    {
+        guard FileManager.default.fileExists(atPath: url.path) else
+        {
+            throw PluginLoadError.bundleNotFound(bundleURL: url)
+        }
+
+        guard let bundle = Bundle(url: url) else
+        {
+            throw PluginLoadError.bundleLoadFailed(bundleURL: url, underlyingError: nil)
+        }
+
+        let pluginInfo = try PluginInfo(bundle: bundle)
+
+        guard pluginInfo.apiVersion == Self.currentAPIVersion else
+        {
+            throw PluginLoadError.unsupportedAPIVersion(pluginID: pluginInfo.id,
+                                                        foundVersion: pluginInfo.apiVersion,
+                                                        supportedVersion: Self.currentAPIVersion)
+        }
+
+        guard loadedPlugins[pluginInfo.id] == nil else
+        {
+            throw PluginLoadError.duplicatePluginIdentifier(pluginID: pluginInfo.id)
+        }
+
+        do
+        {
+            try bundle.loadAndReturnError()
+        }
+        catch
+        {
+            throw PluginLoadError.bundleLoadFailed(bundleURL: url, underlyingError: error)
+        }
+
+        let principalClass = try loadPrincipalClass(from: pluginInfo)
+        principalClass?.pluginDidLoad(bundle: bundle)
+
+        var nodeClasses: [Node.Type] = []
+
+        for className in pluginInfo.nodeClassNames
+        {
+            nodeClasses.append(try loadNodeClass(className: className, pluginID: pluginInfo.id))
+        }
+
+        nodeClasses.append(contentsOf: principalClass?.additionalNodeClasses() ?? [])
+
+        for nodeClass in nodeClasses
+        {
+            try registerNodeClass(nodeClass,
+                                  pluginID: pluginInfo.id,
+                                  existingNodeNames: existingNodeNames)
+        }
+
+        loadedPlugins[pluginInfo.id] = pluginInfo
+        logger.info("Loaded Fabric plugin '\(pluginInfo.displayName)' with \(nodeClasses.count) node class(es)")
+    }
+
+    public func nodeClass(for nodeName: String) -> Node.Type?
+    {
+        let resolvedName = classNameAliases[nodeName] ?? nodeName
+        return pluginNodeClasses[resolvedName]?.nodeClass
+    }
+
+    public func resolveClassName(_ className: String) -> String
+    {
+        classNameAliases[className] ?? className
+    }
+
+    private func loadPrincipalClass(from pluginInfo: PluginInfo) throws -> FabricPlugin.Type?
+    {
+        guard let principalClassName = pluginInfo.principalClassName else { return nil }
+
+        guard let principalClass = NSClassFromString(principalClassName) as? FabricPlugin.Type else
+        {
+            throw PluginLoadError.principalClassLoadFailed(pluginID: pluginInfo.id, className: principalClassName)
+        }
+
+        return principalClass
+    }
+
+    private func loadNodeClass(className: String, pluginID: String) throws -> Node.Type
+    {
+        guard let loadedClass = NSClassFromString(className) else
+        {
+            throw PluginLoadError.classNotFound(pluginID: pluginID, className: className)
+        }
+
+        guard let nodeClass = loadedClass as? Node.Type else
+        {
+            throw PluginLoadError.classNotNodeSubclass(pluginID: pluginID, className: className)
+        }
+
+        return nodeClass
+    }
+
+    private func registerNodeClass(_ nodeClass: Node.Type,
+                                   pluginID: String,
+                                   existingNodeNames: Set<String>) throws
+    {
+        let lookupName = String(describing: nodeClass)
+        let displayName = nodeClass.name
+
+        if let existingPlugin = pluginNodeClasses[lookupName]?.pluginID
+        {
+            throw PluginLoadError.duplicateNodeName(pluginID: pluginID,
+                                                    nodeName: lookupName,
+                                                    existingSource: "plugin '\(existingPlugin)'")
+        }
+
+        if let existingWrapper = pluginNodeWrappers.first(where: { $0.nodeName == displayName })
+        {
+            throw PluginLoadError.duplicateNodeName(pluginID: pluginID,
+                                                    nodeName: displayName,
+                                                    existingSource: "plugin '\(existingWrapper.pluginBundleID ?? "unknown")'")
+        }
+
+        if existingNodeNames.contains(lookupName) || existingNodeNames.contains(displayName)
+        {
+            throw PluginLoadError.duplicateNodeName(pluginID: pluginID,
+                                                    nodeName: displayName,
+                                                    existingSource: "previously registered nodes")
+        }
+
+        pluginNodeClasses[lookupName] = (nodeClass: nodeClass, pluginID: pluginID)
+        pluginNodeWrappers.append(NodeClassWrapper(nodeClass: nodeClass,
+                                                   nodeType: nodeClass.nodeType,
+                                                   pluginBundleID: pluginID))
+
+        let unqualifiedName = String(lookupName.split(separator: ".").last ?? Substring(lookupName))
+        if unqualifiedName != lookupName
+        {
+            classNameAliases[unqualifiedName] = lookupName
+        }
+
+        logger.debug("Registered node class '\(lookupName)' from plugin '\(pluginID)'")
+    }
+
+    private func currentRegisteredNodeNames() -> Set<String>
+    {
+        Set(pluginNodeClasses.flatMap { nodeName, entry in
+            [nodeName, entry.nodeClass.name]
+        } + pluginNodeWrappers.map(\.nodeName))
+    }
+}

--- a/Fabric/Nodes/Utility/CursorNode.swift
+++ b/Fabric/Nodes/Utility/CursorNode.swift
@@ -98,6 +98,7 @@ public class CursorNode : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         
 #if os(macOS)

--- a/Fabric/Nodes/Utility/GateNode.swift
+++ b/Fabric/Nodes/Utility/GateNode.swift
@@ -64,6 +64,7 @@ public final class GateNode: RoutingNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         selectedOutputPort()?.sendBoxed(input.snapshotValue(), force: true)
     }

--- a/Fabric/Nodes/Utility/JavaScriptNode.swift
+++ b/Fabric/Nodes/Utility/JavaScriptNode.swift
@@ -340,7 +340,9 @@ private final class JavaScriptNodeRuntime
         context.evaluateScript(signature.transpiledSource)
         if let diagnostic = capturedDiagnostic {
             self.latestDiagnostic = diagnostic
-            throw NSError(domain: "JavaScriptNodeRuntime", code: 1, userInfo: [NSLocalizedDescriptionKey: diagnostic.summary])
+            throw FabricError(.execution(.syntax),
+                              severity: .recoverable,
+                              message: diagnostic.summary)
         }
 
         guard let mainFunction = context.objectForKeyedSubscript("main"), mainFunction.isObject else {
@@ -367,7 +369,9 @@ private final class JavaScriptNodeRuntime
         }
 
         if let diagnostic = self.latestDiagnostic {
-            throw NSError(domain: "JavaScriptNodeRuntime", code: 2, userInfo: [NSLocalizedDescriptionKey: diagnostic.summary])
+            throw FabricError(.execution(.syntax),
+                              severity: .recoverable,
+                              message: diagnostic.summary)
         }
 
         guard result.isObject else {
@@ -514,9 +518,18 @@ public final class JavaScriptNode: Node
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard let compiledSignature,
-              let runtime else {
+              let runtime else
+        {
+            if let diagnostic = self.diagnostics.first
+            {
+                throw FabricError(.execution(.syntax),
+                                  severity: .recoverable,
+                                  message: diagnostic.summary)
+            }
+
             return
         }
 
@@ -532,6 +545,10 @@ public final class JavaScriptNode: Node
         catch {
             let summary = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
             self.diagnostics = [JavaScriptNodeDiagnostic(summary: summary, detail: summary)]
+            throw FabricError(.execution(.syntax),
+                              severity: .recoverable,
+                              message: summary,
+                              underlyingError: error)
         }
     }
 

--- a/Fabric/Nodes/Utility/KeyboardNode.swift
+++ b/Fabric/Nodes/Utility/KeyboardNode.swift
@@ -199,6 +199,7 @@ public class KeyboardNode : Node
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if let eventInfo = executionInfo.eventInfo,
            let event = eventInfo.event,

--- a/Fabric/Nodes/Utility/LogNode.swift
+++ b/Fabric/Nodes/Utility/LogNode.swift
@@ -60,6 +60,7 @@ public class LogNode : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         if self.inputAny.valueDidChange,
            let value = self.inputAny.value

--- a/Fabric/Nodes/Utility/MatrixSwitchNode.swift
+++ b/Fabric/Nodes/Utility/MatrixSwitchNode.swift
@@ -96,6 +96,7 @@ public final class MatrixSwitchNode: RoutingNodeBase
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         let sources = sourceInputsByOutput()
 

--- a/Fabric/Nodes/Utility/PixelsToUnitsNode.swift
+++ b/Fabric/Nodes/Utility/PixelsToUnitsNode.swift
@@ -61,6 +61,7 @@ public class PixelsToUnitsNode : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         
         if self.inputCursorPosition.valueDidChange,

--- a/Fabric/Nodes/Utility/RenderInfoNode.swift
+++ b/Fabric/Nodes/Utility/RenderInfoNode.swift
@@ -41,6 +41,7 @@ public class RenderInfoNode : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         let size = renderer.renderEncoder.size
         self.outputWidth.send( size.width )

--- a/Fabric/Nodes/Utility/SampleAndHoldNode.swift
+++ b/Fabric/Nodes/Utility/SampleAndHoldNode.swift
@@ -58,6 +58,7 @@ public class SampleAndHoldNode: TypeAgnosticNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard let inputValue:  Port = findPort(named: "inputValue"),
               let outputValue: Port = findPort(named: "outputValue") else { return }

--- a/Fabric/Nodes/Utility/SignalNode.swift
+++ b/Fabric/Nodes/Utility/SignalNode.swift
@@ -37,6 +37,7 @@ public class SignalNode : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         let signal = self.inputValue.valueDidChange
         print("Signal \(signal)")

--- a/Fabric/Nodes/Utility/SwitchNode.swift
+++ b/Fabric/Nodes/Utility/SwitchNode.swift
@@ -60,6 +60,7 @@ public final class SwitchNode: RoutingNode
                                  executionInfo: GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         guard let selectedInput: Port = findPort(named: Self.inputPortName(selectedRouteIndex()))
         else { return }

--- a/Fabric/Nodes/Utility/UnitsoPixelsNode.swift
+++ b/Fabric/Nodes/Utility/UnitsoPixelsNode.swift
@@ -61,6 +61,7 @@ public class UnitsoPixelsNode : Node
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
                                  commandBuffer: MTLCommandBuffer)
+    throws
     {
         
         if self.inputUnitPosition.valueDidChange,

--- a/Fabric/Views/Graph/GraphCanvas.swift
+++ b/Fabric/Views/Graph/GraphCanvas.swift
@@ -173,7 +173,7 @@ public struct GraphCanvas : View
             provider.loadDataRepresentation(forTypeIdentifier: UTType.nodeRegistryItem.identifier) { data, error in
                 guard let data = data,
                       let dragData = try? JSONDecoder().decode(NodeRegistryDragData.self, from: data),
-                      let wrapper = NodeRegistry.shared.availableNodes.first(where: { $0.id == dragData.wrapperID })
+                      let wrapper = try? NodeRegistry.shared.availableNodes.first(where: { $0.id == dragData.wrapperID })
                 else {
                     print("GraphCanvas: registry drag decode failed: \(error?.localizedDescription ?? "unknown")")
                     handled = false
@@ -215,7 +215,7 @@ public struct GraphCanvas : View
 
                 guard let resourceValues = try? url.resourceValues(forKeys: [.contentTypeKey]),
                       let contentType = resourceValues.contentType,
-                      let nodeClass = NodeRegistry.shared.dropTargetNodeClass(for: contentType)
+                      let nodeClass = try? NodeRegistry.shared.dropTargetNodeClass(for: contentType)
                 else { return }
 
                 let node = nodeClass.init(context: currentGraph.context)

--- a/Fabric/Views/NodeRegisitryView.swift
+++ b/Fabric/Views/NodeRegisitryView.swift
@@ -226,7 +226,7 @@ public struct NodeRegisitryView: View {
     {
         for nodeID in self.selection
         {
-            if let nodeWrapper = NodeRegistry.shared.availableNodes.first(where: { $0.id == nodeID })
+            if let nodeWrapper = try? NodeRegistry.shared.availableNodes.first(where: { $0.id == nodeID })
             {
                  do
                  {
@@ -285,7 +285,7 @@ public struct NodeRegisitryView: View {
 
     func filteredNodes(forType nodeType:Node.NodeType) -> [NodeClassWrapper]
     {
-        let availableNodes:[NodeClassWrapper] = NodeRegistry.shared.availableNodes
+        let availableNodes:[NodeClassWrapper] = (try? NodeRegistry.shared.availableNodes) ?? []
         let nodesForType:[NodeClassWrapper] = availableNodes.filter( { $0.nodeType == nodeType })
         return  self.searchString.isEmpty ? nodesForType : nodesForType.filter {  $0.nodeName.localizedCaseInsensitiveContains(self.searchString) }
     }

--- a/Fabric/Views/NodeRegisitryView.swift
+++ b/Fabric/Views/NodeRegisitryView.swift
@@ -234,8 +234,8 @@ public struct NodeRegisitryView: View {
                      
                      try self.editingContext.layoutNode(node)
                      
-                     node.enableExecution(renderer: self.graphRenderer)
-                     node.startExecution(renderer: self.graphRenderer)
+                     try node.enableExecution(renderer: self.graphRenderer)
+                     try node.startExecution(renderer: self.graphRenderer)
                      
                      self.editingContext.currentGraph.addNode(node)
                  }

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -1,0 +1,77 @@
+# Fabric Plugin Development Guide
+
+Fabric plugins provide `Node` subclasses through the same registration path used by Fabric's built-in nodes.
+
+Fabric's core nodes are supplied by an embedded plugin implementation compiled into the Fabric framework. This keeps Swift Package integration zero-config: clients only depend on the `Fabric` product, and `NodeRegistry` transparently loads the embedded core plugin before any external bundles.
+
+External plugins are `.fabricplugin` bundles loaded after the embedded core plugin.
+
+## Bundle Layout
+
+```text
+MyPlugin.fabricplugin/
+  Contents/
+    Info.plist
+    MacOS/
+      MyPlugin
+    Resources/
+```
+
+## Info.plist Keys
+
+Required:
+
+- `CFBundleIdentifier`: unique plugin identifier.
+- `CFBundleName`: bundle name.
+- `FabricPluginAPIVersion`: integer API version. Current value is `1`.
+- `FabricPluginNodeClasses`: fully qualified Swift node class names, or provide `NSPrincipalClass` with `FabricPlugin.additionalNodeClasses()`.
+
+Optional:
+
+- `FabricPluginDisplayName`
+- `FabricPluginAuthor`
+- `FabricPluginDescription`
+- `CFBundleShortVersionString`
+- `NSPrincipalClass`
+
+Example:
+
+```xml
+<key>FabricPluginAPIVersion</key>
+<integer>1</integer>
+<key>FabricPluginNodeClasses</key>
+<array>
+    <string>MyPlugin.MyCustomNode</string>
+</array>
+```
+
+## Lifecycle
+
+Plugins may define a principal class:
+
+```swift
+import Fabric
+
+public final class PluginMain: NSObject, FabricPlugin
+{
+    public static func pluginDidLoad(bundle: Bundle) {}
+    public static func pluginWillUnload() {}
+    public static func additionalNodeClasses() -> [Node.Type] { [] }
+}
+```
+
+## Discovery
+
+`NodeRegistry` transparently asks `PluginLoader` to load plugins on first use. The embedded core plugin is always loaded first.
+
+Fabric searches:
+
+- `Fabric.app/Contents/PlugIns/`
+- `~/Library/Application Support/Fabric/Plugins/`
+- `/Library/Application Support/Fabric/Plugins/` on macOS
+
+## Loading Errors
+
+Plugin loading is non-fatal. Fabric logs errors and continues with other plugins. Phase 2 supports errors for missing bundles, bundle load failures, missing identifiers, unsupported API versions, missing node declarations, missing classes, non-node classes, principal-class failures, duplicate plugin identifiers, and duplicate node names.
+
+The embedded core plugin is fatal to useful operation if it fails to register, but the failure is still represented in `NodeRegistry.pluginLoadErrors` so callers can surface it in UI.

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         .package(url: "https://github.com/vade/SwiftSimplify", branch: "master"),
         .package(url: "https://github.com/gonzalezreal/textual", from: "0.1.1"),
         .package(url: "https://github.com/orchetect/OSCKit", from: "2.1.1"),
-        .package(url: "https://github.com/orchetect/MIDIKit", from: "0.10.7"),
+        .package(url: "https://github.com/orchetect/MIDIKit", from: "0.12.0"),
         .package(url: "https://github.com/mchakravarty/CodeEditorView.git", from: "0.7.0"),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,7 @@ let package = Package(
     products: [
         .library(
             name: "Fabric",
+            type: .dynamic,
             targets: ["Fabric"]
         ),
     ],

--- a/Tests/ConsolidatedNumericNodeTests.swift
+++ b/Tests/ConsolidatedNumericNodeTests.swift
@@ -29,9 +29,9 @@ struct ConsolidatedNumericNodeTests
         graph.addNode(distance)
         publish(distance.outputDistance, in: graph)
 
-        harness.renderer.startExecution(graph: graph)
+        try harness.renderer.startExecution(graph: graph)
         try harness.execute(graph, checkCommandBufferError: false)
-        harness.renderer.stopExecution(graph: graph)
+        try harness.renderer.stopExecution(graph: graph)
 
         #expect(distance.outputDistance.value == 5)
     }
@@ -51,9 +51,9 @@ struct ConsolidatedNumericNodeTests
         graph.addNode(distance)
         publish(distance.outputDistances, in: graph)
 
-        harness.renderer.startExecution(graph: graph)
+        try harness.renderer.startExecution(graph: graph)
         try harness.execute(graph, checkCommandBufferError: false)
-        harness.renderer.stopExecution(graph: graph)
+        try harness.renderer.stopExecution(graph: graph)
 
         #expect(distance.outputDistances.value == [3, 4])
     }
@@ -73,9 +73,9 @@ struct ConsolidatedNumericNodeTests
         graph.addNode(resample)
         publish(outputArray, in: graph)
 
-        harness.renderer.startExecution(graph: graph)
+        try harness.renderer.startExecution(graph: graph)
         try harness.execute(graph, checkCommandBufferError: false)
-        harness.renderer.stopExecution(graph: graph)
+        try harness.renderer.stopExecution(graph: graph)
 
         #expect(outputArray.value == [0, 5, 10])
     }

--- a/Tests/FabricErrorTests.swift
+++ b/Tests/FabricErrorTests.swift
@@ -1,0 +1,52 @@
+import Testing
+import Foundation
+@testable import Fabric
+
+@Suite("Fabric Error")
+struct FabricErrorTests
+{
+    @Test("FabricError preserves author-selected severity")
+    func fabricErrorPreservesSeverity()
+    {
+        let recoverable = FabricError(.execution(.gpu),
+                                      severity: .recoverable,
+                                      message: "Transient Metal command failure.")
+        let fatal = FabricError(.execution(.gpu),
+                                severity: .fatal,
+                                message: "Metal device is unavailable.")
+
+        #expect(recoverable.kind == .execution(.gpu))
+        #expect(recoverable.severity == .recoverable)
+        #expect(recoverable.errorDescription == "Transient Metal command failure.")
+
+        #expect(fatal.kind == .execution(.gpu))
+        #expect(fatal.severity == .fatal)
+        #expect(fatal.errorDescription == "Metal device is unavailable.")
+    }
+
+    @Test("Plugin errors can extend the protocol")
+    func pluginErrorsCanExtendProtocol()
+    {
+        struct PluginSpecificError: FabricErrorProtocol
+        {
+            let severity: FabricErrorSeverity
+            let errorDescription: String?
+        }
+
+        let error: any FabricErrorProtocol = PluginSpecificError(severity: .recoverable,
+                                                                 errorDescription: "Plugin-specific warning.")
+
+        #expect(error.severity == .recoverable)
+        #expect(error.errorDescription == "Plugin-specific warning.")
+    }
+
+    @Test("Plugin load errors participate in the shared error protocol")
+    func pluginLoadErrorsUseSharedProtocol()
+    {
+        let error: any FabricErrorProtocol = PluginLoadError.classNotFound(pluginID: "test.plugin",
+                                                                           className: "MissingNode")
+
+        #expect(error.severity == .recoverable)
+        #expect(error.errorDescription?.localizedStandardContains("MissingNode") == true)
+    }
+}

--- a/Tests/GraphExecutionTestSupport.swift
+++ b/Tests/GraphExecutionTestSupport.swift
@@ -148,14 +148,14 @@ struct GraphExecutionTestHarness
         }
 
         if drawScene {
-            renderer.executeAndDraw(
+            try renderer.executeAndDraw(
                 graph: graph,
                 executionInfo: executionInfo,
                 renderPassDescriptor: renderPassDescriptor,
                 commandBuffer: commandBuffer
             )
         } else {
-            renderer.execute(
+            try renderer.execute(
                 graph: graph,
                 executionInfo: executionInfo,
                 renderPassDescriptor: renderPassDescriptor,
@@ -202,7 +202,7 @@ struct GraphExecutionTestHarness
             throw GraphExecutionTestFailure("Failed to create command buffer")
         }
 
-        node.execute(
+        try node.execute(
             renderer: renderer,
             executionInfo: makeExecutionContext(time: 0, deltaTime: 0, frameNumber: 0),
             renderPassDescriptor: descriptor,

--- a/Tests/GraphExecutionTests.swift
+++ b/Tests/GraphExecutionTests.swift
@@ -306,7 +306,9 @@ struct GraphExecutionTests {
 
     @Test("Spot light node is registered in the node registry")
     func spotLightNodeIsRegistered() throws {
-        let nodeClass = try NodeRegistry.shared.nodeClass(for: String(describing: SpotLightNode.self))
+        let registry = try NodeRegistry.shared
+        let nodeClass = registry.nodeClass(pluginID: PluginLoader.coreNodesPluginID,
+                                           nodeID: String(describing: SpotLightNode.self))
         #expect(nodeClass == SpotLightNode.self)
     }
 

--- a/Tests/GraphExecutionTests.swift
+++ b/Tests/GraphExecutionTests.swift
@@ -115,9 +115,9 @@ struct GraphExecutionTests {
 
         let context = harness.makeExecutionContext(time: 10, deltaTime: 0, frameNumber: 0)
 
-        harness.renderer.startExecution(graph: graph)
+        try harness.renderer.startExecution(graph: graph)
         try harness.render(graph: graph, executionInfo: context)
-        harness.renderer.stopExecution(graph: graph)
+        try harness.renderer.stopExecution(graph: graph)
 
         try expectEqual(numberNode.output.value, 3.5)
     }
@@ -145,9 +145,9 @@ struct GraphExecutionTests {
 
         let context = harness.makeExecutionContext(time: 20, deltaTime: 0, frameNumber: 0)
 
-        harness.renderer.startExecution(graph: graph)
+        try harness.renderer.startExecution(graph: graph)
         try harness.render(graph: graph, executionInfo: context)
-        harness.renderer.stopExecution(graph: graph)
+        try harness.renderer.stopExecution(graph: graph)
 
         try expectEqual(addNode.outputNumber.value, 7.0)
     }
@@ -176,13 +176,13 @@ struct GraphExecutionTests {
         let firstContext = harness.makeExecutionContext(time: 30, deltaTime: 0, frameNumber: 0)
         let secondContext = harness.makeExecutionContext(time: 31, deltaTime: 1, frameNumber: 1)
 
-        harness.renderer.startExecution(graph: graph)
+        try harness.renderer.startExecution(graph: graph)
         try harness.render(graph: graph, executionInfo: firstContext)
         try expectEqual(addNode.outputNumber.value, 3)
 
         right.input.value = 9
         try harness.render(graph: graph, executionInfo: secondContext)
-        harness.renderer.stopExecution(graph: graph)
+        try harness.renderer.stopExecution(graph: graph)
 
         try expectEqual(addNode.outputNumber.value, 10)
     }
@@ -199,12 +199,12 @@ struct GraphExecutionTests {
         let firstContext = harness.makeExecutionContext(time: 100, deltaTime: 0, systemTime: 200, frameNumber: 0)
         let secondContext = harness.makeExecutionContext(time: 101.25, deltaTime: 1.25, systemTime: 201, frameNumber: 1)
 
-        harness.renderer.startExecution(graph: graph)
+        try harness.renderer.startExecution(graph: graph)
         try harness.render(graph: graph, executionInfo: firstContext)
         try expectEqual(timeNode.outputNumber.value, 0)
 
         try harness.render(graph: graph, executionInfo: secondContext)
-        harness.renderer.stopExecution(graph: graph)
+        try harness.renderer.stopExecution(graph: graph)
 
         try expectEqual(timeNode.outputNumber.value, 1.25)
     }
@@ -221,12 +221,12 @@ struct GraphExecutionTests {
         let firstContext = harness.makeExecutionContext(time: 100, deltaTime: 0, systemTime: 500, frameNumber: 0)
         let secondContext = harness.makeExecutionContext(time: 101, deltaTime: 1, systemTime: 502.5, frameNumber: 1)
 
-        harness.renderer.startExecution(graph: graph)
+        try harness.renderer.startExecution(graph: graph)
         try harness.render(graph: graph, executionInfo: firstContext)
         try expectEqual(timeNode.outputNumber.value, 0)
 
         try harness.render(graph: graph, executionInfo: secondContext)
-        harness.renderer.stopExecution(graph: graph)
+        try harness.renderer.stopExecution(graph: graph)
 
         try expectEqual(timeNode.outputNumber.value, 2.5)
     }
@@ -250,9 +250,9 @@ struct GraphExecutionTests {
 
         let executionContext = harness.makeExecutionContext(time: 1.0, deltaTime: 0.0, frameNumber: 0)
 
-        harness.renderer.startExecution(graph: graph)
+        try harness.renderer.startExecution(graph: graph)
         try harness.render(graph: graph, executionInfo: executionContext, drawScene: false)
-        harness.renderer.stopExecution(graph: graph)
+        try harness.renderer.stopExecution(graph: graph)
 
         guard let light = node.getObject() as? SpotLight else {
             throw GraphExecutionTestFailure("Spot light node did not vend a SpotLight object")
@@ -285,9 +285,9 @@ struct GraphExecutionTests {
 
         let executionContext = harness.makeExecutionContext(time: 2.0, deltaTime: 0.0, frameNumber: 0)
 
-        harness.renderer.startExecution(graph: graph)
+        try harness.renderer.startExecution(graph: graph)
         try harness.render(graph: graph, executionInfo: executionContext, drawScene: false)
-        harness.renderer.stopExecution(graph: graph)
+        try harness.renderer.stopExecution(graph: graph)
 
         guard let light = node.getObject() as? SpotLight else {
             throw GraphExecutionTestFailure("Spot light node did not vend a SpotLight object")
@@ -305,8 +305,8 @@ struct GraphExecutionTests {
     }
 
     @Test("Spot light node is registered in the node registry")
-    func spotLightNodeIsRegistered() {
-        let nodeClass = NodeRegistry.shared.nodeClass(for: String(describing: SpotLightNode.self))
+    func spotLightNodeIsRegistered() throws {
+        let nodeClass = try NodeRegistry.shared.nodeClass(for: String(describing: SpotLightNode.self))
         #expect(nodeClass == SpotLightNode.self)
     }
 
@@ -323,9 +323,9 @@ struct GraphExecutionTests {
 
         let executionContext = harness.makeExecutionContext(time: 0, deltaTime: 0, frameNumber: 0)
 
-        harness.renderer.startExecution(graph: graph)
+        try harness.renderer.startExecution(graph: graph)
         try harness.render(graph: graph, executionInfo: executionContext, drawScene: false)
-        harness.renderer.stopExecution(graph: graph)
+        try harness.renderer.stopExecution(graph: graph)
 
         let outputImage = try requireValue(node.outputImage.value, "Expected depth-of-field output image")
         #expect(outputImage.texture.width == 48)
@@ -345,9 +345,9 @@ struct GraphExecutionTests {
 
         let executionContext = harness.makeExecutionContext(time: 0, deltaTime: 1.0 / 60.0, frameNumber: 0)
 
-        harness.renderer.startExecution(graph: graph)
+        try harness.renderer.startExecution(graph: graph)
         try harness.render(graph: graph, executionInfo: executionContext, drawScene: false)
-        harness.renderer.stopExecution(graph: graph)
+        try harness.renderer.stopExecution(graph: graph)
 
         let outputImage = try requireValue(node.outputImage.value, "Expected motion-blur output image")
         #expect(outputImage.texture.width == 40)
@@ -355,8 +355,8 @@ struct GraphExecutionTests {
     }
 
     @Test("Depth of field and post process motion blur nodes are registered in the node registry")
-    func postProcessBlurNodesAreRegistered() {
-        let availableNames = Set(NodeRegistry.shared.availableNodes.map(\.nodeName))
+    func postProcessBlurNodesAreRegistered() throws {
+        let availableNames = try Set(NodeRegistry.shared.availableNodes.map(\.nodeName))
         #expect(availableNames.contains(DepthOfFieldNode.name))
         #expect(availableNames.contains(PostProcessMotionBlurNode.name))
     }
@@ -373,7 +373,7 @@ struct GraphExecutionTests {
         let firstContext = harness.makeExecutionContext(time: 200, deltaTime: 0, frameNumber: 0)
         let secondContext = harness.makeExecutionContext(time: 201, deltaTime: 1, frameNumber: 1)
 
-        harness.renderer.startExecution(graph: graph)
+        try harness.renderer.startExecution(graph: graph)
         try harness.render(graph: graph, executionInfo: firstContext)
 
         try expectEqual(renderInfoNode.outputWidth.value, 640)
@@ -381,7 +381,7 @@ struct GraphExecutionTests {
         #expect(renderInfoNode.outputFrameNumber.value == 0)
 
         try harness.render(graph: graph, executionInfo: secondContext)
-        harness.renderer.stopExecution(graph: graph)
+        try harness.renderer.stopExecution(graph: graph)
 
         #expect(renderInfoNode.outputFrameNumber.value == 1)
     }
@@ -415,9 +415,9 @@ struct GraphExecutionTests {
 
         let context = harness.makeExecutionContext(time: 300, deltaTime: 0, frameNumber: 0)
 
-        harness.renderer.startExecution(graph: graph)
+        try harness.renderer.startExecution(graph: graph)
         try harness.render(graph: graph, executionInfo: context)
-        harness.renderer.stopExecution(graph: graph)
+        try harness.renderer.stopExecution(graph: graph)
 
         try expectEqual(innerAdd.inputNumber1.value, 4)
         try expectEqual(proxyOutput.value, 7)
@@ -467,9 +467,9 @@ struct GraphExecutionTests {
 
         let context = harness.makeExecutionContext(time: 400, deltaTime: 0, frameNumber: 0)
 
-        harness.renderer.startExecution(graph: graph)
+        try harness.renderer.startExecution(graph: graph)
         try harness.render(graph: graph, executionInfo: context)
-        harness.renderer.stopExecution(graph: graph)
+        try harness.renderer.stopExecution(graph: graph)
 
         #expect(indexProxy.value == 3)
         #expect(countProxy.value == 4)
@@ -501,9 +501,9 @@ struct GraphExecutionTests {
 
         let context = harness.makeExecutionContext(time: 500, deltaTime: 0, frameNumber: 0)
 
-        harness.renderer.startExecution(graph: graph)
+        try harness.renderer.startExecution(graph: graph)
         try harness.render(graph: graph, executionInfo: context)
-        harness.renderer.stopExecution(graph: graph)
+        try harness.renderer.stopExecution(graph: graph)
 
         let colorImage = try requireValue(deferred.outputColorTexture.value, "Expected deferred color output")
         #expect(colorImage.texture.width == 64)
@@ -568,9 +568,9 @@ struct GraphExecutionTests {
 
         let context = harness.makeExecutionContext(time: 550, deltaTime: 0, frameNumber: 0)
 
-        harness.renderer.startExecution(graph: graph)
+        try harness.renderer.startExecution(graph: graph)
         try harness.render(graph: graph, executionInfo: context)
-        harness.renderer.stopExecution(graph: graph)
+        try harness.renderer.stopExecution(graph: graph)
 
         let albedoImage = try requireValue(imagePort(named: "Albedo Texture", kind: .Outlet, on: deferred).value, "Expected deferred albedo output")
         let normalImage = try requireValue(imagePort(named: "Normals Texture", kind: .Outlet, on: deferred).value, "Expected deferred normals output")
@@ -619,9 +619,9 @@ struct GraphExecutionTests {
 
         let context = harness.makeExecutionContext(time: 600, deltaTime: 0, frameNumber: 0)
 
-        harness.renderer.startExecution(graph: decodedGraph)
+        try harness.renderer.startExecution(graph: decodedGraph)
         try harness.render(graph: decodedGraph, executionInfo: context)
-        harness.renderer.stopExecution(graph: decodedGraph)
+        try harness.renderer.stopExecution(graph: decodedGraph)
 
         try expectEqual(decodedAddNode.outputNumber.value, 21)
     }
@@ -668,9 +668,9 @@ struct GraphExecutionTests {
 
         let context = harness.makeExecutionContext(time: 700, deltaTime: 0, frameNumber: 0)
 
-        harness.renderer.startExecution(graph: decodedGraph)
+        try harness.renderer.startExecution(graph: decodedGraph)
         try harness.render(graph: decodedGraph, executionInfo: context)
-        harness.renderer.stopExecution(graph: decodedGraph)
+        try harness.renderer.stopExecution(graph: decodedGraph)
 
         try expectEqual(decodedProxyOutput.value, 11)
     }
@@ -735,9 +735,9 @@ struct GraphExecutionTests {
 
         let context = harness.makeExecutionContext(time: 750, deltaTime: 0, frameNumber: 0)
 
-        harness.renderer.startExecution(graph: decodedGraph)
+        try harness.renderer.startExecution(graph: decodedGraph)
         try harness.render(graph: decodedGraph, executionInfo: context)
-        harness.renderer.stopExecution(graph: decodedGraph)
+        try harness.renderer.stopExecution(graph: decodedGraph)
 
         try expectEqual(decodedOuterProxyOutput.value, 12)
     }
@@ -777,9 +777,9 @@ struct GraphExecutionTests {
 
         let context = harness.makeExecutionContext(time: 800, deltaTime: 0, frameNumber: 0)
 
-        harness.renderer.startExecution(graph: decodedGraph)
+        try harness.renderer.startExecution(graph: decodedGraph)
         try harness.render(graph: decodedGraph, executionInfo: context)
-        harness.renderer.stopExecution(graph: decodedGraph)
+        try harness.renderer.stopExecution(graph: decodedGraph)
 
         let colorImage = try requireValue(decodedDeferred.outputColorTexture.value, "Expected decoded deferred color output")
         #expect(colorImage.texture.width == 48)
@@ -828,9 +828,9 @@ struct GraphExecutionTests {
 
         let context = harness.makeExecutionContext(time: 850, deltaTime: 0, frameNumber: 0)
 
-        harness.renderer.startExecution(graph: decodedGraph)
+        try harness.renderer.startExecution(graph: decodedGraph)
         try harness.render(graph: decodedGraph, executionInfo: context)
-        harness.renderer.stopExecution(graph: decodedGraph)
+        try harness.renderer.stopExecution(graph: decodedGraph)
 
         let albedoImage = try requireValue(imagePort(named: "Albedo Texture", kind: .Outlet, on: decodedDeferred).value, "Expected decoded deferred albedo output")
         let velocityImage = try requireValue(imagePort(named: "Velocity Texture", kind: .Outlet, on: decodedDeferred).value, "Expected decoded deferred velocity output")

--- a/Tests/GraphExportRendererTests.swift
+++ b/Tests/GraphExportRendererTests.swift
@@ -42,10 +42,10 @@ struct GraphExportRendererTests {
             colorPixelFormat: .bgra8Unorm
         )
 
-        renderer.start()
+        try renderer.start()
         try renderer.renderFrame(into: texture, time: 5.0)
         try expectExportEqual(timeNode.outputNumber.value, 5.0)
-        renderer.finish()
+        try renderer.finish()
     }
 
     @Test("Sequential export frames derive delta time internally")
@@ -66,7 +66,7 @@ struct GraphExportRendererTests {
             colorPixelFormat: .bgra8Unorm
         )
 
-        renderer.start()
+        try renderer.start()
         try renderer.renderFrame(into: texture, time: 10.0)
         try expectExportEqual(integralNode.outputNumber.value, 0.0)
 
@@ -75,7 +75,7 @@ struct GraphExportRendererTests {
 
         try renderer.renderFrame(into: texture, time: 12.0)
         try expectExportEqual(integralNode.outputNumber.value, 4.0)
-        renderer.finish()
+        try renderer.finish()
     }
 
     @Test("Sequential export frames advance internal frame number")
@@ -95,12 +95,12 @@ struct GraphExportRendererTests {
             colorPixelFormat: .bgra8Unorm
         )
 
-        renderer.start()
+        try renderer.start()
         try renderer.renderFrame(into: texture, time: 1.0)
         #expect(renderInfoNode.outputFrameNumber.value == 0)
 
         try renderer.renderFrame(into: texture, time: 2.0)
         #expect(renderInfoNode.outputFrameNumber.value == 1)
-        renderer.finish()
+        try renderer.finish()
     }
 }

--- a/Tests/NodeRegistryTests.swift
+++ b/Tests/NodeRegistryTests.swift
@@ -6,8 +6,8 @@ import Foundation
 struct NodeRegistryTests {
 
     @Test("Core nodes are loaded through the plugin loader")
-    func coreNodesLoadThroughPluginLoader() {
-        let registry = NodeRegistry()
+    func coreNodesLoadThroughPluginLoader() throws {
+        let registry = try NodeRegistry()
 
         let nodeClassFound = registry.nodeClass(for: "PerspectiveCameraNode") != nil
         #expect(nodeClassFound)
@@ -20,8 +20,8 @@ struct NodeRegistryTests {
     }
 
     @Test("Shader-backed dynamic nodes are owned by the core plugin")
-    func dynamicShaderNodesLoadThroughCorePlugin() {
-        let registry = NodeRegistry()
+    func dynamicShaderNodesLoadThroughCorePlugin() throws {
+        let registry = try NodeRegistry()
 
         let dynamicNodes = registry.availableNodes.filter { wrapper in
             wrapper.fileURL?.pathExtension == "metal"
@@ -35,10 +35,10 @@ struct NodeRegistryTests {
     // access from render queues must only allow one loader pass to initialize
     // the registry.
     @Test("Concurrent first access to a cold registry is safe")
-    func nodeRegistryConcurrentFirstAccess() async {
+    func nodeRegistryConcurrentFirstAccess() async throws {
         for _ in 0..<100 {
             // Fresh registry wrapper so each iteration hits the loader path.
-            let registry = NodeRegistry()
+            let registry = try NodeRegistry()
             await withTaskGroup(of: Void.self) { group in
                 for _ in 0..<16 {
                     group.addTask {

--- a/Tests/NodeRegistryTests.swift
+++ b/Tests/NodeRegistryTests.swift
@@ -9,7 +9,8 @@ struct NodeRegistryTests {
     func coreNodesLoadThroughPluginLoader() throws {
         let registry = try NodeRegistry()
 
-        let nodeClassFound = registry.nodeClass(for: "PerspectiveCameraNode") != nil
+        let nodeClassFound = registry.nodeClass(pluginID: PluginLoader.coreNodesPluginID,
+                                                nodeID: "PerspectiveCameraNode") != nil
         #expect(nodeClassFound)
         #expect(PluginLoader.shared.loadedPlugins[FabricCoreNodesPlugin.pluginID] != nil)
 
@@ -42,7 +43,8 @@ struct NodeRegistryTests {
             await withTaskGroup(of: Void.self) { group in
                 for _ in 0..<16 {
                     group.addTask {
-                        _ = registry.nodeClass(for: "PerspectiveCameraNode")
+                        _ = registry.nodeClass(pluginID: PluginLoader.coreNodesPluginID,
+                                               nodeID: "PerspectiveCameraNode")
                     }
                 }
             }
@@ -50,7 +52,8 @@ struct NodeRegistryTests {
             // generic __checkBinaryOperation crashes the runtime's metadata
             // instantiation (metatype generic argument), independent of the
             // registry race this test guards against.
-            let found = registry.nodeClass(for: "PerspectiveCameraNode") != nil
+            let found = registry.nodeClass(pluginID: PluginLoader.coreNodesPluginID,
+                                           nodeID: "PerspectiveCameraNode") != nil
             #expect(found)
         }
     }

--- a/Tests/NodeRegistryTests.swift
+++ b/Tests/NodeRegistryTests.swift
@@ -5,16 +5,39 @@ import Foundation
 @Suite("Node Registry")
 struct NodeRegistryTests {
 
-    // Swift `lazy var` initialization is not atomic: concurrent first reads of
-    // NodeRegistry's lookup tables raced on the backing store and crashed in
-    // _DictionaryStorage.deinit. NodeRegistry.init now builds the render-path
-    // tables eagerly, so first access from many threads at once must be safe.
-    // Under Thread Sanitizer the old race is reported deterministically;
-    // without TSan it was an intermittent crash, hence the loop.
+    @Test("Core nodes are loaded through the plugin loader")
+    func coreNodesLoadThroughPluginLoader() {
+        let registry = NodeRegistry()
+
+        let nodeClassFound = registry.nodeClass(for: "PerspectiveCameraNode") != nil
+        #expect(nodeClassFound)
+        #expect(PluginLoader.shared.loadedPlugins[FabricCoreNodesPlugin.pluginID] != nil)
+
+        let perspectiveWrapper = registry.availableNodes.first { wrapper in
+            wrapper.nodeClass == PerspectiveCameraNode.self
+        }
+        #expect(perspectiveWrapper?.pluginBundleID == FabricCoreNodesPlugin.pluginID)
+    }
+
+    @Test("Shader-backed dynamic nodes are owned by the core plugin")
+    func dynamicShaderNodesLoadThroughCorePlugin() {
+        let registry = NodeRegistry()
+
+        let dynamicNodes = registry.availableNodes.filter { wrapper in
+            wrapper.fileURL?.pathExtension == "metal"
+        }
+
+        #expect(!dynamicNodes.isEmpty)
+        #expect(dynamicNodes.allSatisfy { $0.pluginBundleID == FabricCoreNodesPlugin.pluginID })
+    }
+
+    // Plugin loading is lazy and mutates lookup dictionaries. Concurrent first
+    // access from render queues must only allow one loader pass to initialize
+    // the registry.
     @Test("Concurrent first access to a cold registry is safe")
     func nodeRegistryConcurrentFirstAccess() async {
         for _ in 0..<100 {
-            // Fresh instance so the lookup tables are cold each iteration.
+            // Fresh registry wrapper so each iteration hits the loader path.
             let registry = NodeRegistry()
             await withTaskGroup(of: Void.self) { group in
                 for _ in 0..<16 {

--- a/Tests/PortConnectionTests.swift
+++ b/Tests/PortConnectionTests.swift
@@ -76,6 +76,44 @@ struct PortConnectionTests {
         #expect(decodedSource.outputNumber.connections.count == 1)
     }
 
+    @Test("Graph encoding records required plugins and qualified node IDs")
+    func graphEncodingRecordsRequiredPluginsAndQualifiedNodeIDs() throws {
+        guard let context = makeContext() else { return }
+
+        let graph = Graph(context: context)
+        graph.addNode(PerspectiveCameraNode(context: context))
+
+        let data = try JSONEncoder().encode(graph)
+        let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let requiredPlugins = try #require(object?["requiredPlugins"] as? [[String: Any]])
+        let nodeMap = try #require(object?["nodeMap"] as? [[String: Any]])
+
+        #expect(requiredPlugins.contains { $0["id"] as? String == PluginLoader.coreNodesPluginID })
+        #expect(nodeMap.first?["type"] as? String == "\(PluginLoader.coreNodesPluginID)/PerspectiveCameraNode")
+    }
+
+    @Test("Legacy unqualified node IDs decode as core plugin nodes")
+    func legacyUnqualifiedNodeIDsDecodeAsCorePluginNodes() throws {
+        guard let context = makeContext() else { return }
+
+        let graph = Graph(context: context)
+        graph.addNode(PerspectiveCameraNode(context: context))
+
+        let encodedData = try JSONEncoder().encode(graph)
+        var object = try #require(JSONSerialization.jsonObject(with: encodedData) as? [String: Any])
+        var nodeMap = try #require(object["nodeMap"] as? [[String: Any]])
+        nodeMap[0]["type"] = "PerspectiveCameraNode"
+        object["nodeMap"] = nodeMap
+        object.removeValue(forKey: "requiredPlugins")
+
+        let legacyData = try JSONSerialization.data(withJSONObject: object)
+        let decoder = JSONDecoder()
+        decoder.context = DecoderContext(documentContext: context)
+        let decodedGraph = try decoder.decode(Graph.self, from: legacyData)
+
+        #expect(decodedGraph.nodes.first is PerspectiveCameraNode)
+    }
+
     @Test("Generic array virtual type compatibility is array scoped")
     func genericArrayVirtualTypeCompatibilityIsArrayScoped() {
         let genericArray = PortType.Array(portType: .Virtual)

--- a/Tests/RoutingNodeExecutionTests.swift
+++ b/Tests/RoutingNodeExecutionTests.swift
@@ -715,9 +715,9 @@ struct RoutingNodeExecutionTests
     }
 
     @Test("Routing nodes are registered")
-    func routingNodesAreRegistered()
+    func routingNodesAreRegistered() throws
     {
-        let availableNames = Set(NodeRegistry.shared.availableNodes.map(\.nodeName))
+        let availableNames = try Set(NodeRegistry.shared.availableNodes.map(\.nodeName))
         #expect(availableNames.contains(SwitchNode.name))
         #expect(availableNames.contains(GateNode.name))
         #expect(availableNames.contains(MatrixSwitchNode.name))


### PR DESCRIPTION
This PR 

* Updates Satin submodule to a branch that adds throwable to setup, update and draw, and adds a delegate method to vend errors thrown behind Apple api boundaries that dont support surfacing errors (see CAMetalDisplayLink / CAMetalDrawable stuff)

* Updates Document loading GraphRenderer, and Node api's to support throwing new Fabric Errors, which have both fatal and recoverable variants. 

* Updates Fabric Editor to surface fatal errors to users, and catch recoverable without any real issue. The goal to eventually allow the UI to surface specific nodes throwing during execution in the UI (ie warning icons or what not)

* Updates the Fabric framework to support a QC Plugin like api surface  area with a new `FabricPlugin` api,  allowing:
   - `FabricPlugins` to host multiple nodes
   - `FabricPlugins` to be auto discovered via the `NodeRegistry`
   - `FabricPlugins` to have author metadata, versions etc
   - Bundles existing nodes into a core plugin : `FabricCoreNodesPlugin`
   
   
 Notes / Design decisions
 
 * `FabricCoreNodesPlugin` isnt a separate build target, mostly to ease integration, but it is loaded / treated as one internally by the NodeRegistry
 
 * `FabricPlugin` can be loaded from  `/Library/Application Support/Fabric/Plugins` and " ~/Library/Application Support/Fabric/Plugins`
 
 * Recoverable Errors thrown - im not convinced the current design is the best, we can review and keep this as a starting point