### PR TITLE
Feature – Plugin nodes can be renderable or subgraph types

### DIFF
--- a/Fabric/Graph/Node/Node.swift
+++ b/Fabric/Graph/Node/Node.swift
@@ -75,7 +75,7 @@ open class Node : Codable, Equatable, Identifiable, Hashable, Copyable
 
     public private(set) var context:Context
 
-    weak var graph:Graph?
+    public internal(set) weak var graph:Graph?
 
     // Method to register ports
     open class func registerPorts(context: Context) -> [(name: String, port: Port)] { [] }

--- a/Fabric/Nodes/Base/BaseObjectNode.swift
+++ b/Fabric/Nodes/Base/BaseObjectNode.swift
@@ -11,12 +11,12 @@ import Satin
 import simd
 import Metal
 
-public class BaseObjectNode : Node
+open class BaseObjectNode : Node
 {
-    override public class var nodeExecutionMode: Node.ExecutionMode { .Consumer }
-    override public class var nodeTimeMode: Node.TimeMode { .None }
+    override open class var nodeExecutionMode: Node.ExecutionMode { .Consumer }
+    override open class var nodeTimeMode: Node.TimeMode { .None }
 
-    public func getObject() -> Object? {
+    open func getObject() -> Object? {
         return nil
     }
 }
@@ -53,7 +53,7 @@ public class ObjectNode<ObjectType : Satin.Object> : BaseObjectNode
     override public func getObject() -> Object? {
         return self.object
     }
-    
+
     var object: ObjectType? {
         return nil
     }

--- a/Fabric/Nodes/Base/BaseObjectNode.swift
+++ b/Fabric/Nodes/Base/BaseObjectNode.swift
@@ -22,9 +22,9 @@ open class BaseObjectNode : Node
 }
 
 
-public class ObjectNode<ObjectType : Satin.Object> : BaseObjectNode
+open class ObjectNode<ObjectType : Satin.Object> : BaseObjectNode
 {
-    override public class func registerPorts(context: Context) -> [(name: String, port: Port)] {
+    override open class func registerPorts(context: Context) -> [(name: String, port: Port)] {
         let ports = super.registerPorts(context: context)
         
         return [
@@ -50,15 +50,15 @@ public class ObjectNode<ObjectType : Satin.Object> : BaseObjectNode
     public var inputScale:ParameterPort<simd_float3>          { port(named: "inputScale") }
     public var inputOrientation:ParameterPort<simd_float4>          { port(named: "inputOrientation") }
     
-    override public func getObject() -> Object? {
+    override open func getObject() -> Object? {
         return self.object
     }
 
-    var object: ObjectType? {
+    open var object: ObjectType? {
         return nil
     }
 
-    public func evaluate(object:Object?, atTime:TimeInterval) -> Bool
+    open func evaluate(object:Object?, atTime:TimeInterval) -> Bool
     {
         var shouldOutput = false
         

--- a/Fabric/Nodes/Base/BaseRenderableNode.swift
+++ b/Fabric/Nodes/Base/BaseRenderableNode.swift
@@ -12,10 +12,10 @@ import simd
 import Metal
 
 
-public class BaseRenderableNode<ObjectType : Renderable> : ObjectNode<ObjectType>
+open class BaseRenderableNode<ObjectType : Renderable> : ObjectNode<ObjectType>
 {
-    
-    override public func evaluate(object:Object?, atTime:TimeInterval) -> Bool
+
+    override open func evaluate(object:Object?, atTime:TimeInterval) -> Bool
     {
         var shouldOutput = super.evaluate(object: object, atTime: atTime)
 

--- a/Fabric/Nodes/Object/SubGraph/DeferredSubgraphNode.swift
+++ b/Fabric/Nodes/Object/SubGraph/DeferredSubgraphNode.swift
@@ -110,11 +110,19 @@ public class DeferredSubgraphNode: SubgraphNode
     public required init(context: Context)
     {
         self.graphRenderer = GraphRenderer(context: context)
-        
+
         super.init(context: context)
         self.synchronizeDeferredConfiguration()
     }
-    
+
+    public override init(context: Context, subGraph: Graph)
+    {
+        self.graphRenderer = GraphRenderer(context: context)
+
+        super.init(context: context, subGraph: subGraph)
+        self.synchronizeDeferredConfiguration()
+    }
+
     public required init(from decoder: any Decoder) throws
     {
         guard let decodeContext = decoder.context else

--- a/Fabric/Nodes/Object/SubGraph/SubgraphNode.swift
+++ b/Fabric/Nodes/Object/SubGraph/SubgraphNode.swift
@@ -18,7 +18,7 @@ open class SubgraphNode: BaseObjectNode
     override open class var nodeTimeMode: Node.TimeMode { .TimeBase }
     override open class var nodeDescription: String { "A Sub Graph of Nodes, useful for organizing or encapsulation"}
 
-    let subGraph:Graph
+    public private(set) var subGraph:Graph
 
     /// ProxyPorts wrapping the sub graph's published ports.
     /// Each proxy has node = self (the SubgraphNode) and published = false.
@@ -178,7 +178,18 @@ open class SubgraphNode: BaseObjectNode
         self.wireSubGraphCallback()
         self.rebuildProxyPorts()
     }
-    
+
+    /// Wrap an existing graph as this node's sub graph, for embedders that
+    /// decode a graph separately and then nest it.
+    public init(context: Context, subGraph: Graph)
+    {
+        self.subGraph = subGraph
+
+        super.init(context: context)
+        self.wireSubGraphCallback()
+        self.rebuildProxyPorts()
+    }
+
     enum CodingKeys : String, CodingKey
     {
         case subGraph

--- a/Fabric/Nodes/Object/SubGraph/SubgraphNode.swift
+++ b/Fabric/Nodes/Object/SubGraph/SubgraphNode.swift
@@ -10,13 +10,13 @@ import Satin
 import simd
 import Metal
 
-public class SubgraphNode: BaseObjectNode
+open class SubgraphNode: BaseObjectNode
 {
-    override public class var name:String { "Sub Graph" }
-    override public class var nodeType:Node.NodeType { Node.NodeType.Subgraph }
-    override public class var nodeExecutionMode: Node.ExecutionMode { .Consumer } // TODO: ??
-    override public class var nodeTimeMode: Node.TimeMode { .TimeBase }
-    override public class var nodeDescription: String { "A Sub Graph of Nodes, useful for organizing or encapsulation"}
+    override open class var name:String { "Sub Graph" }
+    override open class var nodeType:Node.NodeType { Node.NodeType.Subgraph }
+    override open class var nodeExecutionMode: Node.ExecutionMode { .Consumer } // TODO: ??
+    override open class var nodeTimeMode: Node.TimeMode { .TimeBase }
+    override open class var nodeDescription: String { "A Sub Graph of Nodes, useful for organizing or encapsulation"}
 
     let subGraph:Graph
 
@@ -26,11 +26,11 @@ public class SubgraphNode: BaseObjectNode
     /// Lazily rebuilt when the sub graph's published ports change.
     private var proxyPorts: [Port] = []
 
-    override public var ports:[Port] { self.proxyPorts + super.ports }
+    override open var ports:[Port] { self.proxyPorts + super.ports }
 
     /// Rebuild proxy ports from the sub graph's current published ports.
     /// Called via callback when the sub graph's published ports change.
-    public func rebuildProxyPorts()
+    open func rebuildProxyPorts()
     {
         self.invalidatePortCaches()
 
@@ -134,7 +134,7 @@ public class SubgraphNode: BaseObjectNode
         }
     }
 
-    override public var nodeExecutionMode:ExecutionMode
+    override open var nodeExecutionMode:ExecutionMode
     {
         let publishedInputPorts = self.proxyPorts.filter { $0.kind == .Inlet }
         let publishedOutputPorts = self.proxyPorts.filter { $0.kind == .Outlet }
@@ -161,12 +161,12 @@ public class SubgraphNode: BaseObjectNode
         return Self.nodeExecutionMode
     }
 
-    override public func getObject() -> Object?
+    override open func getObject() -> Object?
     {
         return self.object
     }
-    
-    public var object:Object? {
+
+    open var object:Object? {
         self.subGraph.scene
     }
     
@@ -185,7 +185,7 @@ public class SubgraphNode: BaseObjectNode
         case proxyPorts
     }
     
-    public override func encode(to encoder:Encoder) throws
+    open override func encode(to encoder:Encoder) throws
     {
         var container = encoder.container(keyedBy: CodingKeys.self)
         
@@ -251,10 +251,10 @@ public class SubgraphNode: BaseObjectNode
      
     // Ensure we always render!
 //    override public var isDirty:Bool { get {  true /*self.subGraph.needsExecution*/  } set { } }
-    override public var isDirty:Bool { get {  self.subGraph.needsExecution  } set { } }
+    override open var isDirty:Bool { get {  self.subGraph.needsExecution  } set { } }
 
 
-    override public func markClean()
+    override open func markClean()
     {
         for node in self.subGraph.nodes
         {
@@ -264,7 +264,7 @@ public class SubgraphNode: BaseObjectNode
         super.markClean()
     }
          
-    override public func markDirty()
+    override open func markDirty()
     {
         for node in self.subGraph.nodes
         {
@@ -274,27 +274,27 @@ public class SubgraphNode: BaseObjectNode
         super.markDirty()
     }
     
-    override public func startExecution(renderer:GraphRenderer) throws
+    override open func startExecution(renderer:GraphRenderer) throws
     {
         try renderer.startExecution(graph: self.subGraph)
     }
-    
-    override public func stopExecution(renderer:GraphRenderer) throws
+
+    override open func stopExecution(renderer:GraphRenderer) throws
     {
         try renderer.stopExecution(graph: self.subGraph)
     }
 
-    override public func enableExecution(renderer:GraphRenderer) throws
+    override open func enableExecution(renderer:GraphRenderer) throws
     {
         try renderer.enableExecution(graph: self.subGraph)
     }
-    
-    override public func disableExecution(renderer:GraphRenderer) throws
+
+    override open func disableExecution(renderer:GraphRenderer) throws
     {
         try renderer.disableExecution(graph: self.subGraph)
     }
-    
-    public func forwardPortValues(force:Bool = false)
+
+    open func forwardPortValues(force:Bool = false)
     {
         // Forward outlet values from inner ports to proxy ports so the
         // parent graph receives sub graph outputs.
@@ -304,7 +304,7 @@ public class SubgraphNode: BaseObjectNode
         }
     }
     
-    override  public func execute(renderer:GraphRenderer,
+    override open func execute(renderer:GraphRenderer,
                                   executionInfo:GraphExecutionInfo,
                                   renderPassDescriptor: MTLRenderPassDescriptor,
                                   commandBuffer: MTLCommandBuffer) throws    {


### PR DESCRIPTION
Latest changes to #303 solve most the structural issues flagged by the first round of *spark stage migrating to the new plugin API. The remaining gap is that the current plugin API does not allow plugins to provide renderable nodes (BaseObjectNode / BaseRenderableNode subclasses) or subgraph nodes (SubgraphNode subclasses).

This gap cannot be worked around on the plugin side: the graph discovers scene objects by `as? BaseObjectNode → getObject()` and subgraphs by `as? SubgraphNode`, so a node that doesn't subclass them is invisible to scene assembly and subgraph handling; and the base implementations call internal symbols (e.g. `invalidatePortCaches`, `portsChangedSubject`), so they can't be re-implemented against the public API either. The cause is that these base classes are public rather than open. This PR opens the object-node/renderable and subgraph node hierarchies (plus Node.teardown and Node.graph) for external subclassing — access widening only, no behavioural change. The alternative is to dispatch on a public protocol (e.g. SceneObjectProviding / SubgraphProviding) instead of concrete-class casts, letting plugins conform without subclassing — a larger change that inverts the current type-based dispatch.