### PR TITLE
Feature – Plugin loader resilience

### DIFF
--- a/Fabric/Nodes/NodeRegistry.swift
+++ b/Fabric/Nodes/NodeRegistry.swift
@@ -115,14 +115,21 @@ public class NodeRegistry
         registerCoreAlias("PassThroughNode<Satin.SatinGeometry>", PassThroughNode<Geometry>.self)
 
         // Structural array nodes were previously generic; old docs decode to type-agnostic versions.
+        //
+        // These suffixes must be spelled the way a *document* spells them, which is
+        // `String(describing:)` of the generic parameter — and that prints the
+        // underlying type, not the source alias. `simd_float2/3/4` are typealiases
+        // for `SIMD2/3/4<Float>`, so a saved graph reads `ArrayCountNode<SIMD3<Float>>`
+        // and never `ArrayCountNode<simd_float3>`. `simd_float4x4` is a struct in its
+        // own right, so it is spelled as written.
         let agnosticSuffixes = [
             "Bool",
             "Int",
             "Float",
             "String",
-            "simd_float2",
-            "simd_float3",
-            "simd_float4",
+            "SIMD2<Float>",
+            "SIMD3<Float>",
+            "SIMD4<Float>",
             "simd_float4x4",
             "FabricImage",
         ]
@@ -140,7 +147,7 @@ public class NodeRegistry
         }
 
         // Vector compose/decompose nodes were previously generic; old docs map to consolidated versions.
-        let vectorSuffixes = ["simd_float2", "simd_float3", "simd_float4"]
+        let vectorSuffixes = ["SIMD2<Float>", "SIMD3<Float>", "SIMD4<Float>"]
 
         for suffix in vectorSuffixes
         {

--- a/Fabric/Nodes/Plugin/PluginLoader.swift
+++ b/Fabric/Nodes/Plugin/PluginLoader.swift
@@ -28,6 +28,19 @@ public final class PluginLoader
 
     private init() {}
 
+    /// The plugin folder inside a domain's Application Support directory, or nil if
+    /// the domain has none.
+    public static func pluginDirectory(in domain: FileManager.SearchPathDomainMask) -> URL?
+    {
+        FileManager.default
+            .urls(for: .applicationSupportDirectory, in: domain)
+            .first?
+            .appending(path: "Fabric", directoryHint: .isDirectory)
+            .appending(path: "Plugins", directoryHint: .isDirectory)
+    }
+
+    /// Where plugins are looked for, in precedence order: the host application's
+    /// own bundle first, then the user's plugin folder, then the machine's.
     public func pluginSearchDirectories() -> [URL]
     {
         var directories: [URL] = []
@@ -37,15 +50,16 @@ public final class PluginLoader
             directories.append(builtInPlugInsURL)
         }
 
-        if let appSupportURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+        if let userPluginDirectory = Self.pluginDirectory(in: .userDomainMask)
         {
-            directories.append(appSupportURL
-                .appending(path: "Fabric", directoryHint: .isDirectory)
-                .appending(path: "Plugins", directoryHint: .isDirectory))
+            directories.append(userPluginDirectory)
         }
 
         #if os(macOS)
-        directories.append(URL(filePath: "/Library/Application Support/Fabric/Plugins", directoryHint: .isDirectory))
+        if let localPluginDirectory = Self.pluginDirectory(in: .localDomainMask)
+        {
+            directories.append(localPluginDirectory)
+        }
         #endif
 
         return directories

--- a/Fabric/Nodes/Plugin/PluginLoader.swift
+++ b/Fabric/Nodes/Plugin/PluginLoader.swift
@@ -98,33 +98,51 @@ public final class PluginLoader
         }
     }
 
+    /// Loads every discovered plugin bundle.
+    ///
+    /// One bundle's failure costs that bundle only: the pass records the error in
+    /// `loadErrors` for a host to surface, and carries on with the rest. Without
+    /// that, a single stale or malformed bundle in a shared plugin folder would
+    /// take down every plugin behind it in the search order — including the host's
+    /// own — which is a lot of collateral for someone else's bad plugin.
+    ///
+    /// A bundle re-declaring an already-loaded plugin identifier is not a failure
+    /// and is not recorded as one. Search order is precedence
+    /// (`pluginSearchDirectories()`: the app bundle first, then the user's plugin
+    /// folder, then the system's), so the first one found wins and the rest are
+    /// redundant copies. That is what lets an app embed a plugin *and* install it
+    /// for other Fabric hosts to share without breaking its own load.
     public func loadDiscoveredPlugins() throws
     {
-        let existingNodeNames = currentRegisteredNodeNames()
-
-        let pluginURLs: [URL]
-        pluginURLs = try discoverPlugins()
+        let pluginURLs = try discoverPlugins()
 
         logger.info("Found \(pluginURLs.count) Fabric plugin bundle(s)")
 
         for pluginURL in pluginURLs
         {
+            // Re-read per bundle: a plugin loaded earlier in this same pass must
+            // count as already-registered for the ones that follow it.
+            let existingNodeNames = currentRegisteredNodeNames()
+
             do
             {
                 try loadPlugin(at: pluginURL, existingNodeNames: existingNodeNames)
+            }
+            catch PluginLoadError.duplicatePluginIdentifier(let pluginID)
+            {
+                let winning = loadedPlugins[pluginID]?.bundleURL.path ?? "an earlier bundle"
+                logger.notice("Ignoring \(pluginURL.path, privacy: .public) — plugin '\(pluginID, privacy: .public)' is already provided by \(winning, privacy: .public)")
             }
             catch let error as PluginLoadError
             {
                 loadErrors.append(error)
                 logger.error("\(error.localizedDescription)")
-                throw error
             }
             catch
             {
                 let wrappedError = PluginLoadError.bundleLoadFailed(bundleURL: pluginURL, underlyingError: error)
                 loadErrors.append(wrappedError)
                 logger.error("\(wrappedError.localizedDescription)")
-                throw wrappedError
             }
         }
     }

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -64,14 +64,24 @@ public final class PluginMain: NSObject, FabricPlugin
 
 `NodeRegistry` transparently asks `PluginLoader` to load plugins on first use. The embedded core plugin is always loaded first.
 
-Fabric searches:
+Fabric searches, in this order:
 
 - `Fabric.app/Contents/PlugIns/`
 - `~/Library/Application Support/Fabric/Plugins/`
 - `/Library/Application Support/Fabric/Plugins/` on macOS
 
+## Precedence
+
+**Search order is precedence.** The first bundle found to declare a given plugin identifier wins; later bundles declaring the same identifier are ignored, logged, and *not* treated as errors.
+
+This is what lets an application embed a plugin in its own `Contents/PlugIns/` *and* install a copy in the user's plugin folder for other Fabric hosts to share. Inside that application the embedded copy wins; every other host loads the installed one. Both apps work, and neither has to know what the other did.
+
 ## Loading Errors
 
-Plugin loading is non-fatal. Fabric logs errors and continues with other plugins. Phase 2 supports errors for missing bundles, bundle load failures, missing identifiers, unsupported API versions, missing node declarations, missing classes, non-node classes, principal-class failures, duplicate plugin identifiers, and duplicate node names.
+Plugin loading is non-fatal. One bundle's failure costs that bundle only — Fabric records the error in `NodeRegistry.pluginLoadErrors` for a host to surface, and continues with the remaining bundles. This matters in a shared plugin folder: a stale or malformed bundle must not take down the plugins behind it in the search order, including the host's own.
+
+Errors are represented for missing bundles, bundle load failures, missing identifiers, unsupported API versions, missing node declarations, missing classes, non-node classes, principal-class failures, and duplicate node names.
+
+A plugin whose node names collide with already-registered ones is rejected as a whole, so a bundle cannot partially register.
 
 The embedded core plugin is fatal to useful operation if it fails to register, but the failure is still represented in `NodeRegistry.pluginLoadErrors` so callers can surface it in UI.

--- a/Tests/NodeRegistryTests.swift
+++ b/Tests/NodeRegistryTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import simd
 @testable import Fabric
 
 @Suite("Node Registry")
@@ -56,5 +57,64 @@ struct NodeRegistryTests {
                                            nodeID: "PerspectiveCameraNode") != nil
             #expect(found)
         }
+    }
+
+    // MARK: - Legacy aliases
+
+    /// A saved graph spells a generic parameter the way `String(describing:)` prints
+    /// it, which is the underlying type rather than the source alias. These are the
+    /// spellings that actually appear in documents, so they are the ones the legacy
+    /// lookup has to answer to — asserting them here keeps the table honest, since
+    /// nothing else would notice an entry that can never match.
+    @Test("Legacy array-node aliases resolve the spellings documents use")
+    func legacyArrayAliasesUseDocumentSpellings() throws {
+        let registry = try NodeRegistry()
+
+        for nodeID in ["ArrayCountNode<SIMD3<Float>>",
+                       "ArrayIndexValueNode<SIMD4<Float>>",
+                       "ArrayQueueNode<SIMD2<Float>>",
+                       "ArrayAppendNode<Float>",
+                       "ArrayReplaceValueAtIndexNode<simd_float4x4>"] {
+            let resolved = registry.nodeClass(pluginID: PluginLoader.coreNodesPluginID,
+                                              nodeID: nodeID) != nil
+            #expect(resolved, "no legacy alias for '\(nodeID)'")
+        }
+    }
+
+    @Test("Legacy vector compose/decompose aliases resolve the spellings documents use")
+    func legacyVectorAliasesUseDocumentSpellings() throws {
+        let registry = try NodeRegistry()
+
+        for nodeID in ["ComposeVectorNode<SIMD2<Float>>",
+                       "DecomposeVectorNode<SIMD3<Float>>",
+                       "ComposeVectorArrayNode<SIMD4<Float>>",
+                       "DecomposeVectorArrayNode<SIMD3<Float>>"] {
+            let resolved = registry.nodeClass(pluginID: PluginLoader.coreNodesPluginID,
+                                              nodeID: nodeID) != nil
+            #expect(resolved, "no legacy alias for '\(nodeID)'")
+        }
+    }
+
+    /// The spelling that motivated the fix: `simd_float3` is a typealias, so it is
+    /// never what a document contains. Guards against the table drifting back.
+    @Test("Source-alias spellings are not what the lookup is keyed on")
+    func legacyAliasesAreNotKeyedOnSourceSpellings() throws {
+        let registry = try NodeRegistry()
+
+        let sourceSpellingResolves = registry.nodeClass(pluginID: PluginLoader.coreNodesPluginID,
+                                                        nodeID: "ArrayCountNode<simd_float3>") != nil
+        #expect(!sourceSpellingResolves,
+                "keyed on a spelling no document contains — the SIMD3<Float> form is the real one")
+    }
+
+    /// `String(describing:)` is the source of truth for both halves of the mapping,
+    /// so pin the assumption the alias table rests on rather than trusting it.
+    @Test("simd typealiases print as their underlying SIMD types")
+    func simdTypeNamesPrintAsUnderlyingTypes() {
+        #expect(String(describing: simd_float2.self) == "SIMD2<Float>")
+        #expect(String(describing: simd_float3.self) == "SIMD3<Float>")
+        #expect(String(describing: simd_float4.self) == "SIMD4<Float>")
+        // Not a SIMD typealias — a struct, so it keeps its own name.
+        #expect(String(describing: simd_float4x4.self) == "simd_float4x4")
     }
 }


### PR DESCRIPTION
Further, potentially final, issues encountered and addressed in the process of making *spark stage adopt Fabric w/ plugins.

Two of the three commits are important and the title should be enough here
- [One plugin's failure should not cost the plugins behind it](https://github.com/Fabric-Project/Fabric/commit/79b207acf4717c2a7c58564989a7429b36435254)
- [Key the legacy node aliases on the spellings documents actually use](https://github.com/Fabric-Project/Fabric/commit/b1d2b56affc46906836b8bc185c162eeabfe6641)