### PR TITLE
Feature – Graph execution sync

### DIFF
--- a/Fabric/Graph/Graph.swift
+++ b/Fabric/Graph/Graph.swift
@@ -6,6 +6,7 @@
 //
 import SwiftUI
 import Satin
+import os
 internal import AnyCodable
 
 public struct Connection: Codable, Identifiable, Hashable
@@ -49,7 +50,12 @@ public struct Connection: Codable, Identifiable, Hashable
     public private(set) var nodes: [Node]
     public private(set) var notes: [Note]
     internal var connections: [Connection] = []
-    internal var nodesInExecutionOrder: [Node] = []
+
+    /// The cached execution plan. Written only from rebuildNodesInExecutionOrderIfNeeded,
+    /// which GraphRenderer calls at the top of each execute pass — on the execute thread,
+    /// never mid-frame. @ObservationIgnored: SwiftUI must not track state that mutates on
+    /// the execute thread.
+    @ObservationIgnored internal private(set) var nodesInExecutionOrder: [Node] = []
 
     /// NodeViewModels shadow the nodes array 1-to-1. Always created/destroyed
     /// in lockstep with addNode / delete so the array is safe to force-index.
@@ -85,16 +91,17 @@ public struct Connection: Codable, Identifiable, Hashable
     // Fix for #103 - connection/topology changes trigger syncNodesToScene() inside of `GraphRenderer`.
     @ObservationIgnored private var pendingConnectionSceneSync = false
     public private(set) var connectionRevision = 0
-    private var connectionTopologyGeneration = 0 {
-        didSet { rebuildNodesInExecutionOrder() }
-    }
-    private var executionTopologyGeneration = 0 {
-        didSet { rebuildNodesInExecutionOrder() }
-    }
+
+    /// Topology marks only set this flag; the plan rebuild is deferred to
+    /// rebuildNodesInExecutionOrderIfNeeded at the top of the next execute pass.
+    /// Routing nodes mark from inside execute() on the execute thread while the UI
+    /// marks from the main thread, so this flag is the one piece of cross-thread
+    /// state and is lock-protected.
+    @ObservationIgnored private let executionPlanIsStale = OSAllocatedUnfairLock(initialState: true)
 
     @ObservationIgnored private var cachedPublishedOutputPortsRevision: Int?
     @ObservationIgnored private var cachedPublishedOutputPorts: [Port] = []
-  
+
 
     @ObservationIgnored weak var lastNode:(Node)? = nil
 
@@ -102,12 +109,12 @@ public struct Connection: Codable, Identifiable, Hashable
     {
         connectionRevision += 1
         pendingConnectionSceneSync = true
-        connectionTopologyGeneration += 1
+        executionPlanIsStale.withLock { $0 = true }
     }
 
     public func markExecutionTopologyChanged()
     {
-        executionTopologyGeneration += 1
+        executionPlanIsStale.withLock { $0 = true }
     }
 
     public func markConnectionsChanged()
@@ -323,7 +330,7 @@ public struct Connection: Codable, Identifiable, Hashable
         }
         
         self.rebuildPublishedParameterGroup()
-        self.rebuildNodesInExecutionOrder()
+        self.rebuildNodesInExecutionOrderIfNeeded()
     }
 
     deinit
@@ -567,7 +574,23 @@ public struct Connection: Codable, Identifiable, Hashable
         }
     }
 
-    func rebuildNodesInExecutionOrder()
+    /// The single point where the cached execution plan is rebuilt. GraphRenderer calls
+    /// this at the top of each execute pass, so the plan never changes mid-frame and
+    /// rebuilds at most once per frame however many topology marks arrived since the
+    /// last pass — an animated route index costs a flag set, not a planning walk.
+    func rebuildNodesInExecutionOrderIfNeeded()
+    {
+        let wasStale = executionPlanIsStale.withLock { isStale in
+            defer { isStale = false }
+            return isStale
+        }
+
+        guard wasStale else { return }
+
+        rebuildNodesInExecutionOrder()
+    }
+
+    private func rebuildNodesInExecutionOrder()
     {
         var ordered: [Node] = []
         ordered.reserveCapacity(nodes.count)

--- a/Fabric/Graph/Graph.swift
+++ b/Fabric/Graph/Graph.swift
@@ -95,9 +95,35 @@ public struct Connection: Codable, Identifiable, Hashable
     /// Topology marks only set this flag; the plan rebuild is deferred to
     /// rebuildNodesInExecutionOrderIfNeeded at the top of the next execute pass.
     /// Routing nodes mark from inside execute() on the execute thread while the UI
-    /// marks from the main thread, so this flag is the one piece of cross-thread
-    /// state and is lock-protected.
+    /// marks from the main thread, so this flag is written cross-thread and is
+    /// lock-protected independently of the structural mutation lock (marking must
+    /// stay cheap and lock-free with respect to execution).
     @ObservationIgnored private let executionPlanIsStale = OSAllocatedUnfairLock(initialState: true)
+
+    /// This graph's synchronization contract: structural mutations — port
+    /// registry changes, connect/disconnect, node add/delete — serialize against
+    /// graph execution on this lock. GraphRenderer holds it for the whole execute
+    /// pass, so a Settings-driven port rebuild or a canvas edit blocks for at
+    /// most one frame instead of racing the pass. Structural mutations are
+    /// main-thread operations (they are user actions); UI reads of ports and
+    /// topology are therefore ordered against mutations by the main thread
+    /// itself and take no lock — the lock exists solely for the execute pass,
+    /// which runs off-main. Compound transitions (rebuildPorts, shader-driven
+    /// port sync) hold the lock across the whole transition so a pass never
+    /// observes a half-rebuilt port set. Recursive, because nodes legitimately
+    /// mutate their own ports from inside execute, which runs with the lock
+    /// already held. Each graph has its own lock; nested subgraph execution
+    /// takes the child's lock while holding the parent's, and mutations only
+    /// ever take the lock of the graph they mutate, so lock ordering is always
+    /// parent-to-child.
+    @ObservationIgnored private let structuralMutationLock = NSRecursiveLock()
+
+    func withStructuralMutationLock<Result>(_ body: () throws -> Result) rethrows -> Result
+    {
+        structuralMutationLock.lock()
+        defer { structuralMutationLock.unlock() }
+        return try body()
+    }
 
     @ObservationIgnored private var cachedPublishedOutputPortsRevision: Int?
     @ObservationIgnored private var cachedPublishedOutputPorts: [Port] = []
@@ -400,6 +426,11 @@ public struct Connection: Codable, Identifiable, Hashable
     /// interactive placement with scroll-offset and rapid-add staggering).
     public func addNode(_ node:Node)
     {
+        withStructuralMutationLock { self.addNodeLocked(node) }
+    }
+
+    private func addNodeLocked(_ node:Node)
+    {
         print("Graph: \(self.id) Add Node", node.name)
         self.maybeAddNodeToScene(node)
 
@@ -436,6 +467,11 @@ public struct Connection: Codable, Identifiable, Hashable
     }
     
     public func delete(node:Node, disconnect:Bool = true)
+    {
+        withStructuralMutationLock { self.deleteLocked(node: node, disconnect: disconnect) }
+    }
+
+    private func deleteLocked(node:Node, disconnect:Bool)
     {
         let savedOffset = node.offset
         let savedConnections = node.ports.flatMap { port in
@@ -507,59 +543,67 @@ public struct Connection: Codable, Identifiable, Hashable
 
     func registerConnection(between portA: Port, and portB: Port)
     {
-        guard let normalized = normalizedConnectionPorts(portA, portB) else { return }
-        guard !connections.contains(where: {
-            $0.outletPortID == normalized.outlet.id && $0.inletPortID == normalized.inlet.id
-        }) else { return }
+        withStructuralMutationLock {
+            guard let normalized = normalizedConnectionPorts(portA, portB) else { return }
+            guard !connections.contains(where: {
+                $0.outletPortID == normalized.outlet.id && $0.inletPortID == normalized.inlet.id
+            }) else { return }
 
-        connections.append(Connection(outletPortID: normalized.outlet.id,
-                                      inletPortID: normalized.inlet.id))
-        markConnectionTopologyChanged()
+            connections.append(Connection(outletPortID: normalized.outlet.id,
+                                          inletPortID: normalized.inlet.id))
+            markConnectionTopologyChanged()
+        }
     }
 
     @discardableResult
     func unregisterConnection(between portA: Port, and portB: Port) -> Bool
     {
-        guard let normalized = normalizedConnectionPorts(portA, portB) else { return false }
-        let oldCount = connections.count
-        connections.removeAll {
-            $0.outletPortID == normalized.outlet.id && $0.inletPortID == normalized.inlet.id
-        }
+        withStructuralMutationLock {
+            guard let normalized = normalizedConnectionPorts(portA, portB) else { return false }
+            let oldCount = connections.count
+            connections.removeAll {
+                $0.outletPortID == normalized.outlet.id && $0.inletPortID == normalized.inlet.id
+            }
 
-        if connections.count != oldCount {
-            markConnectionTopologyChanged()
-            return true
-        }
+            if connections.count != oldCount {
+                markConnectionTopologyChanged()
+                return true
+            }
 
-        return false
+            return false
+        }
     }
 
     public func setConnectionActive(_ active: Bool, connectionID: UUID)
     {
-        guard let index = connections.firstIndex(where: { $0.id == connectionID }),
-              connections[index].active != active
-        else { return }
+        withStructuralMutationLock {
+            guard let index = connections.firstIndex(where: { $0.id == connectionID }),
+                  connections[index].active != active
+            else { return }
 
-        connections[index].active = active
-        markExecutionTopologyChanged()
+            connections[index].active = active
+            markExecutionTopologyChanged()
+        }
     }
 
     public func setActiveInletPorts(forNodeID nodeID: UUID, inletPortIDs: Set<UUID>)
     {
-        guard let node = node(forID: nodeID) else { return }
-        let nodeInletIDs = Set(node.inputPorts().map(\.id))
-        var changed = false
+        withStructuralMutationLock {
+            guard let node = node(forID: nodeID) else { return }
+            let nodeInletIDs = Set(node.inputPorts().map(\.id))
+            var changed = false
 
-        for index in connections.indices where nodeInletIDs.contains(connections[index].inletPortID) {
-            let active = inletPortIDs.contains(connections[index].inletPortID)
-            if connections[index].active != active {
-                connections[index].active = active
-                changed = true
+            for index in connections.indices where nodeInletIDs.contains(connections[index].inletPortID) {
+                let active = inletPortIDs.contains(connections[index].inletPortID)
+                if connections[index].active != active {
+                    connections[index].active = active
+                    changed = true
+                }
             }
-        }
 
-        if changed {
-            markExecutionTopologyChanged()
+            if changed {
+                markExecutionTopologyChanged()
+            }
         }
     }
 
@@ -587,7 +631,9 @@ public struct Connection: Codable, Identifiable, Hashable
 
         guard wasStale else { return }
 
-        rebuildNodesInExecutionOrder()
+        withStructuralMutationLock {
+            rebuildNodesInExecutionOrder()
+        }
     }
 
     private func rebuildNodesInExecutionOrder()

--- a/Fabric/Graph/GraphRenderer.swift
+++ b/Fabric/Graph/GraphRenderer.swift
@@ -246,6 +246,27 @@ public class GraphRenderer : ViewRenderer
             }
         }
 
+        // Hold the graph's structural mutation lock for the whole pass; see
+        // Graph.structuralMutationLock for the contract.
+        try graph.withStructuralMutationLock {
+            try executeLocked(graph: graph,
+                              executionInfo: executionInfo,
+                              renderPassDescriptor: renderPassDescriptor,
+                              commandBuffer: commandBuffer,
+                              clearFlags: clearFlags,
+                              forceEvaluationForTheseNodes: forceEvaluationForTheseNodes)
+        }
+    }
+
+    private func executeLocked(graph: Graph,
+                               executionInfo: GraphExecutionInfo,
+                               renderPassDescriptor: MTLRenderPassDescriptor,
+                               commandBuffer: MTLCommandBuffer,
+                               clearFlags: Bool,
+                               forceEvaluationForTheseNodes: [Node]) throws
+    {
+        let feedbackCache = self.feedbackCache(for: graph.id)
+
         self.currentCamera = graph.firstCamera ?? self.currentCamera ?? self.defaultCamera
 
         graph.rebuildNodesInExecutionOrderIfNeeded()

--- a/Fabric/Graph/GraphRenderer.swift
+++ b/Fabric/Graph/GraphRenderer.swift
@@ -248,6 +248,8 @@ public class GraphRenderer : ViewRenderer
 
         self.currentCamera = graph.firstCamera ?? self.currentCamera ?? self.defaultCamera
 
+        graph.rebuildNodesInExecutionOrderIfNeeded()
+
         var capturedError: (any Error)?
         var scheduledNodes = graph.nodesInExecutionOrder
         var scheduledNodeIDs = Set(scheduledNodes.map(\.id))

--- a/Fabric/Graph/Node/Node.swift
+++ b/Fabric/Graph/Node/Node.swift
@@ -293,14 +293,32 @@ open class Node : Codable, Equatable, Identifiable, Hashable, Copyable
         self.registry.port(named: name) as? T
     }
 
+    /// Runs `body` under the owning graph's structural mutation lock (see
+    /// Graph.structuralMutationLock). Before the node joins a graph nothing can
+    /// be executing it, so the body runs unlocked. Compound port transitions
+    /// (rebuildPorts, shader-driven port sync) must wrap their whole transition
+    /// in this — per-step locking would let an execute pass observe a
+    /// half-rebuilt port set between steps.
+    internal func withStructuralMutationLockIfAttached<Result>(_ body: () throws -> Result) rethrows -> Result
+    {
+        if let graph
+        {
+            return try graph.withStructuralMutationLock(body)
+        }
+
+        return try body()
+    }
+
     // Dynamic add/remove (kept by serialization automatically)
     public func addDynamicPort(_ p: Port, name:String? = nil)
     {
-        self.registry.addDynamic(p, owner: self, name:name)
-        self.invalidatePortCaches()
-        if let param = p.parameter
-        {
-            self.parameterGroup.append(param)
+        withStructuralMutationLockIfAttached {
+            self.registry.addDynamic(p, owner: self, name:name)
+            self.invalidatePortCaches()
+            if let param = p.parameter
+            {
+                self.parameterGroup.append(param)
+            }
         }
 
         self.graph?.markConnectionsChanged()
@@ -309,11 +327,13 @@ open class Node : Codable, Equatable, Identifiable, Hashable, Copyable
 
     public func removePort(_ p: Port)
     {
-        self.registry.remove(p)
-        self.invalidatePortCaches()
-        if let param = p.parameter
-        {
-            self.parameterGroup.remove(param)
+        withStructuralMutationLockIfAttached {
+            self.registry.remove(p)
+            self.invalidatePortCaches()
+            if let param = p.parameter
+            {
+                self.parameterGroup.remove(param)
+            }
         }
 
         self.graph?.markConnectionsChanged()
@@ -322,22 +342,26 @@ open class Node : Codable, Equatable, Identifiable, Hashable, Copyable
 
     internal func replaceParameterOfPort(_ port:Port, withParam param:(any Parameter))
     {
-        // Remove existing param from group
-        if let existingParam = port.parameter
-        {
-            self.parameterGroup.remove(existingParam)
+        withStructuralMutationLockIfAttached {
+            // Remove existing param from group
+            if let existingParam = port.parameter
+            {
+                self.parameterGroup.remove(existingParam)
+            }
+
+            // Add new param to group
+            self.parameterGroup.append(param)
+
+            port.parameter = param
         }
-
-        // Add new param to group
-        self.parameterGroup.append(param)
-
-        port.parameter = param
     }
 
     internal func reorderPorts(_ reordered: [Port])
     {
-        self.registry.reorder(reordered)
-        self.invalidatePortCaches()
+        withStructuralMutationLockIfAttached {
+            self.registry.reorder(reordered)
+            self.invalidatePortCaches()
+        }
     }
 
     internal func inputPorts() -> [Port]

--- a/Fabric/Graph/Port/NodePort.swift
+++ b/Fabric/Graph/Port/NodePort.swift
@@ -133,9 +133,21 @@ public class NodePort<Value : PortValueRepresentable>: Port
     
     private func validatedDisconnect(from other: Port)
     {
-//        print("Port \(self) Disconnect from \(other)")
-
         let graph = self.node?.graph ?? other.node?.graph
+
+        if let graph
+        {
+            graph.withStructuralMutationLock { validatedDisconnectLocked(from: other, graph: graph) }
+        }
+        else
+        {
+            validatedDisconnectLocked(from: other, graph: nil)
+        }
+    }
+
+    private func validatedDisconnectLocked(from other: Port, graph: Graph?)
+    {
+//        print("Port \(self) Disconnect from \(other)")
         let removedGraphConnection = graph?.unregisterConnection(between: self, and: other) ?? false
 
         if let node = self.node,
@@ -213,8 +225,6 @@ public class NodePort<Value : PortValueRepresentable>: Port
         
     private func validatedConnect(to other:  Port)
     {
-//        print("Port \(self) Connect to \(other)")
-
         // A dynamic port can remain alive briefly in a transient SwiftUI view
         // after the registry has replaced it. Removed ports are detached from
         // their node, so reject gestures involving those stale instances.
@@ -222,6 +232,20 @@ public class NodePort<Value : PortValueRepresentable>: Port
         {
             return
         }
+
+        if let graph = self.node?.graph ?? other.node?.graph
+        {
+            graph.withStructuralMutationLock { validatedConnectLocked(to: other) }
+        }
+        else
+        {
+            validatedConnectLocked(to: other)
+        }
+    }
+
+    private func validatedConnectLocked(to other:  Port)
+    {
+//        print("Port \(self) Connect to \(other)")
 
         if self.kind == other.kind
         {

--- a/Fabric/Nodes/Image/LiveCode/LiveImageNode.swift
+++ b/Fabric/Nodes/Image/LiveCode/LiveImageNode.swift
@@ -174,7 +174,11 @@ public class LiveImageNode: BaseImageNode
         if let sourceShader = self.postMaterial.shader as? SourceShader {
             sourceShader.reloadFromSource()
             if sourceShader.pipelineError == nil && shouldSynchronizePorts {
-                self.postSetupSynchronizePorts(allowReplace: false)
+                // One lock acquisition for the whole port sync — see
+                // Node.withStructuralMutationLockIfAttached.
+                withStructuralMutationLockIfAttached {
+                    self.postSetupSynchronizePorts(allowReplace: false)
+                }
             }
         }
     }

--- a/Fabric/Nodes/Parameters/Number/MathExpressionNode.swift
+++ b/Fabric/Nodes/Parameters/Number/MathExpressionNode.swift
@@ -412,7 +412,11 @@ public class MathExpressionNode: Node
         if result.isValid
         {
             self.portInterface = result.interface
-            self.syncPorts(to: result.interface)
+            // One lock acquisition for the whole port sync — see
+            // Node.withStructuralMutationLockIfAttached.
+            withStructuralMutationLockIfAttached {
+                self.syncPorts(to: result.interface)
+            }
             self.needsEvaluation = true
         }
 

--- a/Fabric/Nodes/Parameters/StrategyNode.swift
+++ b/Fabric/Nodes/Parameters/StrategyNode.swift
@@ -137,7 +137,11 @@ public class StrategyNode: Node
     {
         didSet
         {
-            self.rebuildPorts(forStrategy: strategy)
+            // One lock acquisition for the whole rebuild — see
+            // Node.withStructuralMutationLockIfAttached.
+            withStructuralMutationLockIfAttached {
+                self.rebuildPorts(forStrategy: strategy)
+            }
             // `displayName` is derived from `strategy`; notify so the title refreshes.
             self.nameSubject.send()
         }

--- a/Fabric/Nodes/Utility/RoutingNode.swift
+++ b/Fabric/Nodes/Utility/RoutingNode.swift
@@ -67,7 +67,11 @@ public class RoutingNodeBase: TypeAgnosticNode
         let clamped = Self.clampedRouteCount(count)
         guard clamped != routeCount else { return }
         routeCount = clamped
-        rebuildPorts(forStrategy: strategy)
+        // One lock acquisition for the whole rebuild — see
+        // Node.withStructuralMutationLockIfAttached.
+        withStructuralMutationLockIfAttached {
+            rebuildPorts(forStrategy: strategy)
+        }
     }
 
     public func setPortType(_ portType: PortType)

--- a/Tests/StructuralMutationLockTests.swift
+++ b/Tests/StructuralMutationLockTests.swift
@@ -1,0 +1,132 @@
+import Testing
+import Foundation
+import Metal
+import os
+@testable import Fabric
+import Satin
+
+/// Exercises the synchronization contract on Graph.structuralMutationLock:
+/// main-thread structural mutations (Settings-driven port rebuilds,
+/// connect/disconnect) serialize against an off-main execute loop. Run under
+/// Thread Sanitizer these tests fail without the lock; without TSan they still
+/// exercise the racing interleavings (registry churn during an execute pass)
+/// far more often than real usage does.
+/// Consumer that anchors the execution plan so the churned nodes upstream of it
+/// are actually scheduled and read by every pass.
+private final class RecordingFloatConsumerNode: Node
+{
+    override class var name: String { "Recording Float Consumer" }
+    override class var nodeType: Node.NodeType { .Utility }
+    override class var nodeExecutionMode: Node.ExecutionMode { .Consumer }
+    override class var nodeTimeMode: Node.TimeMode { .None }
+    override class var nodeDescription: String { "Test consumer recording the last value received." }
+
+    var lastValue: Float?
+    var input: NodePort<Float> { port(named: "input") }
+
+    override class func registerPorts(context: Context) -> [(name: String, port: Fabric.Port)]
+    {
+        super.registerPorts(context: context) + [
+            ("input", NodePort<Float>(name: "Input", kind: .Inlet)),
+        ]
+    }
+
+    override func execute(renderer: GraphRenderer,
+                          executionInfo: GraphExecutionInfo,
+                          renderPassDescriptor: MTLRenderPassDescriptor,
+                          commandBuffer: MTLCommandBuffer)
+    {
+        lastValue = input.value
+    }
+}
+
+@Suite("Structural Mutation Lock")
+struct StructuralMutationLockTests
+{
+    /// Runs `mutate` on the main queue `iterations` times while a background
+    /// thread executes `graph` continuously, mirroring the app's threading:
+    /// user edits on main, rendering off-main.
+    private func churnAgainstExecution(harness: GraphExecutionTestHarness,
+                                       graph: Graph,
+                                       iterations: Int,
+                                       mutate: @escaping (Int) -> Void) throws
+    {
+        let stopExecuting = OSAllocatedUnfairLock(initialState: false)
+
+        let executor = Thread {
+            var frameNumber = 0
+            while !stopExecuting.withLock({ $0 })
+            {
+                _ = try? harness.execute(graph, frameNumber: frameNumber, checkCommandBufferError: false)
+                frameNumber += 1
+            }
+        }
+        executor.start()
+
+        for iteration in 0..<iterations
+        {
+            DispatchQueue.main.sync { mutate(iteration) }
+        }
+
+        stopExecuting.withLock { $0 = true }
+        while executor.isExecuting { usleep(1000) }
+    }
+
+    @Test("Settings-driven port rebuilds serialize against a concurrent execute loop")
+    func portRebuildsDuringExecution() throws
+    {
+        guard let harness = GraphExecutionTestHarness(renderWidth: 32, renderHeight: 32) else { return }
+
+        let graph = Graph(context: harness.context)
+        let sampleAndHold = SampleAndHoldNode(context: harness.context, portType: .Float)
+        let consumer = RecordingFloatConsumerNode(context: harness.context)
+        graph.addNode(sampleAndHold)
+        graph.addNode(consumer)
+
+        // Anchor the plan: with the consumer downstream, every pass pulls and
+        // executes the sample-and-hold whose ports the churn is rebuilding.
+        if let output: Fabric.Port = sampleAndHold.findPort(named: "outputValue")
+        {
+            output.connect(to: consumer.input)
+        }
+
+        // Every strategy switch rebuilds the node's dynamic port set through
+        // removePort/addDynamicPort while the executor is mid-pass, and rewires
+        // the replacement ports' connections.
+        let strategies: [PortType] = [.Float, .Virtual, .Vector3, .Float]
+        try churnAgainstExecution(harness: harness, graph: graph, iterations: 500) { iteration in
+            sampleAndHold.strategy = strategies[iteration % strategies.count].rawValue
+        }
+
+        #expect(!sampleAndHold.ports.isEmpty)
+    }
+
+    @Test("Connect/disconnect churn serializes against a concurrent execute loop")
+    func connectionChurnDuringExecution() throws
+    {
+        guard let harness = GraphExecutionTestHarness(renderWidth: 32, renderHeight: 32) else { return }
+
+        let graph = Graph(context: harness.context)
+        let sourceA = NumberBinaryOperator(context: harness.context)
+        let sourceB = NumberBinaryOperator(context: harness.context)
+        let sink = NumberBinaryOperator(context: harness.context)
+        let consumer = RecordingFloatConsumerNode(context: harness.context)
+        graph.addNode(sourceA)
+        graph.addNode(sourceB)
+        graph.addNode(sink)
+        graph.addNode(consumer)
+
+        // Anchor the plan so every pass pulls through the churned connections.
+        sink.outputNumber.connect(to: consumer.input)
+
+        // Alternate which source feeds the sink — every flip is a disconnect,
+        // a connect, a Connection register/unregister, and a plan rebuild on
+        // the next pass, while the executor reads topology.
+        try churnAgainstExecution(harness: harness, graph: graph, iterations: 500) { iteration in
+            let source = iteration % 2 == 0 ? sourceA : sourceB
+            source.outputNumber.connect(to: sink.inputNumber1)
+        }
+
+        #expect(sink.inputNumber1.connections.count == 1)
+    }
+}


### PR DESCRIPTION
These two commits address mutate-in-main while read-in-render issues brought up over various code reviews in the past few days. See the commit message for each.

This branch is based on @vade’s hand-over-for-review commit 4742aab7603a8ff87913d5b0045a68c9bec25a3a. The PR won’t allow that, so... I’m not sure how to proceed, beyond making it clear that I’m not promoting this be merged, it’s here as a candidate or illustration. I’d be interested in a call to go over performance profiling, this here seems a good example.