### PR TITLE
Nodes have a regular, canonical name for logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,15 +77,17 @@ For all development:
 
 ### 2.1  Nodes & Execution
 - Nodes define immutable static metadata:  `nodeType`, `nodeExecutionMode`, `nodeTimeMode`,  `name`, `nodeDescription`.
-- A node is named from three sources, two of them overridden by the subclass:
-  - `class var name` — override: the name the type is registered and listed under; `canonicalName` on an instance.
-  - `func deriveSubtitle() -> String?` — override where the node describes itself, nil otherwise: Math Expression's expression, StrategyNode's strategy. Read it off an instance as `subtitle`, final and normalized.
-  - `var userName: String?` — final: the user's rename, serialized.
-  - An empty name is no name: `subtitle` reads a `deriveSubtitle()` of "" as nil, and `userName` normalizes "" to nil at set and decode. Overrides and consumers never guard emptiness themselves.
+- A node is named from four sources, three of them overridden by the subclass:
+  - `class var name` — override: the stable name the type is registered and listed under, and the default instance title.
+  - `func deriveTitle() -> String` — override only when an instance has a more specific authoritative title, such as a shader-backed `BaseImageNode`; defaults to `Self.name`.
+  - `func deriveSubtitle() -> String?` — override where the node describes itself, nil otherwise: Math Expression's expression, StrategyNode's strategy.
+  - `var userName: String?` — final: the user's rename, serialized and public for rename-specific callers.
+  - An empty name is no name: `userName` normalizes "" to nil at set and decode.
 - From those it composes, both final:
-  - `var title` — what to call the node: `userName ?? canonicalName`. Note `subtitle` is deliberately absent: it accompanies the title, it does not replace it.
-  - `var debugDescription` — every name the node answers to, e.g. `Math Expression (sin(x) · My Rename)`. `print(node)` and `"\(node)"` give it: log a node directly rather than reaching for a name. Use `canonicalName` where brevity or per-frame cost matters.
-- Fire `subtitleSubject.send()` whenever state feeding `subtitle` changes; `NodeViewModel` mirrors the node's `title` / `canonicalName` / `subtitle` observably, and adds `titleLabel` (`userName ?? subtitle`) — the label all title UI draws ahead of the canonical name.
+  - `var title` — the normalized result of `deriveTitle()`, falling back to `Self.name` when empty.
+  - `var subtitle` — `userName ?? deriveSubtitle()`, normalized so empty values and values equal to `title` read as nil. General consumers read this rather than `userName`.
+  - `var debugDescription` — the title plus resolved subtitle, e.g. `Math Expression (My Rename)`. `print(node)` and `"\(node)"` give it; diagnostic labels and traces use it when they need both values.
+- Fire `subtitleSubject.send()` whenever state feeding `deriveTitle()` or `deriveSubtitle()` changes; `NodeViewModel` mirrors the node's `title` / `subtitle` observably and keeps `userName` only for rename editing, clearing, and undo.
 - Execution is **pull-based**; one execute per node per pass.
 - `GraphRenderer` (executor and scheduler) today does not use `nodeExecutionMode` or `nodeTimeMode` but will in the future.
 - **Iterator (QC-style)** remains the multi-evaluation macro; refinements allowed, paradigm fixed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,8 +79,9 @@ For all development:
 - Nodes define immutable static metadata:  `nodeType`, `nodeExecutionMode`, `nodeTimeMode`,  `name`, `nodeDescription`.
 - A node is named from three sources, two of them overridden by the subclass:
   - `class var name` — override: the name the type is registered and listed under; `registryName` on an instance.
-  - `var customName: String?` — override where the node names itself, nil otherwise: Math Expression's expression, StrategyNode's strategy.
+  - `func deriveCustomName() -> String?` — override where the node names itself, nil otherwise: Math Expression's expression, StrategyNode's strategy. Read it off an instance as `customName`, final and normalized.
   - `var userName: String?` — final: the user's rename, serialized.
+  - An empty name is no name: `customName` reads a `deriveCustomName()` of "" as nil, and `userName` normalizes "" to nil at set and decode. Overrides and consumers never guard emptiness themselves.
 - From those it composes two names, both final:
   - `var name` — what to call the node: `userName ?? registryName`. Note `customName` is deliberately absent: it is a subtitle, not a replacement name.
   - `var canonicalName` — every name the node answers to, e.g. `Math Expression (sin(x) · My Rename)`. It is also the node's `debugDescription`, so `print(node)` and `"\(node)"` give it: log a node directly rather than reaching for a name. Use `registryName` where brevity or per-frame cost matters.
@@ -203,7 +204,7 @@ Some nodes operate identically regardless of what data flows through them (e.g. 
 - [ ] If Node dynamically changes port count or type, we should only trigger via Setting in Settings View, not within the graph
 - [ ] If we have a Settings View, we should have a custom initializer so procedural graph creation has an entry to settings.
 - [ ] If we have a Settings View and a custom initializer, use a custom struct or enum for the settings
-- [ ] If the Node overrides `customName`, every mutation of the state it derives from fires `nameSubject.send()` (StrategyNode's `strategy` already does)
+- [ ] If the Node overrides `deriveCustomName()`, every mutation of the state it derives from fires `nameSubject.send()` (StrategyNode's `strategy` already does)
 - [ ] New Nodes should live in an appropriate spot in the NodeRegistry
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,11 +77,14 @@ For all development:
 
 ### 2.1  Nodes & Execution
 - Nodes define immutable static metadata:  `nodeType`, `nodeExecutionMode`, `nodeTimeMode`,  `name`, `nodeDescription`.
-- Node naming is three-tiered; instance `name` resolves `userName ?? displayName ?? Self.name` — never override it directly:
-  - `class var name` — static TYPE name; immutable metadata.
-  - `var displayName: String?` — optional node-generated title (e.g. Math Expression's expression; StrategyNode subclasses just set `strategyTitleSuffix`). Override this; nil for none.
-  - `var userName: String?` — the user's rename; serialized, always wins.
-- Fire `nameSubject.send()` whenever state feeding `displayName` changes; `NodeViewModel` caches the title and exposes `name` / `typeName` / `hasCustomLabel` for all title UI.
+- A node is named from three sources, two of them overridden by the subclass:
+  - `class var name` — override: the node's TYPE name; `typeName` on an instance.
+  - `var customName: String?` — override where the node names itself, nil otherwise: Math Expression's expression, StrategyNode's strategy.
+  - `var userName: String?` — final: the user's rename, serialized.
+- From those it composes two names, both final:
+  - `var name` — what to call the node: `userName ?? typeName`. Note `customName` is deliberately absent: it is a subtitle, not a replacement name.
+  - `var canonicalName` — every name the node answers to, e.g. `Math Expression (sin(x) · My Rename)`. Use it for logging and diagnostics; use `typeName` where brevity or per-frame cost matters.
+- Fire `nameSubject.send()` whenever state feeding `customName` changes; `NodeViewModel` mirrors the node's `name` / `typeName` / `customName` observably, and adds `customLabel` (`userName ?? customName`) — the label all title UI draws ahead of the type name.
 - Execution is **pull-based**; one execute per node per pass.
 - `GraphRenderer` (executor and scheduler) today does not use `nodeExecutionMode` or `nodeTimeMode` but will in the future.
 - **Iterator (QC-style)** remains the multi-evaluation macro; refinements allowed, paradigm fixed.
@@ -175,7 +178,7 @@ Some nodes operate identically regardless of what data flows through them (e.g. 
 | Topology recomputed each frame | No caching | Recompute only on connect/disconnect |
 | Type-erasure confusion | Mixing `any` with Equatable generics | Stay typed; use Utility/Log node for debug |
 | Serialization drift | Ad-hoc encoders | Always through registry + `PortType` |
-| Stale node title on canvas/inspector | `displayName` input changed without notifying | Fire `nameSubject.send()` in the `didSet` of any state `displayName` derives from |
+| Stale node title on canvas/inspector | `customName` input changed without notifying | Fire `nameSubject.send()` in the `didSet` of any state `customName` derives from |
 
 ---
 
@@ -200,7 +203,7 @@ Some nodes operate identically regardless of what data flows through them (e.g. 
 - [ ] If Node dynamically changes port count or type, we should only trigger via Setting in Settings View, not within the graph
 - [ ] If we have a Settings View, we should have a custom initializer so procedural graph creation has an entry to settings.
 - [ ] If we have a Settings View and a custom initializer, use a custom struct or enum for the settings
-- [ ] If the Node overrides `displayName`, every mutation of the state it derives from fires `nameSubject.send()` (StrategyNode's `strategy` already does)
+- [ ] If the Node overrides `customName`, every mutation of the state it derives from fires `nameSubject.send()` (StrategyNode's `strategy` already does)
 - [ ] New Nodes should live in an appropriate spot in the NodeRegistry
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,14 +78,14 @@ For all development:
 ### 2.1  Nodes & Execution
 - Nodes define immutable static metadata:  `nodeType`, `nodeExecutionMode`, `nodeTimeMode`,  `name`, `nodeDescription`.
 - A node is named from three sources, two of them overridden by the subclass:
-  - `class var name` — override: the name the type is registered and listed under; `registryName` on an instance.
-  - `func deriveCustomName() -> String?` — override where the node names itself, nil otherwise: Math Expression's expression, StrategyNode's strategy. Read it off an instance as `customName`, final and normalized.
+  - `class var name` — override: the name the type is registered and listed under; `canonicalName` on an instance.
+  - `func deriveSubtitle() -> String?` — override where the node describes itself, nil otherwise: Math Expression's expression, StrategyNode's strategy. Read it off an instance as `subtitle`, final and normalized.
   - `var userName: String?` — final: the user's rename, serialized.
-  - An empty name is no name: `customName` reads a `deriveCustomName()` of "" as nil, and `userName` normalizes "" to nil at set and decode. Overrides and consumers never guard emptiness themselves.
-- From those it composes two names, both final:
-  - `var name` — what to call the node: `userName ?? registryName`. Note `customName` is deliberately absent: it is a subtitle, not a replacement name.
-  - `var canonicalName` — every name the node answers to, e.g. `Math Expression (sin(x) · My Rename)`. It is also the node's `debugDescription`, so `print(node)` and `"\(node)"` give it: log a node directly rather than reaching for a name. Use `registryName` where brevity or per-frame cost matters.
-- Fire `nameSubject.send()` whenever state feeding `customName` changes; `NodeViewModel` mirrors the node's `name` / `registryName` / `customName` observably, and adds `customLabel` (`userName ?? customName`) — the label all title UI draws ahead of the registry name.
+  - An empty name is no name: `subtitle` reads a `deriveSubtitle()` of "" as nil, and `userName` normalizes "" to nil at set and decode. Overrides and consumers never guard emptiness themselves.
+- From those it composes, both final:
+  - `var title` — what to call the node: `userName ?? canonicalName`. Note `subtitle` is deliberately absent: it accompanies the title, it does not replace it.
+  - `var debugDescription` — every name the node answers to, e.g. `Math Expression (sin(x) · My Rename)`. `print(node)` and `"\(node)"` give it: log a node directly rather than reaching for a name. Use `canonicalName` where brevity or per-frame cost matters.
+- Fire `subtitleSubject.send()` whenever state feeding `subtitle` changes; `NodeViewModel` mirrors the node's `title` / `canonicalName` / `subtitle` observably, and adds `titleLabel` (`userName ?? subtitle`) — the label all title UI draws ahead of the canonical name.
 - Execution is **pull-based**; one execute per node per pass.
 - `GraphRenderer` (executor and scheduler) today does not use `nodeExecutionMode` or `nodeTimeMode` but will in the future.
 - **Iterator (QC-style)** remains the multi-evaluation macro; refinements allowed, paradigm fixed.
@@ -179,7 +179,7 @@ Some nodes operate identically regardless of what data flows through them (e.g. 
 | Topology recomputed each frame | No caching | Recompute only on connect/disconnect |
 | Type-erasure confusion | Mixing `any` with Equatable generics | Stay typed; use Utility/Log node for debug |
 | Serialization drift | Ad-hoc encoders | Always through registry + `PortType` |
-| Stale node title on canvas/inspector | `customName` input changed without notifying | Fire `nameSubject.send()` in the `didSet` of any state `customName` derives from |
+| Stale node title on canvas/inspector | `subtitle` input changed without notifying | Fire `subtitleSubject.send()` in the `didSet` of any state `subtitle` derives from |
 
 ---
 
@@ -204,7 +204,7 @@ Some nodes operate identically regardless of what data flows through them (e.g. 
 - [ ] If Node dynamically changes port count or type, we should only trigger via Setting in Settings View, not within the graph
 - [ ] If we have a Settings View, we should have a custom initializer so procedural graph creation has an entry to settings.
 - [ ] If we have a Settings View and a custom initializer, use a custom struct or enum for the settings
-- [ ] If the Node overrides `deriveCustomName()`, every mutation of the state it derives from fires `nameSubject.send()` (StrategyNode's `strategy` already does)
+- [ ] If the Node overrides `deriveSubtitle()`, every mutation of the state it derives from fires `subtitleSubject.send()` (StrategyNode’s `strategy` already does)
 - [ ] New Nodes should live in an appropriate spot in the NodeRegistry
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,13 +78,13 @@ For all development:
 ### 2.1  Nodes & Execution
 - Nodes define immutable static metadata:  `nodeType`, `nodeExecutionMode`, `nodeTimeMode`,  `name`, `nodeDescription`.
 - A node is named from three sources, two of them overridden by the subclass:
-  - `class var name` — override: the node's TYPE name; `typeName` on an instance.
+  - `class var name` — override: the name the type is registered and listed under; `registryName` on an instance.
   - `var customName: String?` — override where the node names itself, nil otherwise: Math Expression's expression, StrategyNode's strategy.
   - `var userName: String?` — final: the user's rename, serialized.
 - From those it composes two names, both final:
-  - `var name` — what to call the node: `userName ?? typeName`. Note `customName` is deliberately absent: it is a subtitle, not a replacement name.
-  - `var canonicalName` — every name the node answers to, e.g. `Math Expression (sin(x) · My Rename)`. It is also the node's `debugDescription`, so `print(node)` and `"\(node)"` give it: log a node directly rather than reaching for a name. Use `typeName` where brevity or per-frame cost matters.
-- Fire `nameSubject.send()` whenever state feeding `customName` changes; `NodeViewModel` mirrors the node's `name` / `typeName` / `customName` observably, and adds `customLabel` (`userName ?? customName`) — the label all title UI draws ahead of the type name.
+  - `var name` — what to call the node: `userName ?? registryName`. Note `customName` is deliberately absent: it is a subtitle, not a replacement name.
+  - `var canonicalName` — every name the node answers to, e.g. `Math Expression (sin(x) · My Rename)`. It is also the node's `debugDescription`, so `print(node)` and `"\(node)"` give it: log a node directly rather than reaching for a name. Use `registryName` where brevity or per-frame cost matters.
+- Fire `nameSubject.send()` whenever state feeding `customName` changes; `NodeViewModel` mirrors the node's `name` / `registryName` / `customName` observably, and adds `customLabel` (`userName ?? customName`) — the label all title UI draws ahead of the registry name.
 - Execution is **pull-based**; one execute per node per pass.
 - `GraphRenderer` (executor and scheduler) today does not use `nodeExecutionMode` or `nodeTimeMode` but will in the future.
 - **Iterator (QC-style)** remains the multi-evaluation macro; refinements allowed, paradigm fixed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ For all development:
   - `var userName: String?` — final: the user's rename, serialized.
 - From those it composes two names, both final:
   - `var name` — what to call the node: `userName ?? typeName`. Note `customName` is deliberately absent: it is a subtitle, not a replacement name.
-  - `var canonicalName` — every name the node answers to, e.g. `Math Expression (sin(x) · My Rename)`. Use it for logging and diagnostics; use `typeName` where brevity or per-frame cost matters.
+  - `var canonicalName` — every name the node answers to, e.g. `Math Expression (sin(x) · My Rename)`. It is also the node's `debugDescription`, so `print(node)` and `"\(node)"` give it: log a node directly rather than reaching for a name. Use `typeName` where brevity or per-frame cost matters.
 - Fire `nameSubject.send()` whenever state feeding `customName` changes; `NodeViewModel` mirrors the node's `name` / `typeName` / `customName` observably, and adds `customLabel` (`userName ?? customName`) — the label all title UI draws ahead of the type name.
 - Execution is **pull-based**; one execute per node per pass.
 - `GraphRenderer` (executor and scheduler) today does not use `nodeExecutionMode` or `nodeTimeMode` but will in the future.

--- a/Fabric Editor/Views/ContentView.swift
+++ b/Fabric Editor/Views/ContentView.swift
@@ -72,7 +72,7 @@ struct ContentView: View {
                     ForEach(self.document.editingContext.entries) { node in
                         Text("›")
                             .font(.headline)
-                        Button(node.name) { self.document.editingContext.popTo(node) }
+                        Button(node.title) { self.document.editingContext.popTo(node) }
                             .font(.headline)
                             .buttonStyle(.plain)
                     }

--- a/Fabric.xcodeproj/xcshareddata/xcschemes/Fabric Editor.xcscheme
+++ b/Fabric.xcodeproj/xcshareddata/xcschemes/Fabric Editor.xcscheme
@@ -31,7 +31,7 @@
       shouldAutocreateTestPlan = "YES">
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       disableMainThreadChecker = "YES"
@@ -40,7 +40,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      enableGPUFrameCaptureMode = "3"
+      enableGPUFrameCaptureMode = "1"
       enableGPUValidationMode = "1"
       showGraphicsOverview = "Yes"
       allowLocationSimulation = "YES"

--- a/Fabric/Graph/Graph.swift
+++ b/Fabric/Graph/Graph.swift
@@ -381,7 +381,7 @@ internal import AnyCodable
     /// interactive placement with scroll-offset and rapid-add staggering).
     public func addNode(_ node:Node)
     {
-        print("Graph: \(self.id) Add Node", node.name)
+        print("Graph: \(self.id) Add Node", node.debugName)
         self.maybeAddNodeToScene(node)
 
         // Create the ViewModel before appending so it is always present
@@ -753,7 +753,7 @@ internal import AnyCodable
                     break
                 }
                 
-                print(referenceNode.name, referenceNode.offset, angle, direction, "to:", $0.name, $0.offset)
+                print(referenceNode.debugName, referenceNode.offset, angle, direction, "to:", $0.debugName, $0.offset)
                 return (distance, direction, $0 )
             }
             
@@ -761,7 +761,7 @@ internal import AnyCodable
             
             if let closestDistanceDirectionNodeTuples = relevantDistanceDirectionNodeTuples.sorted(by: { $0.Distance < $1.Distance }).first
             {
-                print("reference node", referenceNode.name)
+                print("reference node", referenceNode.debugName)
 
                 self.selectNode(node: closestDistanceDirectionNodeTuples.Node, expandSelection: expandSelection)
             }
@@ -878,12 +878,12 @@ internal import AnyCodable
         if let objectNode = node as? BaseObjectNode,
            let object = objectNode.getObject()
         {
-//            print("Graph: \(self.id) Scene: Added Child", objectNode.name)
+//            print("Graph: \(self.id) Scene: Added Child", objectNode.debugName)
             self.scene.add( object )
         }
         else
         {
-//            print("Graph: \(self.id) Scene: Skipped Child", node.name)
+//            print("Graph: \(self.id) Scene: Skipped Child", node.debugName)
         }
     }
     
@@ -1150,7 +1150,7 @@ internal import AnyCodable
             }
             catch
             {
-                print("duplicateNodes: Failed to encode \(node.name): \(error)")
+                print("duplicateNodes: Failed to encode \(node.debugName): \(error)")
             }
         }
 

--- a/Fabric/Graph/Graph.swift
+++ b/Fabric/Graph/Graph.swift
@@ -381,7 +381,7 @@ internal import AnyCodable
     /// interactive placement with scroll-offset and rapid-add staggering).
     public func addNode(_ node:Node)
     {
-        print("Graph: \(self.id) Add Node", node.debugName)
+        print("Graph: \(self.id) Add Node", node.canonicalName)
         self.maybeAddNodeToScene(node)
 
         // Create the ViewModel before appending so it is always present
@@ -753,7 +753,7 @@ internal import AnyCodable
                     break
                 }
                 
-                print(referenceNode.debugName, referenceNode.offset, angle, direction, "to:", $0.debugName, $0.offset)
+                print(referenceNode.canonicalName, referenceNode.offset, angle, direction, "to:", $0.canonicalName, $0.offset)
                 return (distance, direction, $0 )
             }
             
@@ -761,7 +761,7 @@ internal import AnyCodable
             
             if let closestDistanceDirectionNodeTuples = relevantDistanceDirectionNodeTuples.sorted(by: { $0.Distance < $1.Distance }).first
             {
-                print("reference node", referenceNode.debugName)
+                print("reference node", referenceNode.canonicalName)
 
                 self.selectNode(node: closestDistanceDirectionNodeTuples.Node, expandSelection: expandSelection)
             }
@@ -878,12 +878,12 @@ internal import AnyCodable
         if let objectNode = node as? BaseObjectNode,
            let object = objectNode.getObject()
         {
-//            print("Graph: \(self.id) Scene: Added Child", objectNode.debugName)
+//            print("Graph: \(self.id) Scene: Added Child", objectNode.canonicalName)
             self.scene.add( object )
         }
         else
         {
-//            print("Graph: \(self.id) Scene: Skipped Child", node.debugName)
+//            print("Graph: \(self.id) Scene: Skipped Child", node.canonicalName)
         }
     }
     
@@ -1150,7 +1150,7 @@ internal import AnyCodable
             }
             catch
             {
-                print("duplicateNodes: Failed to encode \(node.debugName): \(error)")
+                print("duplicateNodes: Failed to encode \(node.canonicalName): \(error)")
             }
         }
 

--- a/Fabric/Graph/Graph.swift
+++ b/Fabric/Graph/Graph.swift
@@ -381,7 +381,7 @@ internal import AnyCodable
     /// interactive placement with scroll-offset and rapid-add staggering).
     public func addNode(_ node:Node)
     {
-        print("Graph: \(self.id) Add Node", node.canonicalName)
+        print("Graph: \(self.id) Add Node", node)
         self.maybeAddNodeToScene(node)
 
         // Create the ViewModel before appending so it is always present
@@ -753,7 +753,7 @@ internal import AnyCodable
                     break
                 }
                 
-                print(referenceNode.canonicalName, referenceNode.offset, angle, direction, "to:", $0.canonicalName, $0.offset)
+                print(referenceNode, referenceNode.offset, angle, direction, "to:", $0, $0.offset)
                 return (distance, direction, $0 )
             }
             
@@ -761,7 +761,7 @@ internal import AnyCodable
             
             if let closestDistanceDirectionNodeTuples = relevantDistanceDirectionNodeTuples.sorted(by: { $0.Distance < $1.Distance }).first
             {
-                print("reference node", referenceNode.canonicalName)
+                print("reference node", referenceNode)
 
                 self.selectNode(node: closestDistanceDirectionNodeTuples.Node, expandSelection: expandSelection)
             }
@@ -878,12 +878,12 @@ internal import AnyCodable
         if let objectNode = node as? BaseObjectNode,
            let object = objectNode.getObject()
         {
-//            print("Graph: \(self.id) Scene: Added Child", objectNode.canonicalName)
+//            print("Graph: \(self.id) Scene: Added Child", objectNode)
             self.scene.add( object )
         }
         else
         {
-//            print("Graph: \(self.id) Scene: Skipped Child", node.canonicalName)
+//            print("Graph: \(self.id) Scene: Skipped Child", node)
         }
     }
     
@@ -1150,7 +1150,7 @@ internal import AnyCodable
             }
             catch
             {
-                print("duplicateNodes: Failed to encode \(node.canonicalName): \(error)")
+                print("duplicateNodes: Failed to encode \(node): \(error)")
             }
         }
 

--- a/Fabric/Graph/GraphRenderer.swift
+++ b/Fabric/Graph/GraphRenderer.swift
@@ -221,7 +221,7 @@ public class GraphRenderer : ViewRenderer
             }
 
 #if DEBUG
-            commandBuffer.pushDebugGroup(node.name)
+            commandBuffer.pushDebugGroup(node.title)
 #endif
             do
             {

--- a/Fabric/Graph/GraphRenderer.swift
+++ b/Fabric/Graph/GraphRenderer.swift
@@ -221,7 +221,7 @@ public class GraphRenderer : ViewRenderer
             }
 
 #if DEBUG
-            commandBuffer.pushDebugGroup(node.name)
+            commandBuffer.pushDebugGroup(node.typeName)
 #endif
             do
             {

--- a/Fabric/Graph/GraphRenderer.swift
+++ b/Fabric/Graph/GraphRenderer.swift
@@ -221,7 +221,7 @@ public class GraphRenderer : ViewRenderer
             }
 
 #if DEBUG
-            commandBuffer.pushDebugGroup(node.registryName)
+            commandBuffer.pushDebugGroup(node.name)
 #endif
             do
             {

--- a/Fabric/Graph/GraphRenderer.swift
+++ b/Fabric/Graph/GraphRenderer.swift
@@ -221,7 +221,7 @@ public class GraphRenderer : ViewRenderer
             }
 
 #if DEBUG
-            commandBuffer.pushDebugGroup(node.title)
+            commandBuffer.pushDebugGroup(node.debugDescription)
 #endif
             do
             {

--- a/Fabric/Graph/GraphRenderer.swift
+++ b/Fabric/Graph/GraphRenderer.swift
@@ -221,7 +221,7 @@ public class GraphRenderer : ViewRenderer
             }
 
 #if DEBUG
-            commandBuffer.pushDebugGroup(node.typeName)
+            commandBuffer.pushDebugGroup(node.registryName)
 #endif
             do
             {

--- a/Fabric/Graph/Node/Node.swift
+++ b/Fabric/Graph/Node/Node.swift
@@ -14,12 +14,13 @@ import UniformTypeIdentifiers
 
 open class Node : Codable, Equatable, Identifiable, Hashable, Copyable, CustomDebugStringConvertible
 {
-    // User interface name — the node's TYPE name (each subclass overrides).
+    // The name this node type is registered and listed under (each subclass
+    // overrides). Read it off an instance as `registryName`.
     open class var name: String {  fatalError("\(String(describing:self)) Must implement name") }
 
     // Node-generated name, e.g. Math Expression shows its expression. Override
     // this; nil for none. Not part of `name` — it is a subtitle the node offers
-    // alongside its type name, which title UI composes as it sees fit.
+    // alongside its registry name, which title UI composes as it sees fit.
     open var customName: String? { nil }
 
     // User-supplied name (rename). Wins over the type name.
@@ -55,10 +56,10 @@ open class Node : Codable, Equatable, Identifiable, Hashable, Copyable, CustomDe
     // What to call this node: the user's rename if they gave one, else its type.
     final public var name : String
     {
-        return userName ?? typeName
+        return userName ?? registryName
     }
 
-    final public var typeName : String
+    final public var registryName : String
     {
         Self.name
     }
@@ -68,10 +69,10 @@ open class Node : Codable, Equatable, Identifiable, Hashable, Copyable, CustomDe
     {
         switch (self.customName, self.userName)
         {
-        case (nil, nil):               return self.typeName
-        case (let custom?, nil):       return "\(self.typeName) (\(custom))"
-        case (nil, let user?):         return "\(self.typeName) (\(user))"
-        case (let custom?, let user?): return "\(self.typeName) (\(custom) · \(user))"
+        case (nil, nil):               return self.registryName
+        case (let custom?, nil):       return "\(self.registryName) (\(custom))"
+        case (nil, let user?):         return "\(self.registryName) (\(user))"
+        case (let custom?, let user?): return "\(self.registryName) (\(custom) · \(user))"
         }
     }
 

--- a/Fabric/Graph/Node/Node.swift
+++ b/Fabric/Graph/Node/Node.swift
@@ -19,12 +19,25 @@ open class Node : Codable, Equatable, Identifiable, Hashable, Copyable, CustomDe
     open class var name: String {  fatalError("\(String(describing:self)) Must implement name") }
 
     // Node-generated name, e.g. Math Expression shows its expression. Override
-    // this; nil for none. Not part of `name` — it is a subtitle the node offers
-    // alongside its registry name, which title UI composes as it sees fit.
-    open var customName: String? { nil }
+    // where the node names itself; nil for none. Raw: empty is allowed here
+    // and reads as absence. Read `customName`, never this.
+    open func deriveCustomName() -> String? { nil }
 
-    // User-supplied name (rename). Wins over the type name.
+    // The node-generated name. Not part of `name` — it is a subtitle the node
+    // offers alongside its registry name, which title UI composes as it sees
+    // fit. Never empty: an empty name is no name.
+    final public var customName: String?
+    {
+        guard let derived = self.deriveCustomName(), !derived.isEmpty else { return nil }
+        return derived
+    }
+
+    // User-supplied name (rename). Wins over the type name. Empty is absence:
+    // a cleared rename must not become a name.
     final public var userName: String?
+    {
+        didSet { if userName?.isEmpty == true { userName = nil } }
+    }
 
     // User interface organizing principle
     open class var nodeType:Node.NodeType { fatalError("\(String(describing:self)) Must implement nodeType") }
@@ -191,7 +204,9 @@ open class Node : Codable, Equatable, Identifiable, Hashable, Copyable, CustomDe
 
         self.id = try container.decode(UUID.self, forKey: .id)
         self.offset = try container.decode(CGSize.self, forKey: .nodeOffset)
-        self.userName = try container.decodeIfPresent(String.self, forKey: .userName)
+        // didSet does not fire during init; normalize the decoded rename here.
+        let decodedUserName = try container.decodeIfPresent(String.self, forKey: .userName)
+        self.userName = decodedUserName?.isEmpty == true ? nil : decodedUserName
 
         let snaps = try container.decodeIfPresent([PortRegistry.Snapshot].self, forKey: .ports) ?? []
 

--- a/Fabric/Graph/Node/Node.swift
+++ b/Fabric/Graph/Node/Node.swift
@@ -15,29 +15,8 @@ import UniformTypeIdentifiers
 open class Node : Codable, Equatable, Identifiable, Hashable, Copyable, CustomDebugStringConvertible
 {
     // The name this node type is registered and listed under (each subclass
-    // overrides). Read it off an instance as `canonicalName`.
+    // overrides). Read it off an instance as `title`.
     open class var name: String {  fatalError("\(String(describing:self)) Must implement name") }
-
-    // Node-generated subtitle, e.g. Math Expression shows its expression.
-    // Override where the node describes itself; nil for none. Raw: empty is
-    // allowed here and reads as absence. Read `subtitle`, never this.
-    open func deriveSubtitle() -> String? { nil }
-
-    // The node-generated subtitle. Not part of `title` — it is offered
-    // alongside the canonical name, which title UI composes as it sees fit.
-    // Never empty: an empty name is no name.
-    final public var subtitle: String?
-    {
-        guard let derived = self.deriveSubtitle(), !derived.isEmpty else { return nil }
-        return derived
-    }
-
-    // User-supplied name (rename). Wins over the type name. Empty is absence:
-    // a cleared rename must not become a name.
-    final public var userName: String?
-    {
-        didSet { if userName?.isEmpty == true { userName = nil } }
-    }
 
     // User interface organizing principle
     open class var nodeType:Node.NodeType { fatalError("\(String(describing:self)) Must implement nodeType") }
@@ -66,27 +45,55 @@ open class Node : Codable, Equatable, Identifiable, Hashable, Copyable, CustomDe
         return lhs.id == rhs.id
     }
 
-    // What to call this node: the user's rename if they gave one, else its type.
+    // The instance title. Most nodes use their registered type name; nodes
+    // backed by instance-specific resources can override deriveTitle().
     final public var title : String
     {
-        return userName ?? canonicalName
+        let derivedTitle = self.deriveTitle()
+        return derivedTitle.isEmpty ? Self.name : derivedTitle
     }
 
-    final public var canonicalName : String
+    // Override when an instance has a more specific authoritative title than
+    // its registered type name, e.g. a shader-backed BaseImageNode.
+    open func deriveTitle() -> String { Self.name }
+
+  
+    // The resolved subtitle: the user's rename when present, otherwise the
+    // node-generated description. Never empty or equal to the registered title.
+    final public var subtitle: String?
     {
-        Self.name
+        let resolvedSubtitle = self.userName ?? self.deriveSubtitle()
+        guard let resolvedSubtitle,
+              !resolvedSubtitle.isEmpty,
+              resolvedSubtitle != self.title
+        else
+        {
+            return nil
+        }
+        return resolvedSubtitle
     }
 
-    // CustomDebugStringConvertible: every name this node answers to.
+    // Node-generated subtitle, e.g. Math Expression shows its expression.
+    // Override where the node describes itself; nil for none. Raw: empty is
+    // allowed here and reads as absence. Read `subtitle`, never this.
+    open func deriveSubtitle() -> String? { nil }
+
+    // User-supplied rename. Wins over the node-derived subtitle. Empty is
+    // absence: a cleared rename must reveal the derived subtitle again.
+    final public var userName: String?
+    {
+        didSet
+        {
+            if userName?.isEmpty == true { userName = nil }
+            subtitleSubject.send()
+        }
+    }
+    
+    // CustomDebugStringConvertible: the registered title and resolved subtitle.
     final public var debugDescription: String
     {
-        switch (self.subtitle, self.userName)
-        {
-        case (nil, nil):                 return self.canonicalName
-        case (let subtitle?, nil):       return "\(self.canonicalName) (\(subtitle))"
-        case (nil, let user?):           return "\(self.canonicalName) (\(user))"
-        case (let subtitle?, let user?): return "\(self.canonicalName) (\(subtitle) · \(user))"
-        }
+        guard let subtitle = self.subtitle else { return self.title }
+        return "\(self.title) (\(subtitle))"
     }
 
     open var nodeType:NodeType
@@ -164,9 +171,8 @@ open class Node : Codable, Equatable, Identifiable, Hashable, Copyable, CustomDe
     /// Fires whenever the port list changes (addDynamicPort / removePort).
     internal let portsChangedSubject = PassthroughSubject<Void, Never>()
 
-    /// Fires whenever the state the node's `subtitle` derives from changes (e.g.
-    /// after a math expression re-parses). NodeViewModel subscribes and caches
-    /// the result.
+    /// Fires whenever state feeding `title` or `subtitle` changes. NodeViewModel
+    /// subscribes and refreshes its observable naming mirrors.
     internal let subtitleSubject = PassthroughSubject<Void, Never>()
 
     // Dirty Handling

--- a/Fabric/Graph/Node/Node.swift
+++ b/Fabric/Graph/Node/Node.swift
@@ -12,7 +12,7 @@ import Combine
 import UniformTypeIdentifiers
 
 
-open class Node : Codable, Equatable, Identifiable, Hashable, Copyable
+open class Node : Codable, Equatable, Identifiable, Hashable, Copyable, CustomDebugStringConvertible
 {
     // User interface name — the node's TYPE name (each subclass overrides).
     open class var name: String {  fatalError("\(String(describing:self)) Must implement name") }
@@ -74,6 +74,9 @@ open class Node : Codable, Equatable, Identifiable, Hashable, Copyable
         case (let custom?, let user?): return "\(self.typeName) (\(custom) · \(user))"
         }
     }
+
+    // CustomDebugStringConvertible
+    final public var debugDescription: String { self.canonicalName }
 
     open var nodeType:NodeType
     {

--- a/Fabric/Graph/Node/Node.swift
+++ b/Fabric/Graph/Node/Node.swift
@@ -15,20 +15,20 @@ import UniformTypeIdentifiers
 open class Node : Codable, Equatable, Identifiable, Hashable, Copyable, CustomDebugStringConvertible
 {
     // The name this node type is registered and listed under (each subclass
-    // overrides). Read it off an instance as `registryName`.
+    // overrides). Read it off an instance as `canonicalName`.
     open class var name: String {  fatalError("\(String(describing:self)) Must implement name") }
 
-    // Node-generated name, e.g. Math Expression shows its expression. Override
-    // where the node names itself; nil for none. Raw: empty is allowed here
-    // and reads as absence. Read `customName`, never this.
-    open func deriveCustomName() -> String? { nil }
+    // Node-generated subtitle, e.g. Math Expression shows its expression.
+    // Override where the node describes itself; nil for none. Raw: empty is
+    // allowed here and reads as absence. Read `subtitle`, never this.
+    open func deriveSubtitle() -> String? { nil }
 
-    // The node-generated name. Not part of `name` — it is a subtitle the node
-    // offers alongside its registry name, which title UI composes as it sees
-    // fit. Never empty: an empty name is no name.
-    final public var customName: String?
+    // The node-generated subtitle. Not part of `title` — it is offered
+    // alongside the canonical name, which title UI composes as it sees fit.
+    // Never empty: an empty name is no name.
+    final public var subtitle: String?
     {
-        guard let derived = self.deriveCustomName(), !derived.isEmpty else { return nil }
+        guard let derived = self.deriveSubtitle(), !derived.isEmpty else { return nil }
         return derived
     }
 
@@ -67,30 +67,27 @@ open class Node : Codable, Equatable, Identifiable, Hashable, Copyable, CustomDe
     }
 
     // What to call this node: the user's rename if they gave one, else its type.
-    final public var name : String
+    final public var title : String
     {
-        return userName ?? registryName
+        return userName ?? canonicalName
     }
 
-    final public var registryName : String
+    final public var canonicalName : String
     {
         Self.name
     }
 
-    // Every name this node answers to, for logging and diagnostics.
-    final public var canonicalName : String
+    // CustomDebugStringConvertible: every name this node answers to.
+    final public var debugDescription: String
     {
-        switch (self.customName, self.userName)
+        switch (self.subtitle, self.userName)
         {
-        case (nil, nil):               return self.registryName
-        case (let custom?, nil):       return "\(self.registryName) (\(custom))"
-        case (nil, let user?):         return "\(self.registryName) (\(user))"
-        case (let custom?, let user?): return "\(self.registryName) (\(custom) · \(user))"
+        case (nil, nil):                 return self.canonicalName
+        case (let subtitle?, nil):       return "\(self.canonicalName) (\(subtitle))"
+        case (nil, let user?):           return "\(self.canonicalName) (\(user))"
+        case (let subtitle?, let user?): return "\(self.canonicalName) (\(subtitle) · \(user))"
         }
     }
-
-    // CustomDebugStringConvertible
-    final public var debugDescription: String { self.canonicalName }
 
     open var nodeType:NodeType
     {
@@ -167,9 +164,10 @@ open class Node : Codable, Equatable, Identifiable, Hashable, Copyable, CustomDe
     /// Fires whenever the port list changes (addDynamicPort / removePort).
     internal let portsChangedSubject = PassthroughSubject<Void, Never>()
 
-    /// Fires whenever the node's computed `name` changes (e.g. after a math
-    /// expression re-parses). NodeViewModel subscribes and caches the result.
-    internal let nameSubject = PassthroughSubject<Void, Never>()
+    /// Fires whenever the state the node's `subtitle` derives from changes (e.g.
+    /// after a math expression re-parses). NodeViewModel subscribes and caches
+    /// the result.
+    internal let subtitleSubject = PassthroughSubject<Void, Never>()
 
     // Dirty Handling
     private(set) public var isDirty: Bool = true

--- a/Fabric/Graph/Node/Node.swift
+++ b/Fabric/Graph/Node/Node.swift
@@ -17,11 +17,13 @@ open class Node : Codable, Equatable, Identifiable, Hashable, Copyable
     // User interface name — the node's TYPE name (each subclass overrides).
     open class var name: String {  fatalError("\(String(describing:self)) Must implement name") }
 
-    // Node-provided dynamic name, e.g. Math Expression shows its expression.
-    open var displayName: String? { nil }
+    // Node-generated name, e.g. Math Expression shows its expression. Override
+    // this; nil for none. Not part of `name` — it is a subtitle the node offers
+    // alongside its type name, which title UI composes as it sees fit.
+    open var customName: String? { nil }
 
-    // User-supplied custom name (rename). Overrides any `displayName`.
-    public var userName: String?
+    // User-supplied name (rename). Wins over the type name.
+    final public var userName: String?
 
     // User interface organizing principle
     open class var nodeType:Node.NodeType { fatalError("\(String(describing:self)) Must implement nodeType") }
@@ -50,9 +52,10 @@ open class Node : Codable, Equatable, Identifiable, Hashable, Copyable
         return lhs.id == rhs.id
     }
 
+    // What to call this node: the user's rename if they gave one, else its type.
     final public var name : String
     {
-        return userName ?? displayName ?? typeName
+        return userName ?? typeName
     }
 
     final public var typeName : String
@@ -60,14 +63,15 @@ open class Node : Codable, Equatable, Identifiable, Hashable, Copyable
         Self.name
     }
 
-    final public var debugName : String
+    // Every name this node answers to, for logging and diagnostics.
+    final public var canonicalName : String
     {
-        switch (self.displayName, self.userName)
+        switch (self.customName, self.userName)
         {
-        case (nil, nil):                return self.typeName
-        case (let display?, nil):       return "\(self.typeName) (\(display))"
-        case (nil, let user?):          return "\(self.typeName) (\(user))"
-        case (let display?, let user?): return "\(self.typeName) (\(display) · \(user))"
+        case (nil, nil):               return self.typeName
+        case (let custom?, nil):       return "\(self.typeName) (\(custom))"
+        case (nil, let user?):         return "\(self.typeName) (\(user))"
+        case (let custom?, let user?): return "\(self.typeName) (\(custom) · \(user))"
         }
     }
 

--- a/Fabric/Graph/Node/Node.swift
+++ b/Fabric/Graph/Node/Node.swift
@@ -18,8 +18,6 @@ open class Node : Codable, Equatable, Identifiable, Hashable, Copyable
     open class var name: String {  fatalError("\(String(describing:self)) Must implement name") }
 
     // Node-provided dynamic name, e.g. Math Expression shows its expression.
-    // Override THIS (not the instance `name`) to give a node a self-generated
-    // title; return nil for none. A user-supplied `userName` always wins over it.
     open var displayName: String? { nil }
 
     // User-supplied custom name (rename). Overrides any `displayName`.
@@ -52,10 +50,25 @@ open class Node : Codable, Equatable, Identifiable, Hashable, Copyable
         return lhs.id == rhs.id
     }
 
-    public var name : String
+    final public var name : String
     {
-        let myType = type(of: self)
-        return userName ?? displayName ?? myType.name
+        return userName ?? displayName ?? typeName
+    }
+
+    final public var typeName : String
+    {
+        Self.name
+    }
+
+    final public var debugName : String
+    {
+        switch (self.displayName, self.userName)
+        {
+        case (nil, nil):                return self.typeName
+        case (let display?, nil):       return "\(self.typeName) (\(display))"
+        case (nil, let user?):          return "\(self.typeName) (\(user))"
+        case (let display?, let user?): return "\(self.typeName) (\(display) · \(user))"
+        }
     }
 
     open var nodeType:NodeType

--- a/Fabric/Graph/Node/NodeType.swift
+++ b/Fabric/Graph/Node/NodeType.swift
@@ -208,7 +208,7 @@ extension Node
         {
             switch self
             {
-            case .Parameter:
+            case .Parameter, .Utility:
                 return self.color( ).opacity(0.6)
                 
             default:

--- a/Fabric/Graph/Port/Port.swift
+++ b/Fabric/Graph/Port/Port.swift
@@ -126,7 +126,7 @@ extension UTType
 
     public var debugDescription: String
     {
-        return "\(self.node?.canonicalName ?? "No Node!!") - \(String(describing: type(of: self)))  \(id)"
+        return "\(self.node?.debugDescription ?? "No Node!!") - \(String(describing: type(of: self)))  \(id)"
     }
     
     public init(name: String, kind: PortKind, description: String = "", id:UUID)

--- a/Fabric/Graph/Port/Port.swift
+++ b/Fabric/Graph/Port/Port.swift
@@ -126,7 +126,7 @@ extension UTType
 
     public var debugDescription: String
     {
-        return "\(self.node?.name ?? "No Node!!") - \(String(describing: type(of: self)))  \(id)"
+        return "\(self.node?.debugName ?? "No Node!!") - \(String(describing: type(of: self)))  \(id)"
     }
     
     public init(name: String, kind: PortKind, description: String = "", id:UUID)

--- a/Fabric/Graph/Port/Port.swift
+++ b/Fabric/Graph/Port/Port.swift
@@ -126,7 +126,7 @@ extension UTType
 
     public var debugDescription: String
     {
-        return "\(self.node?.debugName ?? "No Node!!") - \(String(describing: type(of: self)))  \(id)"
+        return "\(self.node?.canonicalName ?? "No Node!!") - \(String(describing: type(of: self)))  \(id)"
     }
     
     public init(name: String, kind: PortKind, description: String = "", id:UUID)

--- a/Fabric/Graph/Trace/NodeExecutionTraceBuilder.swift
+++ b/Fabric/Graph/Trace/NodeExecutionTraceBuilder.swift
@@ -19,7 +19,7 @@ internal final class NodeExecutionTraceBuilder
     init(node: Node, orderIndex: Int, startedAt: TimeInterval)
     {
         self.nodeID = node.id
-        self.nodeName = node.name
+        self.nodeName = node.canonicalName
         self.nodeTypeName = String(describing: type(of: node))
         self.orderIndex = orderIndex
         self.startedAt = startedAt

--- a/Fabric/Graph/Trace/NodeExecutionTraceBuilder.swift
+++ b/Fabric/Graph/Trace/NodeExecutionTraceBuilder.swift
@@ -19,7 +19,7 @@ internal final class NodeExecutionTraceBuilder
     init(node: Node, orderIndex: Int, startedAt: TimeInterval)
     {
         self.nodeID = node.id
-        self.nodeName = node.canonicalName
+        self.nodeName = node.name
         self.nodeTypeName = String(describing: type(of: node))
         self.orderIndex = orderIndex
         self.startedAt = startedAt

--- a/Fabric/Graph/Trace/NodeExecutionTraceBuilder.swift
+++ b/Fabric/Graph/Trace/NodeExecutionTraceBuilder.swift
@@ -19,7 +19,7 @@ internal final class NodeExecutionTraceBuilder
     init(node: Node, orderIndex: Int, startedAt: TimeInterval)
     {
         self.nodeID = node.id
-        self.nodeName = node.name
+        self.nodeName = node.title
         self.nodeTypeName = String(describing: type(of: node))
         self.orderIndex = orderIndex
         self.startedAt = startedAt

--- a/Fabric/Graph/Trace/NodeExecutionTraceBuilder.swift
+++ b/Fabric/Graph/Trace/NodeExecutionTraceBuilder.swift
@@ -19,7 +19,7 @@ internal final class NodeExecutionTraceBuilder
     init(node: Node, orderIndex: Int, startedAt: TimeInterval)
     {
         self.nodeID = node.id
-        self.nodeName = node.title
+        self.nodeName = node.debugDescription
         self.nodeTypeName = String(describing: type(of: node))
         self.orderIndex = orderIndex
         self.startedAt = startedAt

--- a/Fabric/Nodes/Base/BaseImageNode.swift
+++ b/Fabric/Nodes/Base/BaseImageNode.swift
@@ -232,7 +232,7 @@ public class BaseImageNode: Node, NodeFileLoadingProtocol
 
     private func postInit()
     {
-        self.postProcessor.label = self.typeName + " Post Processor"
+        self.postProcessor.label = self.registryName + " Post Processor"
     }
     
     open func postSetupSynchronizePorts(allowReplace: Bool, preserveExistingImageInputPorts: Bool = false) {
@@ -649,7 +649,7 @@ public class BaseImageNode: Node, NodeFileLoadingProtocol
             partialResult || next.valueDidChange
         }
 
-        commandBuffer.pushDebugGroup(self.typeName + " Execute")
+        commandBuffer.pushDebugGroup(self.registryName + " Execute")
         defer { commandBuffer.popDebugGroup() }
         
         if self.currentImageInputCount == 0 {

--- a/Fabric/Nodes/Base/BaseImageNode.swift
+++ b/Fabric/Nodes/Base/BaseImageNode.swift
@@ -15,7 +15,7 @@ public class BaseImageNode: Node, NodeFileLoadingProtocol
     override public class var nodeTimeMode: Node.TimeMode { .None }
     override public class var nodeDescription: String { "Image processing effect" }
 
-    override public func deriveSubtitle() -> String? { self.cachedFileURLName }
+    override public func deriveTitle() -> String { self.cachedFileURLName ?? Self.name }
 
     open class var sourceShaderName: String { "" }
     open class var defaultImageInputCountHint: Int? { nil }
@@ -127,6 +127,7 @@ public class BaseImageNode: Node, NodeFileLoadingProtocol
 
         self.url = url
         self.cachedFileURLName = cachedName
+        self.updatePostProcessorLabel()
         self.subtitleSubject.send()
 
         guard shouldUpdatePipeline else { return }
@@ -232,7 +233,12 @@ public class BaseImageNode: Node, NodeFileLoadingProtocol
 
     private func postInit()
     {
-        self.postProcessor.label = self.canonicalName + " Post Processor"
+        self.updatePostProcessorLabel()
+    }
+
+    private func updatePostProcessorLabel()
+    {
+        self.postProcessor.label = self.title + " Post Processor"
     }
     
     open func postSetupSynchronizePorts(allowReplace: Bool, preserveExistingImageInputPorts: Bool = false) {
@@ -649,7 +655,7 @@ public class BaseImageNode: Node, NodeFileLoadingProtocol
             partialResult || next.valueDidChange
         }
 
-        commandBuffer.pushDebugGroup(self.title + " Execute")
+        commandBuffer.pushDebugGroup(self.debugDescription + " Execute")
         defer { commandBuffer.popDebugGroup() }
         
         if self.currentImageInputCount == 0 {

--- a/Fabric/Nodes/Base/BaseImageNode.swift
+++ b/Fabric/Nodes/Base/BaseImageNode.swift
@@ -232,7 +232,7 @@ public class BaseImageNode: Node, NodeFileLoadingProtocol
 
     private func postInit()
     {
-        self.postProcessor.label = self.name + " Post Processor"
+        self.postProcessor.label = self.typeName + " Post Processor"
     }
     
     open func postSetupSynchronizePorts(allowReplace: Bool, preserveExistingImageInputPorts: Bool = false) {
@@ -649,7 +649,7 @@ public class BaseImageNode: Node, NodeFileLoadingProtocol
             partialResult || next.valueDidChange
         }
 
-        commandBuffer.pushDebugGroup(self.name + " Execute")
+        commandBuffer.pushDebugGroup(self.typeName + " Execute")
         defer { commandBuffer.popDebugGroup() }
         
         if self.currentImageInputCount == 0 {

--- a/Fabric/Nodes/Base/BaseImageNode.swift
+++ b/Fabric/Nodes/Base/BaseImageNode.swift
@@ -15,7 +15,7 @@ public class BaseImageNode: Node, NodeFileLoadingProtocol
     override public class var nodeTimeMode: Node.TimeMode { .None }
     override public class var nodeDescription: String { "Image processing effect" }
 
-    override public var customName: String? { self.cachedFileURLName }
+    override public func deriveCustomName() -> String? { self.cachedFileURLName }
 
     open class var sourceShaderName: String { "" }
     open class var defaultImageInputCountHint: Int? { nil }

--- a/Fabric/Nodes/Base/BaseImageNode.swift
+++ b/Fabric/Nodes/Base/BaseImageNode.swift
@@ -15,7 +15,7 @@ public class BaseImageNode: Node, NodeFileLoadingProtocol
     override public class var nodeTimeMode: Node.TimeMode { .None }
     override public class var nodeDescription: String { "Image processing effect" }
 
-    override public var displayName: String? { self.cachedFileURLName }
+    override public var customName: String? { self.cachedFileURLName }
 
     open class var sourceShaderName: String { "" }
     open class var defaultImageInputCountHint: Int? { nil }

--- a/Fabric/Nodes/Base/BaseImageNode.swift
+++ b/Fabric/Nodes/Base/BaseImageNode.swift
@@ -649,7 +649,7 @@ public class BaseImageNode: Node, NodeFileLoadingProtocol
             partialResult || next.valueDidChange
         }
 
-        commandBuffer.pushDebugGroup(self.registryName + " Execute")
+        commandBuffer.pushDebugGroup(self.name + " Execute")
         defer { commandBuffer.popDebugGroup() }
         
         if self.currentImageInputCount == 0 {

--- a/Fabric/Nodes/Base/BaseImageNode.swift
+++ b/Fabric/Nodes/Base/BaseImageNode.swift
@@ -15,7 +15,7 @@ public class BaseImageNode: Node, NodeFileLoadingProtocol
     override public class var nodeTimeMode: Node.TimeMode { .None }
     override public class var nodeDescription: String { "Image processing effect" }
 
-    override public func deriveCustomName() -> String? { self.cachedFileURLName }
+    override public func deriveSubtitle() -> String? { self.cachedFileURLName }
 
     open class var sourceShaderName: String { "" }
     open class var defaultImageInputCountHint: Int? { nil }
@@ -127,7 +127,7 @@ public class BaseImageNode: Node, NodeFileLoadingProtocol
 
         self.url = url
         self.cachedFileURLName = cachedName
-        self.nameSubject.send()
+        self.subtitleSubject.send()
 
         guard shouldUpdatePipeline else { return }
 
@@ -232,7 +232,7 @@ public class BaseImageNode: Node, NodeFileLoadingProtocol
 
     private func postInit()
     {
-        self.postProcessor.label = self.registryName + " Post Processor"
+        self.postProcessor.label = self.canonicalName + " Post Processor"
     }
     
     open func postSetupSynchronizePorts(allowReplace: Bool, preserveExistingImageInputPorts: Bool = false) {
@@ -649,7 +649,7 @@ public class BaseImageNode: Node, NodeFileLoadingProtocol
             partialResult || next.valueDidChange
         }
 
-        commandBuffer.pushDebugGroup(self.name + " Execute")
+        commandBuffer.pushDebugGroup(self.title + " Execute")
         defer { commandBuffer.popDebugGroup() }
         
         if self.currentImageInputCount == 0 {

--- a/Fabric/Nodes/Base/BaseMultiPassBlurEffectNode.swift
+++ b/Fabric/Nodes/Base/BaseMultiPassBlurEffectNode.swift
@@ -78,7 +78,7 @@ public class BaseMultiPassBlurEffectNode: BaseImageNode
                 return nil
             }
 
-            commandBuffer.pushDebugGroup("\(self.typeName) - pass \(index)")
+            commandBuffer.pushDebugGroup("\(self.registryName) - pass \(index)")
 
             prepareStep(index, step)
 

--- a/Fabric/Nodes/Base/BaseMultiPassBlurEffectNode.swift
+++ b/Fabric/Nodes/Base/BaseMultiPassBlurEffectNode.swift
@@ -78,7 +78,7 @@ public class BaseMultiPassBlurEffectNode: BaseImageNode
                 return nil
             }
 
-            commandBuffer.pushDebugGroup("\(self.registryName) - pass \(index)")
+            commandBuffer.pushDebugGroup("\(self.name) - pass \(index)")
 
             prepareStep(index, step)
 

--- a/Fabric/Nodes/Base/BaseMultiPassBlurEffectNode.swift
+++ b/Fabric/Nodes/Base/BaseMultiPassBlurEffectNode.swift
@@ -78,7 +78,7 @@ public class BaseMultiPassBlurEffectNode: BaseImageNode
                 return nil
             }
 
-            commandBuffer.pushDebugGroup("\(self.title) - pass \(index)")
+            commandBuffer.pushDebugGroup("\(self.debugDescription) - pass \(index)")
 
             prepareStep(index, step)
 

--- a/Fabric/Nodes/Base/BaseMultiPassBlurEffectNode.swift
+++ b/Fabric/Nodes/Base/BaseMultiPassBlurEffectNode.swift
@@ -37,7 +37,7 @@ public class BaseMultiPassBlurEffectNode: BaseImageNode
         let inputs = self.imageInputPorts()
         if inputs.count != 1 {
             if self.hasLoggedInputCountMismatch == false {
-                print("\(self.debugName) expected exactly 1 input image, but got \(inputs.count).")
+                print("\(self.canonicalName) expected exactly 1 input image, but got \(inputs.count).")
                 self.hasLoggedInputCountMismatch = true
             }
             return nil

--- a/Fabric/Nodes/Base/BaseMultiPassBlurEffectNode.swift
+++ b/Fabric/Nodes/Base/BaseMultiPassBlurEffectNode.swift
@@ -37,7 +37,7 @@ public class BaseMultiPassBlurEffectNode: BaseImageNode
         let inputs = self.imageInputPorts()
         if inputs.count != 1 {
             if self.hasLoggedInputCountMismatch == false {
-                print("\(self.canonicalName) expected exactly 1 input image, but got \(inputs.count).")
+                print("\(self) expected exactly 1 input image, but got \(inputs.count).")
                 self.hasLoggedInputCountMismatch = true
             }
             return nil

--- a/Fabric/Nodes/Base/BaseMultiPassBlurEffectNode.swift
+++ b/Fabric/Nodes/Base/BaseMultiPassBlurEffectNode.swift
@@ -78,7 +78,7 @@ public class BaseMultiPassBlurEffectNode: BaseImageNode
                 return nil
             }
 
-            commandBuffer.pushDebugGroup("\(self.name) - pass \(index)")
+            commandBuffer.pushDebugGroup("\(self.title) - pass \(index)")
 
             prepareStep(index, step)
 

--- a/Fabric/Nodes/Base/BaseMultiPassBlurEffectNode.swift
+++ b/Fabric/Nodes/Base/BaseMultiPassBlurEffectNode.swift
@@ -37,7 +37,7 @@ public class BaseMultiPassBlurEffectNode: BaseImageNode
         let inputs = self.imageInputPorts()
         if inputs.count != 1 {
             if self.hasLoggedInputCountMismatch == false {
-                print("\\(self.name) expected exactly 1 input image, but got \\(inputs.count).")
+                print("\(self.debugName) expected exactly 1 input image, but got \(inputs.count).")
                 self.hasLoggedInputCountMismatch = true
             }
             return nil
@@ -78,7 +78,7 @@ public class BaseMultiPassBlurEffectNode: BaseImageNode
                 return nil
             }
 
-            commandBuffer.pushDebugGroup("\(self.name) - pass \(index)")
+            commandBuffer.pushDebugGroup("\(self.typeName) - pass \(index)")
 
             prepareStep(index, step)
 

--- a/Fabric/Nodes/Base/BaseMultiPassBlurEffectTwoChannelNode.swift
+++ b/Fabric/Nodes/Base/BaseMultiPassBlurEffectTwoChannelNode.swift
@@ -35,7 +35,7 @@ public class BaseMultiPassBlurEffectTwoChannelNode: BaseImageNode
         let inputs = self.imageInputPorts()
         if inputs.count != 2 {
             if self.hasLoggedInputCountMismatch == false {
-                print("\\(self.name) expected exactly 2 input images, but got \\(inputs.count).")
+                print("\(self.debugName) expected exactly 2 input images, but got \(inputs.count).")
                 self.hasLoggedInputCountMismatch = true
             }
             return nil

--- a/Fabric/Nodes/Base/BaseMultiPassBlurEffectTwoChannelNode.swift
+++ b/Fabric/Nodes/Base/BaseMultiPassBlurEffectTwoChannelNode.swift
@@ -35,7 +35,7 @@ public class BaseMultiPassBlurEffectTwoChannelNode: BaseImageNode
         let inputs = self.imageInputPorts()
         if inputs.count != 2 {
             if self.hasLoggedInputCountMismatch == false {
-                print("\(self.debugName) expected exactly 2 input images, but got \(inputs.count).")
+                print("\(self.canonicalName) expected exactly 2 input images, but got \(inputs.count).")
                 self.hasLoggedInputCountMismatch = true
             }
             return nil

--- a/Fabric/Nodes/Base/BaseMultiPassBlurEffectTwoChannelNode.swift
+++ b/Fabric/Nodes/Base/BaseMultiPassBlurEffectTwoChannelNode.swift
@@ -35,7 +35,7 @@ public class BaseMultiPassBlurEffectTwoChannelNode: BaseImageNode
         let inputs = self.imageInputPorts()
         if inputs.count != 2 {
             if self.hasLoggedInputCountMismatch == false {
-                print("\(self.canonicalName) expected exactly 2 input images, but got \(inputs.count).")
+                print("\(self) expected exactly 2 input images, but got \(inputs.count).")
                 self.hasLoggedInputCountMismatch = true
             }
             return nil

--- a/Fabric/Nodes/Base/BaseTextureComputeProcessorNode.swift
+++ b/Fabric/Nodes/Base/BaseTextureComputeProcessorNode.swift
@@ -20,7 +20,7 @@ public class BaseTextureComputeProcessorNode: Node, NodeFileLoadingProtocol
     override public class var nodeTimeMode: Node.TimeMode { .None }
     override public class var nodeDescription: String { "Compute-based image processing effect" }
     
-    override public var customName: String? {
+    override public func deriveCustomName() -> String? {
         guard let fileURL = self.url else { return nil }
         return self.fileURLToName(fileURL: fileURL)
     }

--- a/Fabric/Nodes/Base/BaseTextureComputeProcessorNode.swift
+++ b/Fabric/Nodes/Base/BaseTextureComputeProcessorNode.swift
@@ -20,7 +20,7 @@ public class BaseTextureComputeProcessorNode: Node, NodeFileLoadingProtocol
     override public class var nodeTimeMode: Node.TimeMode { .None }
     override public class var nodeDescription: String { "Compute-based image processing effect" }
     
-    override public var displayName: String? {
+    override public var customName: String? {
         guard let fileURL = self.url else { return nil }
         return self.fileURLToName(fileURL: fileURL)
     }
@@ -96,7 +96,7 @@ public class BaseTextureComputeProcessorNode: Node, NodeFileLoadingProtocol
         {
             throw FabricError(.execution(.gpu),
                               severity: .recoverable,
-                              message: "\(debugName) compute processor is unavailable")
+                              message: "\(canonicalName) compute processor is unavailable")
         }
 
         let outImage = try renderer.newImage(withWidth: inTex.width, height: inTex.height)
@@ -105,7 +105,7 @@ public class BaseTextureComputeProcessorNode: Node, NodeFileLoadingProtocol
         {
             throw FabricError(.execution(.gpu),
                               severity: .recoverable,
-                              message: "Could not create \(debugName) compute encoder")
+                              message: "Could not create \(canonicalName) compute encoder")
         }
         
         // Input Texture to Compute

--- a/Fabric/Nodes/Base/BaseTextureComputeProcessorNode.swift
+++ b/Fabric/Nodes/Base/BaseTextureComputeProcessorNode.swift
@@ -96,7 +96,7 @@ public class BaseTextureComputeProcessorNode: Node, NodeFileLoadingProtocol
         {
             throw FabricError(.execution(.gpu),
                               severity: .recoverable,
-                              message: "\(name) compute processor is unavailable")
+                              message: "\(debugName) compute processor is unavailable")
         }
 
         let outImage = try renderer.newImage(withWidth: inTex.width, height: inTex.height)
@@ -105,7 +105,7 @@ public class BaseTextureComputeProcessorNode: Node, NodeFileLoadingProtocol
         {
             throw FabricError(.execution(.gpu),
                               severity: .recoverable,
-                              message: "Could not create \(name) compute encoder")
+                              message: "Could not create \(debugName) compute encoder")
         }
         
         // Input Texture to Compute

--- a/Fabric/Nodes/Base/BaseTextureComputeProcessorNode.swift
+++ b/Fabric/Nodes/Base/BaseTextureComputeProcessorNode.swift
@@ -20,7 +20,7 @@ public class BaseTextureComputeProcessorNode: Node, NodeFileLoadingProtocol
     override public class var nodeTimeMode: Node.TimeMode { .None }
     override public class var nodeDescription: String { "Compute-based image processing effect" }
     
-    override public func deriveCustomName() -> String? {
+    override public func deriveSubtitle() -> String? {
         guard let fileURL = self.url else { return nil }
         return self.fileURLToName(fileURL: fileURL)
     }
@@ -96,7 +96,7 @@ public class BaseTextureComputeProcessorNode: Node, NodeFileLoadingProtocol
         {
             throw FabricError(.execution(.gpu),
                               severity: .recoverable,
-                              message: "\(canonicalName) compute processor is unavailable")
+                              message: "\(self) compute processor is unavailable")
         }
 
         let outImage = try renderer.newImage(withWidth: inTex.width, height: inTex.height)
@@ -105,7 +105,7 @@ public class BaseTextureComputeProcessorNode: Node, NodeFileLoadingProtocol
         {
             throw FabricError(.execution(.gpu),
                               severity: .recoverable,
-                              message: "Could not create \(canonicalName) compute encoder")
+                              message: "Could not create \(self) compute encoder")
         }
         
         // Input Texture to Compute

--- a/Fabric/Nodes/Deprecated/BaseEffectNode.swift
+++ b/Fabric/Nodes/Deprecated/BaseEffectNode.swift
@@ -19,7 +19,7 @@ public class BaseEffectNode: Node, NodeFileLoadingProtocol
     override public class var nodeTimeMode: Node.TimeMode { .None }
     override public class var nodeDescription: String { "Deprecated single-channel image effect" }
 
-    override public func deriveCustomName() -> String? {
+    override public func deriveSubtitle() -> String? {
         guard let fileURL = self.url else { return nil }
         return self.fileURLToName(fileURL: fileURL)
     }

--- a/Fabric/Nodes/Deprecated/BaseEffectNode.swift
+++ b/Fabric/Nodes/Deprecated/BaseEffectNode.swift
@@ -19,7 +19,7 @@ public class BaseEffectNode: Node, NodeFileLoadingProtocol
     override public class var nodeTimeMode: Node.TimeMode { .None }
     override public class var nodeDescription: String { "Deprecated single-channel image effect" }
 
-    override public var displayName: String? {
+    override public var customName: String? {
         guard let fileURL = self.url else { return nil }
         return self.fileURLToName(fileURL: fileURL)
     }

--- a/Fabric/Nodes/Deprecated/BaseEffectNode.swift
+++ b/Fabric/Nodes/Deprecated/BaseEffectNode.swift
@@ -19,7 +19,7 @@ public class BaseEffectNode: Node, NodeFileLoadingProtocol
     override public class var nodeTimeMode: Node.TimeMode { .None }
     override public class var nodeDescription: String { "Deprecated single-channel image effect" }
 
-    override public var customName: String? {
+    override public func deriveCustomName() -> String? {
         guard let fileURL = self.url else { return nil }
         return self.fileURLToName(fileURL: fileURL)
     }

--- a/Fabric/Nodes/Deprecated/BaseEffectThreeChannelNode.swift
+++ b/Fabric/Nodes/Deprecated/BaseEffectThreeChannelNode.swift
@@ -19,7 +19,7 @@ class BaseEffectThreeChannelNode: Node, NodeFileLoadingProtocol
     override public class var nodeTimeMode: Node.TimeMode { .None }
     override class var nodeDescription: String { "Deprecated three-channel image effect" }
 
-    override func deriveCustomName() -> String? {
+    override func deriveSubtitle() -> String? {
         guard let fileURL = self.url else { return nil }
         return self.fileURLToName(fileURL: fileURL)
     }

--- a/Fabric/Nodes/Deprecated/BaseEffectThreeChannelNode.swift
+++ b/Fabric/Nodes/Deprecated/BaseEffectThreeChannelNode.swift
@@ -19,7 +19,7 @@ class BaseEffectThreeChannelNode: Node, NodeFileLoadingProtocol
     override public class var nodeTimeMode: Node.TimeMode { .None }
     override class var nodeDescription: String { "Deprecated three-channel image effect" }
 
-    override var displayName: String? {
+    override var customName: String? {
         guard let fileURL = self.url else { return nil }
         return self.fileURLToName(fileURL: fileURL)
     }

--- a/Fabric/Nodes/Deprecated/BaseEffectThreeChannelNode.swift
+++ b/Fabric/Nodes/Deprecated/BaseEffectThreeChannelNode.swift
@@ -19,7 +19,7 @@ class BaseEffectThreeChannelNode: Node, NodeFileLoadingProtocol
     override public class var nodeTimeMode: Node.TimeMode { .None }
     override class var nodeDescription: String { "Deprecated three-channel image effect" }
 
-    override var customName: String? {
+    override func deriveCustomName() -> String? {
         guard let fileURL = self.url else { return nil }
         return self.fileURLToName(fileURL: fileURL)
     }

--- a/Fabric/Nodes/Deprecated/BaseEffectTwoChannelNode.swift
+++ b/Fabric/Nodes/Deprecated/BaseEffectTwoChannelNode.swift
@@ -19,7 +19,7 @@ public class BaseEffectTwoChannelNode: Node, NodeFileLoadingProtocol
     override public class var nodeTimeMode: Node.TimeMode { .None }
     override public class var nodeDescription: String { "Deprecated two-channel image effect" }
 
-    override public func deriveCustomName() -> String? {
+    override public func deriveSubtitle() -> String? {
         guard let fileURL = self.url else { return nil }
         return self.fileURLToName(fileURL: fileURL)
     }

--- a/Fabric/Nodes/Deprecated/BaseEffectTwoChannelNode.swift
+++ b/Fabric/Nodes/Deprecated/BaseEffectTwoChannelNode.swift
@@ -19,7 +19,7 @@ public class BaseEffectTwoChannelNode: Node, NodeFileLoadingProtocol
     override public class var nodeTimeMode: Node.TimeMode { .None }
     override public class var nodeDescription: String { "Deprecated two-channel image effect" }
 
-    override public var displayName: String? {
+    override public var customName: String? {
         guard let fileURL = self.url else { return nil }
         return self.fileURLToName(fileURL: fileURL)
     }

--- a/Fabric/Nodes/Deprecated/BaseEffectTwoChannelNode.swift
+++ b/Fabric/Nodes/Deprecated/BaseEffectTwoChannelNode.swift
@@ -19,7 +19,7 @@ public class BaseEffectTwoChannelNode: Node, NodeFileLoadingProtocol
     override public class var nodeTimeMode: Node.TimeMode { .None }
     override public class var nodeDescription: String { "Deprecated two-channel image effect" }
 
-    override public var customName: String? {
+    override public func deriveCustomName() -> String? {
         guard let fileURL = self.url else { return nil }
         return self.fileURLToName(fileURL: fileURL)
     }

--- a/Fabric/Nodes/Deprecated/BaseGeneratorNode.swift
+++ b/Fabric/Nodes/Deprecated/BaseGeneratorNode.swift
@@ -19,7 +19,7 @@ class BaseGeneratorNode: Node, NodeFileLoadingProtocol
     override public class var nodeTimeMode: Node.TimeMode { .None }
     override class var nodeDescription: String { "Deprecated image generator" }
 
-    override public var customName: String? {
+    override public func deriveCustomName() -> String? {
         guard let fileURL = self.url else { return nil }
         return self.fileURLToName(fileURL: fileURL)
     }

--- a/Fabric/Nodes/Deprecated/BaseGeneratorNode.swift
+++ b/Fabric/Nodes/Deprecated/BaseGeneratorNode.swift
@@ -19,7 +19,7 @@ class BaseGeneratorNode: Node, NodeFileLoadingProtocol
     override public class var nodeTimeMode: Node.TimeMode { .None }
     override class var nodeDescription: String { "Deprecated image generator" }
 
-    override public var displayName: String? {
+    override public var customName: String? {
         guard let fileURL = self.url else { return nil }
         return self.fileURLToName(fileURL: fileURL)
     }

--- a/Fabric/Nodes/Deprecated/BaseGeneratorNode.swift
+++ b/Fabric/Nodes/Deprecated/BaseGeneratorNode.swift
@@ -19,7 +19,7 @@ class BaseGeneratorNode: Node, NodeFileLoadingProtocol
     override public class var nodeTimeMode: Node.TimeMode { .None }
     override class var nodeDescription: String { "Deprecated image generator" }
 
-    override public func deriveCustomName() -> String? {
+    override public func deriveSubtitle() -> String? {
         guard let fileURL = self.url else { return nil }
         return self.fileURLToName(fileURL: fileURL)
     }

--- a/Fabric/Nodes/Geometry/MathExpressionParametricGeometryNode.swift
+++ b/Fabric/Nodes/Geometry/MathExpressionParametricGeometryNode.swift
@@ -67,8 +67,8 @@ public class MathExpressionParametricGeometryNode: BaseGeometryNode
 
     /// Shown as the node's title: the three axis expressions, ⚠-prefixed when any
     /// fails to compile. Falls back to the type name when all axes are blank; a
-    /// user `userName` overrides it. Refreshed via nameSubject in parseExpressions().
-    override public func deriveCustomName() -> String? {
+    /// user `userName` overrides it. Refreshed via subtitleSubject in parseExpressions().
+    override public func deriveSubtitle() -> String? {
         let axes = [expressionX, expressionY, expressionZ]
         guard axes.contains(where: { !$0.isEmpty }) else { return nil }
         // Collapse newlines to spaces so the single-line node title reads cleanly.
@@ -261,7 +261,7 @@ public class MathExpressionParametricGeometryNode: BaseGeometryNode
 
         syncVariablePorts()
         _expressionsDirty = true
-        nameSubject.send()
+        subtitleSubject.send()
     }
 
     private func axisExpression(from source: String) -> AxisExpression?

--- a/Fabric/Nodes/Geometry/MathExpressionParametricGeometryNode.swift
+++ b/Fabric/Nodes/Geometry/MathExpressionParametricGeometryNode.swift
@@ -68,7 +68,7 @@ public class MathExpressionParametricGeometryNode: BaseGeometryNode
     /// Shown as the node's title: the three axis expressions, ⚠-prefixed when any
     /// fails to compile. Falls back to the type name when all axes are blank; a
     /// user `userName` overrides it. Refreshed via nameSubject in parseExpressions().
-    override public var customName: String? {
+    override public func deriveCustomName() -> String? {
         let axes = [expressionX, expressionY, expressionZ]
         guard axes.contains(where: { !$0.isEmpty }) else { return nil }
         // Collapse newlines to spaces so the single-line node title reads cleanly.

--- a/Fabric/Nodes/Geometry/MathExpressionParametricGeometryNode.swift
+++ b/Fabric/Nodes/Geometry/MathExpressionParametricGeometryNode.swift
@@ -68,7 +68,7 @@ public class MathExpressionParametricGeometryNode: BaseGeometryNode
     /// Shown as the node's title: the three axis expressions, ⚠-prefixed when any
     /// fails to compile. Falls back to the type name when all axes are blank; a
     /// user `userName` overrides it. Refreshed via nameSubject in parseExpressions().
-    override public var displayName: String? {
+    override public var customName: String? {
         let axes = [expressionX, expressionY, expressionZ]
         guard axes.contains(where: { !$0.isEmpty }) else { return nil }
         // Collapse newlines to spaces so the single-line node title reads cleanly.

--- a/Fabric/Nodes/Image/Analysis/DCTTransformNode.swift
+++ b/Fabric/Nodes/Image/Analysis/DCTTransformNode.swift
@@ -319,8 +319,8 @@ public class BaseDCTTransformNode: Node
                               message: "Could not create DCT Transform compute encoder")
         }
 
-        transformedImage.texture.label = "\(self.title) Output"
-        computeEncoder.label = self.title
+        transformedImage.texture.label = "\(self.debugDescription) Output"
+        computeEncoder.label = self.debugDescription
         computeEncoder.setComputePipelineState(computePipeline)
         computeEncoder.setTexture(sourceTexture, index: 0)
         computeEncoder.setTexture(transformedImage.texture, index: 1)

--- a/Fabric/Nodes/Image/Analysis/DCTTransformNode.swift
+++ b/Fabric/Nodes/Image/Analysis/DCTTransformNode.swift
@@ -319,8 +319,8 @@ public class BaseDCTTransformNode: Node
                               message: "Could not create DCT Transform compute encoder")
         }
 
-        transformedImage.texture.label = "\(name) Output"
-        computeEncoder.label = name
+        transformedImage.texture.label = "\(self.title) Output"
+        computeEncoder.label = self.title
         computeEncoder.setComputePipelineState(computePipeline)
         computeEncoder.setTexture(sourceTexture, index: 0)
         computeEncoder.setTexture(transformedImage.texture, index: 1)

--- a/Fabric/Nodes/Image/Blur/DepthOfFieldNode.swift
+++ b/Fabric/Nodes/Image/Blur/DepthOfFieldNode.swift
@@ -111,9 +111,9 @@ public final class DepthOfFieldNode: Node
         {
             throw FabricError(.execution(.gpu),
                               severity: .recoverable,
-                              message: "Could not create \(name) copy blit encoder")
+                              message: "Could not create \(debugName) copy blit encoder")
         }
-        blitEncoder.label = "\(self.name) Copy"
+        blitEncoder.label = "\(self.typeName) Copy"
         blitEncoder.copy(from: source,
                          sourceSlice: 0,
                          sourceLevel: 0,

--- a/Fabric/Nodes/Image/Blur/DepthOfFieldNode.swift
+++ b/Fabric/Nodes/Image/Blur/DepthOfFieldNode.swift
@@ -111,9 +111,9 @@ public final class DepthOfFieldNode: Node
         {
             throw FabricError(.execution(.gpu),
                               severity: .recoverable,
-                              message: "Could not create \(canonicalName) copy blit encoder")
+                              message: "Could not create \(self) copy blit encoder")
         }
-        blitEncoder.label = "\(self.registryName) Copy"
+        blitEncoder.label = "\(self.canonicalName) Copy"
         blitEncoder.copy(from: source,
                          sourceSlice: 0,
                          sourceLevel: 0,

--- a/Fabric/Nodes/Image/Blur/DepthOfFieldNode.swift
+++ b/Fabric/Nodes/Image/Blur/DepthOfFieldNode.swift
@@ -113,7 +113,7 @@ public final class DepthOfFieldNode: Node
                               severity: .recoverable,
                               message: "Could not create \(canonicalName) copy blit encoder")
         }
-        blitEncoder.label = "\(self.typeName) Copy"
+        blitEncoder.label = "\(self.registryName) Copy"
         blitEncoder.copy(from: source,
                          sourceSlice: 0,
                          sourceLevel: 0,

--- a/Fabric/Nodes/Image/Blur/DepthOfFieldNode.swift
+++ b/Fabric/Nodes/Image/Blur/DepthOfFieldNode.swift
@@ -113,7 +113,7 @@ public final class DepthOfFieldNode: Node
                               severity: .recoverable,
                               message: "Could not create \(self) copy blit encoder")
         }
-        blitEncoder.label = "\(self.canonicalName) Copy"
+        blitEncoder.label = "\(self.title) Copy"
         blitEncoder.copy(from: source,
                          sourceSlice: 0,
                          sourceLevel: 0,

--- a/Fabric/Nodes/Image/Blur/DepthOfFieldNode.swift
+++ b/Fabric/Nodes/Image/Blur/DepthOfFieldNode.swift
@@ -111,7 +111,7 @@ public final class DepthOfFieldNode: Node
         {
             throw FabricError(.execution(.gpu),
                               severity: .recoverable,
-                              message: "Could not create \(debugName) copy blit encoder")
+                              message: "Could not create \(canonicalName) copy blit encoder")
         }
         blitEncoder.label = "\(self.typeName) Copy"
         blitEncoder.copy(from: source,

--- a/Fabric/Nodes/Image/Blur/GaussianBlurChannelsNode.swift
+++ b/Fabric/Nodes/Image/Blur/GaussianBlurChannelsNode.swift
@@ -134,7 +134,7 @@ public final class GaussianBlurChannelsNode: BaseMultiPassBlurEffectTwoChannelNo
                 return nil
             }
 
-            commandBuffer.pushDebugGroup("\(self.registryName) - pass \(index)")
+            commandBuffer.pushDebugGroup("\(self.name) - pass \(index)")
 
             let passUniforms = GaussianPassUniforms(direction: step.vector,
                                                     amountScale: step.amountScale,

--- a/Fabric/Nodes/Image/Blur/GaussianBlurChannelsNode.swift
+++ b/Fabric/Nodes/Image/Blur/GaussianBlurChannelsNode.swift
@@ -134,7 +134,7 @@ public final class GaussianBlurChannelsNode: BaseMultiPassBlurEffectTwoChannelNo
                 return nil
             }
 
-            commandBuffer.pushDebugGroup("\(self.typeName) - pass \(index)")
+            commandBuffer.pushDebugGroup("\(self.registryName) - pass \(index)")
 
             let passUniforms = GaussianPassUniforms(direction: step.vector,
                                                     amountScale: step.amountScale,

--- a/Fabric/Nodes/Image/Blur/GaussianBlurChannelsNode.swift
+++ b/Fabric/Nodes/Image/Blur/GaussianBlurChannelsNode.swift
@@ -134,7 +134,7 @@ public final class GaussianBlurChannelsNode: BaseMultiPassBlurEffectTwoChannelNo
                 return nil
             }
 
-            commandBuffer.pushDebugGroup("\(self.title) - pass \(index)")
+            commandBuffer.pushDebugGroup("\(self.debugDescription) - pass \(index)")
 
             let passUniforms = GaussianPassUniforms(direction: step.vector,
                                                     amountScale: step.amountScale,

--- a/Fabric/Nodes/Image/Blur/GaussianBlurChannelsNode.swift
+++ b/Fabric/Nodes/Image/Blur/GaussianBlurChannelsNode.swift
@@ -134,7 +134,7 @@ public final class GaussianBlurChannelsNode: BaseMultiPassBlurEffectTwoChannelNo
                 return nil
             }
 
-            commandBuffer.pushDebugGroup("\(self.name) - pass \(index)")
+            commandBuffer.pushDebugGroup("\(self.typeName) - pass \(index)")
 
             let passUniforms = GaussianPassUniforms(direction: step.vector,
                                                     amountScale: step.amountScale,

--- a/Fabric/Nodes/Image/Blur/GaussianBlurChannelsNode.swift
+++ b/Fabric/Nodes/Image/Blur/GaussianBlurChannelsNode.swift
@@ -134,7 +134,7 @@ public final class GaussianBlurChannelsNode: BaseMultiPassBlurEffectTwoChannelNo
                 return nil
             }
 
-            commandBuffer.pushDebugGroup("\(self.name) - pass \(index)")
+            commandBuffer.pushDebugGroup("\(self.title) - pass \(index)")
 
             let passUniforms = GaussianPassUniforms(direction: step.vector,
                                                     amountScale: step.amountScale,

--- a/Fabric/Nodes/Image/Blur/PostProcessMotionBlurNode.swift
+++ b/Fabric/Nodes/Image/Blur/PostProcessMotionBlurNode.swift
@@ -94,9 +94,9 @@ public final class PostProcessMotionBlurNode: Node
         {
             throw FabricError(.execution(.gpu),
                               severity: .recoverable,
-                              message: "Could not create \(canonicalName) copy blit encoder")
+                              message: "Could not create \(self) copy blit encoder")
         }
-        blitEncoder.label = "\(self.registryName) Copy"
+        blitEncoder.label = "\(self.canonicalName) Copy"
         blitEncoder.copy(from: source,
                          sourceSlice: 0,
                          sourceLevel: 0,

--- a/Fabric/Nodes/Image/Blur/PostProcessMotionBlurNode.swift
+++ b/Fabric/Nodes/Image/Blur/PostProcessMotionBlurNode.swift
@@ -94,7 +94,7 @@ public final class PostProcessMotionBlurNode: Node
         {
             throw FabricError(.execution(.gpu),
                               severity: .recoverable,
-                              message: "Could not create \(debugName) copy blit encoder")
+                              message: "Could not create \(canonicalName) copy blit encoder")
         }
         blitEncoder.label = "\(self.typeName) Copy"
         blitEncoder.copy(from: source,

--- a/Fabric/Nodes/Image/Blur/PostProcessMotionBlurNode.swift
+++ b/Fabric/Nodes/Image/Blur/PostProcessMotionBlurNode.swift
@@ -96,7 +96,7 @@ public final class PostProcessMotionBlurNode: Node
                               severity: .recoverable,
                               message: "Could not create \(canonicalName) copy blit encoder")
         }
-        blitEncoder.label = "\(self.typeName) Copy"
+        blitEncoder.label = "\(self.registryName) Copy"
         blitEncoder.copy(from: source,
                          sourceSlice: 0,
                          sourceLevel: 0,

--- a/Fabric/Nodes/Image/Blur/PostProcessMotionBlurNode.swift
+++ b/Fabric/Nodes/Image/Blur/PostProcessMotionBlurNode.swift
@@ -94,9 +94,9 @@ public final class PostProcessMotionBlurNode: Node
         {
             throw FabricError(.execution(.gpu),
                               severity: .recoverable,
-                              message: "Could not create \(name) copy blit encoder")
+                              message: "Could not create \(debugName) copy blit encoder")
         }
-        blitEncoder.label = "\(self.name) Copy"
+        blitEncoder.label = "\(self.typeName) Copy"
         blitEncoder.copy(from: source,
                          sourceSlice: 0,
                          sourceLevel: 0,

--- a/Fabric/Nodes/Image/Blur/PostProcessMotionBlurNode.swift
+++ b/Fabric/Nodes/Image/Blur/PostProcessMotionBlurNode.swift
@@ -96,7 +96,7 @@ public final class PostProcessMotionBlurNode: Node
                               severity: .recoverable,
                               message: "Could not create \(self) copy blit encoder")
         }
-        blitEncoder.label = "\(self.canonicalName) Copy"
+        blitEncoder.label = "\(self.title) Copy"
         blitEncoder.copy(from: source,
                          sourceSlice: 0,
                          sourceLevel: 0,

--- a/Fabric/Nodes/Image/Mix/BlendNode.swift
+++ b/Fabric/Nodes/Image/Mix/BlendNode.swift
@@ -20,7 +20,7 @@ public class BlendNode: BaseImageNode
 
     /// BaseImageNode derives a name from its shader file; Blend is always "Blend"
     /// (unless the user renames it, which `userName` handles in the base class).
-    override public var displayName: String? { nil }
+    override public var customName: String? { nil }
 
     override public class var defaultImageInputCountHint: Int? { 2 }
 

--- a/Fabric/Nodes/Image/Mix/BlendNode.swift
+++ b/Fabric/Nodes/Image/Mix/BlendNode.swift
@@ -20,7 +20,7 @@ public class BlendNode: BaseImageNode
 
     /// BaseImageNode derives a name from its shader file; Blend is always "Blend"
     /// (unless the user renames it, which `userName` handles in the base class).
-    override public var customName: String? { nil }
+    override public func deriveCustomName() -> String? { nil }
 
     override public class var defaultImageInputCountHint: Int? { 2 }
 

--- a/Fabric/Nodes/Image/Mix/BlendNode.swift
+++ b/Fabric/Nodes/Image/Mix/BlendNode.swift
@@ -20,7 +20,7 @@ public class BlendNode: BaseImageNode
 
     /// BaseImageNode derives a name from its shader file; Blend is always "Blend"
     /// (unless the user renames it, which `userName` handles in the base class).
-    override public func deriveCustomName() -> String? { nil }
+    override public func deriveSubtitle() -> String? { nil }
 
     override public class var defaultImageInputCountHint: Int? { 2 }
 

--- a/Fabric/Nodes/Image/ScreenCaptureProviderNode.swift
+++ b/Fabric/Nodes/Image/ScreenCaptureProviderNode.swift
@@ -307,8 +307,8 @@ public class ScreenCaptureProviderNode: Node
             for window in windows
             {
                 let appName = window.owningApplication?.applicationName ?? "Unknown App"
-                let title = (window.title?.isEmpty == false) ? window.title! : "Untitled"
-                let option = "\(appName) - \(title)"
+                let windowTitle = (window.title?.isEmpty == false) ? window.title! : "Untitled"
+                let option = "\(appName) - \(windowTitle)"
                 result[option] = .window(window)
             }
 

--- a/Fabric/Nodes/Parameters/Array/Numerics/Array Composition/ComposeVectorArrayNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Numerics/Array Composition/ComposeVectorArrayNode.swift
@@ -20,7 +20,7 @@ public class ComposeVectorArrayNode: StrategyNode
 
     // The vector type is already evident from the component ports, so keep the
     // plain type-name title rather than leading it with the strategy.
-    override public var customName: String? { nil }
+    override public func deriveCustomName() -> String? { nil }
 
     private static let allDynamicNames: Set<String> = [
         "inputComponent0", "inputComponent1", "inputComponent2", "inputComponent3",

--- a/Fabric/Nodes/Parameters/Array/Numerics/Array Composition/ComposeVectorArrayNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Numerics/Array Composition/ComposeVectorArrayNode.swift
@@ -20,7 +20,7 @@ public class ComposeVectorArrayNode: StrategyNode
 
     // The vector type is already evident from the component ports, so keep the
     // plain type-name title rather than leading it with the strategy.
-    override public func deriveCustomName() -> String? { nil }
+    override public func deriveSubtitle() -> String? { nil }
 
     private static let allDynamicNames: Set<String> = [
         "inputComponent0", "inputComponent1", "inputComponent2", "inputComponent3",

--- a/Fabric/Nodes/Parameters/Array/Numerics/Array Composition/ComposeVectorArrayNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Numerics/Array Composition/ComposeVectorArrayNode.swift
@@ -20,7 +20,7 @@ public class ComposeVectorArrayNode: StrategyNode
 
     // The vector type is already evident from the component ports, so keep the
     // plain type-name title rather than leading it with the strategy.
-    override public var displayName: String? { nil }
+    override public var customName: String? { nil }
 
     private static let allDynamicNames: Set<String> = [
         "inputComponent0", "inputComponent1", "inputComponent2", "inputComponent3",

--- a/Fabric/Nodes/Parameters/Array/Numerics/Array Decomposition/DecomposeVectorArrayNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Numerics/Array Decomposition/DecomposeVectorArrayNode.swift
@@ -20,7 +20,7 @@ public class DecomposeVectorArrayNode: StrategyNode
 
     // The vector type is already evident from the component ports, so keep the
     // plain type-name title rather than leading it with the strategy.
-    override public var customName: String? { nil }
+    override public func deriveCustomName() -> String? { nil }
 
     private static let allDynamicNames: Set<String> = [
         "inputArray",

--- a/Fabric/Nodes/Parameters/Array/Numerics/Array Decomposition/DecomposeVectorArrayNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Numerics/Array Decomposition/DecomposeVectorArrayNode.swift
@@ -20,7 +20,7 @@ public class DecomposeVectorArrayNode: StrategyNode
 
     // The vector type is already evident from the component ports, so keep the
     // plain type-name title rather than leading it with the strategy.
-    override public var displayName: String? { nil }
+    override public var customName: String? { nil }
 
     private static let allDynamicNames: Set<String> = [
         "inputArray",

--- a/Fabric/Nodes/Parameters/Array/Numerics/Array Decomposition/DecomposeVectorArrayNode.swift
+++ b/Fabric/Nodes/Parameters/Array/Numerics/Array Decomposition/DecomposeVectorArrayNode.swift
@@ -20,7 +20,7 @@ public class DecomposeVectorArrayNode: StrategyNode
 
     // The vector type is already evident from the component ports, so keep the
     // plain type-name title rather than leading it with the strategy.
-    override public func deriveCustomName() -> String? { nil }
+    override public func deriveSubtitle() -> String? { nil }
 
     private static let allDynamicNames: Set<String> = [
         "inputArray",

--- a/Fabric/Nodes/Parameters/IO/GameControllerNode.swift
+++ b/Fabric/Nodes/Parameters/IO/GameControllerNode.swift
@@ -104,7 +104,7 @@ public class GameControllerNode: Node
     override public class var nodeDescription: String { "Read input from game controllers with semantic button names" }
 
     // Dynamic node name based on selected controller
-    override public func deriveCustomName() -> String?
+    override public func deriveSubtitle() -> String?
     {
         if let controllerID = selectedControllerID,
            let controller = availableControllers.first(where: { $0.id == controllerID })
@@ -163,8 +163,8 @@ public class GameControllerNode: Node
             setupController()
             _settingsModelStorage?.selectedControllerID = selectedControllerID
             _settingsModelStorage?.outputPortCount = outputPorts().count
-            // `customName` is derived from the selected controller; notify so the title refreshes.
-            self.nameSubject.send()
+            // `subtitle` is derived from the selected controller; notify so the title refreshes.
+            self.subtitleSubject.send()
         }
     }
 
@@ -282,8 +282,8 @@ public class GameControllerNode: Node
         }
 
         _settingsModelStorage?.availableControllers = availableControllers
-        // `customName` resolves against the controller list; notify so the title refreshes.
-        self.nameSubject.send()
+        // `subtitle` resolves against the controller list; notify so the title refreshes.
+        self.subtitleSubject.send()
 
         print("[GameController] Found \(availableControllers.count) controllers:")
         for info in availableControllers

--- a/Fabric/Nodes/Parameters/IO/GameControllerNode.swift
+++ b/Fabric/Nodes/Parameters/IO/GameControllerNode.swift
@@ -282,6 +282,8 @@ public class GameControllerNode: Node
         }
 
         _settingsModelStorage?.availableControllers = availableControllers
+        // `customName` resolves against the controller list; notify so the title refreshes.
+        self.nameSubject.send()
 
         print("[GameController] Found \(availableControllers.count) controllers:")
         for info in availableControllers

--- a/Fabric/Nodes/Parameters/IO/GameControllerNode.swift
+++ b/Fabric/Nodes/Parameters/IO/GameControllerNode.swift
@@ -104,7 +104,7 @@ public class GameControllerNode: Node
     override public class var nodeDescription: String { "Read input from game controllers with semantic button names" }
 
     // Dynamic node name based on selected controller
-    override public var customName: String?
+    override public func deriveCustomName() -> String?
     {
         if let controllerID = selectedControllerID,
            let controller = availableControllers.first(where: { $0.id == controllerID })

--- a/Fabric/Nodes/Parameters/IO/GameControllerNode.swift
+++ b/Fabric/Nodes/Parameters/IO/GameControllerNode.swift
@@ -104,7 +104,7 @@ public class GameControllerNode: Node
     override public class var nodeDescription: String { "Read input from game controllers with semantic button names" }
 
     // Dynamic node name based on selected controller
-    override public var displayName: String?
+    override public var customName: String?
     {
         if let controllerID = selectedControllerID,
            let controller = availableControllers.first(where: { $0.id == controllerID })
@@ -163,7 +163,7 @@ public class GameControllerNode: Node
             setupController()
             _settingsModelStorage?.selectedControllerID = selectedControllerID
             _settingsModelStorage?.outputPortCount = outputPorts().count
-            // `displayName` is derived from the selected controller; notify so the title refreshes.
+            // `customName` is derived from the selected controller; notify so the title refreshes.
             self.nameSubject.send()
         }
     }

--- a/Fabric/Nodes/Parameters/IO/MIDIInputNode.swift
+++ b/Fabric/Nodes/Parameters/IO/MIDIInputNode.swift
@@ -317,7 +317,7 @@ public class MIDIInputNode: Node
     override public class var nodeDescription: String { "Receive MIDI messages from external devices" }
 
     // Dynamic node name based on selected input
-    override public var customName: String?
+    override public func deriveCustomName() -> String?
     {
         if let inputID = selectedInputID,
            let input = availableInputs.first(where: { $0.id == inputID })

--- a/Fabric/Nodes/Parameters/IO/MIDIInputNode.swift
+++ b/Fabric/Nodes/Parameters/IO/MIDIInputNode.swift
@@ -515,6 +515,8 @@ public class MIDIInputNode: Node
         }
 
         _settingsModelStorage?.availableInputs = availableInputs
+        // `customName` resolves against the input list; notify so the title refreshes.
+        self.nameSubject.send()
 
         print("[MIDI] Found \(availableInputs.count) MIDI sources:")
         for input in availableInputs

--- a/Fabric/Nodes/Parameters/IO/MIDIInputNode.swift
+++ b/Fabric/Nodes/Parameters/IO/MIDIInputNode.swift
@@ -317,7 +317,7 @@ public class MIDIInputNode: Node
     override public class var nodeDescription: String { "Receive MIDI messages from external devices" }
 
     // Dynamic node name based on selected input
-    override public func deriveCustomName() -> String?
+    override public func deriveSubtitle() -> String?
     {
         if let inputID = selectedInputID,
            let input = availableInputs.first(where: { $0.id == inputID })
@@ -381,8 +381,8 @@ public class MIDIInputNode: Node
         {
             setupMIDIConnection()
             _settingsModelStorage?.selectedInputID = selectedInputID
-            // `customName` is derived from the selected input; notify so the title refreshes.
-            self.nameSubject.send()
+            // `subtitle` is derived from the selected input; notify so the title refreshes.
+            self.subtitleSubject.send()
         }
     }
 
@@ -515,8 +515,8 @@ public class MIDIInputNode: Node
         }
 
         _settingsModelStorage?.availableInputs = availableInputs
-        // `customName` resolves against the input list; notify so the title refreshes.
-        self.nameSubject.send()
+        // `subtitle` resolves against the input list; notify so the title refreshes.
+        self.subtitleSubject.send()
 
         print("[MIDI] Found \(availableInputs.count) MIDI sources:")
         for input in availableInputs

--- a/Fabric/Nodes/Parameters/IO/MIDIInputNode.swift
+++ b/Fabric/Nodes/Parameters/IO/MIDIInputNode.swift
@@ -317,7 +317,7 @@ public class MIDIInputNode: Node
     override public class var nodeDescription: String { "Receive MIDI messages from external devices" }
 
     // Dynamic node name based on selected input
-    override public var displayName: String?
+    override public var customName: String?
     {
         if let inputID = selectedInputID,
            let input = availableInputs.first(where: { $0.id == inputID })
@@ -381,7 +381,7 @@ public class MIDIInputNode: Node
         {
             setupMIDIConnection()
             _settingsModelStorage?.selectedInputID = selectedInputID
-            // `displayName` is derived from the selected input; notify so the title refreshes.
+            // `customName` is derived from the selected input; notify so the title refreshes.
             self.nameSubject.send()
         }
     }

--- a/Fabric/Nodes/Parameters/Number/MathExpressionNode.swift
+++ b/Fabric/Nodes/Parameters/Number/MathExpressionNode.swift
@@ -190,7 +190,7 @@ public class MathExpressionNode: Node
 
     /// Shown as the node's title: the expression, or a ⚠-prefixed form on error.
     /// nil (empty) falls back to the type name; a user `userName` overrides this.
-    override public var customName: String? { evaluatedCustomName.isEmpty ? nil : evaluatedCustomName }
+    override public func deriveCustomName() -> String? { evaluatedCustomName }
     private var evaluatedCustomName: String = ""
 
     /// Extracts the salient part of a (possibly multi-statement) expression for

--- a/Fabric/Nodes/Parameters/Number/MathExpressionNode.swift
+++ b/Fabric/Nodes/Parameters/Number/MathExpressionNode.swift
@@ -190,8 +190,8 @@ public class MathExpressionNode: Node
 
     /// Shown as the node's title: the expression, or a ⚠-prefixed form on error.
     /// nil (empty) falls back to the type name; a user `userName` overrides this.
-    override public var displayName: String? { evaluatedDisplayName.isEmpty ? nil : evaluatedDisplayName }
-    private var evaluatedDisplayName: String = ""
+    override public var customName: String? { evaluatedCustomName.isEmpty ? nil : evaluatedCustomName }
+    private var evaluatedCustomName: String = ""
 
     /// Extracts the salient part of a (possibly multi-statement) expression for
     /// use as the node title. A leading `//` comment is taken verbatim as an
@@ -419,8 +419,8 @@ public class MathExpressionNode: Node
         let hasError = result.diagnostics.contains { $0.severity == .error }
         let title = Self.salientTitle(from: self.stringExpression)
         // An empty title with an error would otherwise render as a bare "⚠ "
-        // — non-empty, so displayName's type-name fallback never kicks in.
-        self.evaluatedDisplayName = switch (hasError, title.isEmpty)
+        // — non-empty, so customName's type-name fallback never kicks in.
+        self.evaluatedCustomName = switch (hasError, title.isEmpty)
         {
             case (true, true):  "⚠ \(Self.name)"
             case (true, false): "⚠ \(title)"

--- a/Fabric/Nodes/Parameters/Number/MathExpressionNode.swift
+++ b/Fabric/Nodes/Parameters/Number/MathExpressionNode.swift
@@ -190,8 +190,8 @@ public class MathExpressionNode: Node
 
     /// Shown as the node's title: the expression, or a ⚠-prefixed form on error.
     /// nil (empty) falls back to the type name; a user `userName` overrides this.
-    override public func deriveCustomName() -> String? { evaluatedCustomName }
-    private var evaluatedCustomName: String = ""
+    override public func deriveSubtitle() -> String? { evaluatedSubtitle }
+    private var evaluatedSubtitle: String = ""
 
     /// Extracts the salient part of a (possibly multi-statement) expression for
     /// use as the node title. A leading `//` comment is taken verbatim as an
@@ -417,14 +417,14 @@ public class MathExpressionNode: Node
         }
 
         let hasError = result.diagnostics.contains { $0.severity == .error }
-        let title = Self.salientTitle(from: self.stringExpression)
+        let salientTitle = Self.salientTitle(from: self.stringExpression)
         // An empty title with an error would otherwise render as a bare "⚠ "
-        // — non-empty, so customName's type-name fallback never kicks in.
-        self.evaluatedCustomName = switch (hasError, title.isEmpty)
+        // — non-empty, so subtitle's type-name fallback never kicks in.
+        self.evaluatedSubtitle = switch (hasError, salientTitle.isEmpty)
         {
             case (true, true):  "⚠ \(Self.name)"
-            case (true, false): "⚠ \(title)"
-            case (false, _):    title
+            case (true, false): "⚠ \(salientTitle)"
+            case (false, _):    salientTitle
         }
 
         // Keep the settings model mirroring the node, not just model → node.
@@ -434,7 +434,7 @@ public class MathExpressionNode: Node
             self._settingsModel.stringExpression = self.stringExpression
         }
         self._settingsModel.diagnostics = result.diagnostics
-        self.nameSubject.send()
+        self.subtitleSubject.send()
     }
 
     /// Diff the compiled interface against the current dynamic ports, adding,

--- a/Fabric/Nodes/Parameters/NumericTypeAgnosticNode.swift
+++ b/Fabric/Nodes/Parameters/NumericTypeAgnosticNode.swift
@@ -56,7 +56,7 @@ public class NumericTypeAgnosticNode: StrategyNode
     /// "Float Tween" (NodeTitleView appends the type name after it). NumericVirtual
     /// — the no-configuration default — suppresses the token so the node reads as
     /// its plain type name.
-    override public func deriveCustomName() -> String? {
+    override public func deriveSubtitle() -> String? {
         let portType = selectedNumericPortType
         return portType == .NumericVirtual ? nil : portType.rawValue
     }

--- a/Fabric/Nodes/Parameters/NumericTypeAgnosticNode.swift
+++ b/Fabric/Nodes/Parameters/NumericTypeAgnosticNode.swift
@@ -56,7 +56,7 @@ public class NumericTypeAgnosticNode: StrategyNode
     /// "Float Tween" (NodeTitleView appends the type name after it). NumericVirtual
     /// — the no-configuration default — suppresses the token so the node reads as
     /// its plain type name.
-    override public var customName: String? {
+    override public func deriveCustomName() -> String? {
         let portType = selectedNumericPortType
         return portType == .NumericVirtual ? nil : portType.rawValue
     }

--- a/Fabric/Nodes/Parameters/NumericTypeAgnosticNode.swift
+++ b/Fabric/Nodes/Parameters/NumericTypeAgnosticNode.swift
@@ -56,7 +56,7 @@ public class NumericTypeAgnosticNode: StrategyNode
     /// "Float Tween" (NodeTitleView appends the type name after it). NumericVirtual
     /// — the no-configuration default — suppresses the token so the node reads as
     /// its plain type name.
-    override public var displayName: String? {
+    override public var customName: String? {
         let portType = selectedNumericPortType
         return portType == .NumericVirtual ? nil : portType.rawValue
     }

--- a/Fabric/Nodes/Parameters/StrategyNode.swift
+++ b/Fabric/Nodes/Parameters/StrategyNode.swift
@@ -106,16 +106,16 @@ public class StrategyNode: Node
     /// When true, the picker inserts a visual separator after the first strategy in the list.
     public class var separatorAfterFirstStrategy: Bool { false }
 
-    /// Standard behaviour: the node-generated `displayName` is the active strategy,
+    /// Standard behaviour: the node-generated `customName` is the active strategy,
     /// e.g. "vec3" for "Vector Compose", or "Random" for "Number Generator".
     /// `NodeTitleView` renders the type name after it (yielding "vec3 Vector
     /// Compose"), so the strategy must not repeat it. An unrecognised strategy
     /// (e.g. a legacy or renamed case) falls back to the plain type name.
     ///
-    /// Subclasses wanting a different title override `displayName` directly: return
+    /// Subclasses wanting a different title override `customName` directly: return
     /// nil for the plain type-name title, or a bespoke string — as the type-agnostic
     /// nodes do, suppressing the token for their Virtual default.
-    override public var displayName: String?
+    override public var customName: String?
     {
         Self.strategies.contains(strategy) ? strategy : nil
     }
@@ -138,7 +138,7 @@ public class StrategyNode: Node
         didSet
         {
             self.rebuildPorts(forStrategy: strategy)
-            // `displayName` is derived from `strategy`; notify so the title refreshes.
+            // `customName` is derived from `strategy`; notify so the title refreshes.
             self.nameSubject.send()
         }
     }

--- a/Fabric/Nodes/Parameters/StrategyNode.swift
+++ b/Fabric/Nodes/Parameters/StrategyNode.swift
@@ -112,10 +112,10 @@ public class StrategyNode: Node
     /// Compose"), so the strategy must not repeat it. An unrecognised strategy
     /// (e.g. a legacy or renamed case) falls back to the plain type name.
     ///
-    /// Subclasses wanting a different title override `customName` directly: return
-    /// nil for the plain type-name title, or a bespoke string — as the type-agnostic
-    /// nodes do, suppressing the token for their Virtual default.
-    override public var customName: String?
+    /// Subclasses wanting a different title override `deriveCustomName()` directly:
+    /// return nil for the plain type-name title, or a bespoke string — as the
+    /// type-agnostic nodes do, suppressing the token for their Virtual default.
+    override public func deriveCustomName() -> String?
     {
         Self.strategies.contains(strategy) ? strategy : nil
     }

--- a/Fabric/Nodes/Parameters/StrategyNode.swift
+++ b/Fabric/Nodes/Parameters/StrategyNode.swift
@@ -106,16 +106,16 @@ public class StrategyNode: Node
     /// When true, the picker inserts a visual separator after the first strategy in the list.
     public class var separatorAfterFirstStrategy: Bool { false }
 
-    /// Standard behaviour: the node-generated `customName` is the active strategy,
+    /// Standard behaviour: the node-generated `subtitle` is the active strategy,
     /// e.g. "vec3" for "Vector Compose", or "Random" for "Number Generator".
     /// `NodeTitleView` renders the type name after it (yielding "vec3 Vector
     /// Compose"), so the strategy must not repeat it. An unrecognised strategy
     /// (e.g. a legacy or renamed case) falls back to the plain type name.
     ///
-    /// Subclasses wanting a different title override `deriveCustomName()` directly:
+    /// Subclasses wanting a different title override `deriveSubtitle()` directly:
     /// return nil for the plain type-name title, or a bespoke string — as the
     /// type-agnostic nodes do, suppressing the token for their Virtual default.
-    override public func deriveCustomName() -> String?
+    override public func deriveSubtitle() -> String?
     {
         Self.strategies.contains(strategy) ? strategy : nil
     }
@@ -138,8 +138,8 @@ public class StrategyNode: Node
         didSet
         {
             self.rebuildPorts(forStrategy: strategy)
-            // `customName` is derived from `strategy`; notify so the title refreshes.
-            self.nameSubject.send()
+            // `subtitle` is derived from `strategy`; notify so the title refreshes.
+            self.subtitleSubject.send()
         }
     }
 

--- a/Fabric/Nodes/Parameters/String/BaseFormatStringNode.swift
+++ b/Fabric/Nodes/Parameters/String/BaseFormatStringNode.swift
@@ -91,7 +91,7 @@ public class BaseFormatStringNode: Node {
     /// The current format string, parsed. Rebuilt only when it changes.
     private(set) var parsedFormatString = ParsedFormatString(tokens: [])
 
-    override public var customName: String? { formatString.isEmpty ? nil : formatString }
+    override public func deriveCustomName() -> String? { formatString }
 
     // MARK: - Init
 

--- a/Fabric/Nodes/Parameters/String/BaseFormatStringNode.swift
+++ b/Fabric/Nodes/Parameters/String/BaseFormatStringNode.swift
@@ -77,7 +77,7 @@ public class BaseFormatStringNode: Node {
     public fileprivate(set) var formatString: String {
         didSet {
             self.updatePorts()
-            self.nameSubject.send()
+            self.subtitleSubject.send()
         }
     }
 
@@ -91,7 +91,7 @@ public class BaseFormatStringNode: Node {
     /// The current format string, parsed. Rebuilt only when it changes.
     private(set) var parsedFormatString = ParsedFormatString(tokens: [])
 
-    override public func deriveCustomName() -> String? { formatString }
+    override public func deriveSubtitle() -> String? { formatString }
 
     // MARK: - Init
 

--- a/Fabric/Nodes/Parameters/String/BaseFormatStringNode.swift
+++ b/Fabric/Nodes/Parameters/String/BaseFormatStringNode.swift
@@ -91,7 +91,7 @@ public class BaseFormatStringNode: Node {
     /// The current format string, parsed. Rebuilt only when it changes.
     private(set) var parsedFormatString = ParsedFormatString(tokens: [])
 
-    override public var displayName: String? { formatString.isEmpty ? nil : formatString }
+    override public var customName: String? { formatString.isEmpty ? nil : formatString }
 
     // MARK: - Init
 

--- a/Fabric/Nodes/Parameters/TypeAgnosticNode.swift
+++ b/Fabric/Nodes/Parameters/TypeAgnosticNode.swift
@@ -42,7 +42,7 @@ public class TypeAgnosticNode: StrategyNode
     /// Sample and Hold" (NodeTitleView appends the type name after it). Virtual —
     /// the no-configuration default — suppresses the token so the node reads as its
     /// plain type name.
-    override public var displayName: String? {
+    override public var customName: String? {
         let portType = selectedPortType
         return portType == .Virtual ? nil : portType.rawValue
     }

--- a/Fabric/Nodes/Parameters/TypeAgnosticNode.swift
+++ b/Fabric/Nodes/Parameters/TypeAgnosticNode.swift
@@ -42,7 +42,7 @@ public class TypeAgnosticNode: StrategyNode
     /// Sample and Hold" (NodeTitleView appends the type name after it). Virtual —
     /// the no-configuration default — suppresses the token so the node reads as its
     /// plain type name.
-    override public func deriveCustomName() -> String? {
+    override public func deriveSubtitle() -> String? {
         let portType = selectedPortType
         return portType == .Virtual ? nil : portType.rawValue
     }

--- a/Fabric/Nodes/Parameters/TypeAgnosticNode.swift
+++ b/Fabric/Nodes/Parameters/TypeAgnosticNode.swift
@@ -42,7 +42,7 @@ public class TypeAgnosticNode: StrategyNode
     /// Sample and Hold" (NodeTitleView appends the type name after it). Virtual —
     /// the no-configuration default — suppresses the token so the node reads as its
     /// plain type name.
-    override public var customName: String? {
+    override public func deriveCustomName() -> String? {
         let portType = selectedPortType
         return portType == .Virtual ? nil : portType.rawValue
     }

--- a/Fabric/Nodes/Parameters/Vector/ComposeVectorNode.swift
+++ b/Fabric/Nodes/Parameters/Vector/ComposeVectorNode.swift
@@ -20,7 +20,7 @@ public class ComposeVectorNode: StrategyNode
 
     // The vector type is already evident from the component ports, so keep the
     // plain type-name title rather than leading it with the strategy.
-    override public var customName: String? { nil }
+    override public func deriveCustomName() -> String? { nil }
 
     private static let allDynamicNames: Set<String> = [
         "inputComponent0", "inputComponent1", "inputComponent2", "inputComponent3",

--- a/Fabric/Nodes/Parameters/Vector/ComposeVectorNode.swift
+++ b/Fabric/Nodes/Parameters/Vector/ComposeVectorNode.swift
@@ -20,7 +20,7 @@ public class ComposeVectorNode: StrategyNode
 
     // The vector type is already evident from the component ports, so keep the
     // plain type-name title rather than leading it with the strategy.
-    override public var displayName: String? { nil }
+    override public var customName: String? { nil }
 
     private static let allDynamicNames: Set<String> = [
         "inputComponent0", "inputComponent1", "inputComponent2", "inputComponent3",

--- a/Fabric/Nodes/Parameters/Vector/ComposeVectorNode.swift
+++ b/Fabric/Nodes/Parameters/Vector/ComposeVectorNode.swift
@@ -20,7 +20,7 @@ public class ComposeVectorNode: StrategyNode
 
     // The vector type is already evident from the component ports, so keep the
     // plain type-name title rather than leading it with the strategy.
-    override public func deriveCustomName() -> String? { nil }
+    override public func deriveSubtitle() -> String? { nil }
 
     private static let allDynamicNames: Set<String> = [
         "inputComponent0", "inputComponent1", "inputComponent2", "inputComponent3",

--- a/Fabric/Nodes/Parameters/Vector/DecomposeVectorNode.swift
+++ b/Fabric/Nodes/Parameters/Vector/DecomposeVectorNode.swift
@@ -20,7 +20,7 @@ public class DecomposeVectorNode: StrategyNode
 
     // The vector type is already evident from the component ports, so keep the
     // plain type-name title rather than leading it with the strategy.
-    override public func deriveCustomName() -> String? { nil }
+    override public func deriveSubtitle() -> String? { nil }
 
     private static let allDynamicNames: Set<String> = [
         "inputVector",

--- a/Fabric/Nodes/Parameters/Vector/DecomposeVectorNode.swift
+++ b/Fabric/Nodes/Parameters/Vector/DecomposeVectorNode.swift
@@ -20,7 +20,7 @@ public class DecomposeVectorNode: StrategyNode
 
     // The vector type is already evident from the component ports, so keep the
     // plain type-name title rather than leading it with the strategy.
-    override public var customName: String? { nil }
+    override public func deriveCustomName() -> String? { nil }
 
     private static let allDynamicNames: Set<String> = [
         "inputVector",

--- a/Fabric/Nodes/Parameters/Vector/DecomposeVectorNode.swift
+++ b/Fabric/Nodes/Parameters/Vector/DecomposeVectorNode.swift
@@ -20,7 +20,7 @@ public class DecomposeVectorNode: StrategyNode
 
     // The vector type is already evident from the component ports, so keep the
     // plain type-name title rather than leading it with the strategy.
-    override public var displayName: String? { nil }
+    override public var customName: String? { nil }
 
     private static let allDynamicNames: Set<String> = [
         "inputVector",

--- a/Fabric/Nodes/Utility/LogNode.swift
+++ b/Fabric/Nodes/Utility/LogNode.swift
@@ -65,7 +65,7 @@ public class LogNode : Node
         if self.inputAny.valueDidChange,
            let value = self.inputAny.value
         {
-            print("\(self.debugName) - Frame \(executionInfo.timing.frameNumber): \(self.inputAny.portType.fullString(for: value))" )
+            print("\(self.canonicalName) - Frame \(executionInfo.timing.frameNumber): \(self.inputAny.portType.fullString(for: value))" )
         }
     }
 }

--- a/Fabric/Nodes/Utility/LogNode.swift
+++ b/Fabric/Nodes/Utility/LogNode.swift
@@ -65,7 +65,7 @@ public class LogNode : Node
         if self.inputAny.valueDidChange,
            let value = self.inputAny.value
         {
-            print("\(self.name) - Frame \(executionInfo.timing.frameNumber): \(self.inputAny.portType.fullString(for: value))" )
+            print("\(self.debugName) - Frame \(executionInfo.timing.frameNumber): \(self.inputAny.portType.fullString(for: value))" )
         }
     }
 }

--- a/Fabric/Nodes/Utility/LogNode.swift
+++ b/Fabric/Nodes/Utility/LogNode.swift
@@ -65,7 +65,7 @@ public class LogNode : Node
         if self.inputAny.valueDidChange,
            let value = self.inputAny.value
         {
-            print("\(self.canonicalName) - Frame \(executionInfo.timing.frameNumber): \(self.inputAny.portType.fullString(for: value))" )
+            print("\(self) - Frame \(executionInfo.timing.frameNumber): \(self.inputAny.portType.fullString(for: value))" )
         }
     }
 }

--- a/Fabric/Views/NodeSelectionInspector.swift
+++ b/Fabric/Views/NodeSelectionInspector.swift
@@ -106,12 +106,12 @@ private struct SelectedNodeCard: View
         {
             VStack(alignment: .leading) {
                 Text(customLabel).foregroundStyle(.primary).bold()
-                Text(nodeViewModel.typeName).foregroundStyle(.secondary).bold()
+                Text(nodeViewModel.registryName).foregroundStyle(.secondary).bold()
             }
         }
         else
         {
-            Text(nodeViewModel.typeName).foregroundStyle(.primary).bold()
+            Text(nodeViewModel.registryName).foregroundStyle(.primary).bold()
         }
     }
 }

--- a/Fabric/Views/NodeSelectionInspector.swift
+++ b/Fabric/Views/NodeSelectionInspector.swift
@@ -102,10 +102,10 @@ private struct SelectedNodeCard: View
 
     @ViewBuilder private var label: some View
     {
-        if nodeViewModel.hasCustomLabel
+        if let customLabel = nodeViewModel.customLabel
         {
             VStack(alignment: .leading) {
-                Text(nodeViewModel.name).foregroundStyle(.primary).bold()
+                Text(customLabel).foregroundStyle(.primary).bold()
                 Text(nodeViewModel.typeName).foregroundStyle(.secondary).bold()
             }
         }

--- a/Fabric/Views/NodeSelectionInspector.swift
+++ b/Fabric/Views/NodeSelectionInspector.swift
@@ -102,16 +102,16 @@ private struct SelectedNodeCard: View
 
     @ViewBuilder private var label: some View
     {
-        if let customLabel = nodeViewModel.customLabel
+        if let titleLabel = nodeViewModel.titleLabel
         {
             VStack(alignment: .leading) {
-                Text(customLabel).foregroundStyle(.primary).bold()
-                Text(nodeViewModel.registryName).foregroundStyle(.secondary).bold()
+                Text(titleLabel).foregroundStyle(.primary).bold()
+                Text(nodeViewModel.canonicalName).foregroundStyle(.secondary).bold()
             }
         }
         else
         {
-            Text(nodeViewModel.registryName).foregroundStyle(.primary).bold()
+            Text(nodeViewModel.canonicalName).foregroundStyle(.primary).bold()
         }
     }
 }

--- a/Fabric/Views/NodeSelectionInspector.swift
+++ b/Fabric/Views/NodeSelectionInspector.swift
@@ -102,16 +102,16 @@ private struct SelectedNodeCard: View
 
     @ViewBuilder private var label: some View
     {
-        if let titleLabel = nodeViewModel.titleLabel
+        if let subtitle = nodeViewModel.subtitle
         {
             VStack(alignment: .leading) {
-                Text(titleLabel).foregroundStyle(.primary).bold()
-                Text(nodeViewModel.canonicalName).foregroundStyle(.secondary).bold()
+                Text(subtitle).foregroundStyle(.primary).bold()
+                Text(nodeViewModel.title).foregroundStyle(.secondary).bold()
             }
         }
         else
         {
-            Text(nodeViewModel.canonicalName).foregroundStyle(.primary).bold()
+            Text(nodeViewModel.title).foregroundStyle(.primary).bold()
         }
     }
 }

--- a/Fabric/Views/Nodes/NodeSettingView.swift
+++ b/Fabric/Views/Nodes/NodeSettingView.swift
@@ -20,7 +20,7 @@ struct NodeSettingView: View
         {
             HStack()
             {
-                Text("\(nodeViewModel.registryName) Settings")
+                Text("\(nodeViewModel.canonicalName) Settings")
                     .lineLimit(1)
                     .font(.system(size: 10))
                     .bold()

--- a/Fabric/Views/Nodes/NodeSettingView.swift
+++ b/Fabric/Views/Nodes/NodeSettingView.swift
@@ -20,7 +20,7 @@ struct NodeSettingView: View
         {
             HStack()
             {
-                Text("\(type(of: nodeViewModel.node).name) Settings")
+                Text("\(nodeViewModel.registryName) Settings")
                     .lineLimit(1)
                     .font(.system(size: 10))
                     .bold()

--- a/Fabric/Views/Nodes/NodeSettingView.swift
+++ b/Fabric/Views/Nodes/NodeSettingView.swift
@@ -20,7 +20,7 @@ struct NodeSettingView: View
         {
             HStack()
             {
-                Text("\(nodeViewModel.canonicalName) Settings")
+                Text("\(nodeViewModel.title) Settings")
                     .lineLimit(1)
                     .font(.system(size: 10))
                     .bold()

--- a/Fabric/Views/Nodes/NodeTitleView.swift
+++ b/Fabric/Views/Nodes/NodeTitleView.swift
@@ -15,7 +15,7 @@ struct NodeTitleView: View
     @State private var renamingText: String = ""
     @FocusState private var renameFieldFocused: Bool
 
-    private var typeName: String { nodeViewModel.typeName }
+    private var registryName: String { nodeViewModel.registryName }
 
     // Nil when the node has neither a rename nor a generated name, so the title
     // is its type name alone.
@@ -64,7 +64,7 @@ struct NodeTitleView: View
                             renaming = false
                         }
 
-                    Text(verbatim: " \(typeName)")
+                    Text(verbatim: " \(registryName)")
                         .font(.system(size: 9))
                         .bold()
                         .foregroundStyle(secondaryColor)
@@ -76,14 +76,14 @@ struct NodeTitleView: View
                 // copy — the literal-interpolation initializer would do a doomed
                 // localization lookup on every render.
                 let primary = Text(primaryLabel).foregroundStyle(.white)
-                let secondary = Text(verbatim: " \(typeName)").foregroundStyle(secondaryColor)
+                let secondary = Text(verbatim: " \(registryName)").foregroundStyle(secondaryColor)
                 (primary + secondary)
                     .font(.system(size: 9))
                     .bold()
             }
             else
             {
-                Text(typeName)
+                Text(registryName)
                     .font(.system(size: 9))
                     .bold()
                     .foregroundStyle(nodeViewModel.nodeType.color())

--- a/Fabric/Views/Nodes/NodeTitleView.swift
+++ b/Fabric/Views/Nodes/NodeTitleView.swift
@@ -51,7 +51,10 @@ struct NodeTitleView: View
             {
                 HStack(spacing: 0)
                 {
-                    TextField(nodeViewModel.name, text: $renamingText)
+                    // Placeholder previews the empty-commit outcome: with no
+                    // rename, customLabel (the node-generated name) shows; the
+                    // registry name already follows as the suffix Text.
+                    TextField(nodeViewModel.customLabel ?? "", text: $renamingText)
                         .textFieldStyle(.plain)
                         .focused($renameFieldFocused)
                         .font(.system(size: 9))

--- a/Fabric/Views/Nodes/NodeTitleView.swift
+++ b/Fabric/Views/Nodes/NodeTitleView.swift
@@ -17,10 +17,9 @@ struct NodeTitleView: View
 
     private var typeName: String { nodeViewModel.typeName }
 
-    private var hasPrimaryLabel: Bool { nodeViewModel.hasCustomLabel }
-
-    // `name` already resolves userName ?? node-generated displayName ?? typeName.
-    private var primaryLabel: String { nodeViewModel.name }
+    // Nil when the node has neither a rename nor a generated name, so the title
+    // is its type name alone.
+    private var primaryLabel: String? { nodeViewModel.customLabel }
 
     /// Opaque across the title, fading to clear over the last ~1 character so an
     /// over-long title dissolves at the node's right edge rather than hard-clipping.
@@ -71,7 +70,7 @@ struct NodeTitleView: View
                         .foregroundStyle(secondaryColor)
                 }
             }
-            else if hasPrimaryLabel
+            else if let primaryLabel
             {
                 // Text(verbatim:) + concatenation: these are data strings, not UI
                 // copy — the literal-interpolation initializer would do a doomed

--- a/Fabric/Views/Nodes/NodeTitleView.swift
+++ b/Fabric/Views/Nodes/NodeTitleView.swift
@@ -15,11 +15,11 @@ struct NodeTitleView: View
     @State private var renamingText: String = ""
     @FocusState private var renameFieldFocused: Bool
 
-    private var registryName: String { nodeViewModel.registryName }
+    private var canonicalName: String { nodeViewModel.canonicalName }
 
     // Nil when the node has neither a rename nor a generated name, so the title
     // is its type name alone.
-    private var primaryLabel: String? { nodeViewModel.customLabel }
+    private var primaryLabel: String? { nodeViewModel.titleLabel }
 
     /// Opaque across the title, fading to clear over the last ~1 character so an
     /// over-long title dissolves at the node's right edge rather than hard-clipping.
@@ -52,9 +52,9 @@ struct NodeTitleView: View
                 HStack(spacing: 0)
                 {
                     // Placeholder previews the empty-commit outcome: with no
-                    // rename, customLabel (the node-generated name) shows; the
-                    // registry name already follows as the suffix Text.
-                    TextField(nodeViewModel.customLabel ?? "", text: $renamingText)
+                    // rename, titleLabel (the node's own subtitle) shows; the
+                    // canonical name already follows as the suffix Text.
+                    TextField(nodeViewModel.titleLabel ?? "", text: $renamingText)
                         .textFieldStyle(.plain)
                         .focused($renameFieldFocused)
                         .font(.system(size: 9))
@@ -67,7 +67,7 @@ struct NodeTitleView: View
                             renaming = false
                         }
 
-                    Text(verbatim: " \(registryName)")
+                    Text(verbatim: " \(canonicalName)")
                         .font(.system(size: 9))
                         .bold()
                         .foregroundStyle(secondaryColor)
@@ -79,14 +79,14 @@ struct NodeTitleView: View
                 // copy — the literal-interpolation initializer would do a doomed
                 // localization lookup on every render.
                 let primary = Text(primaryLabel).foregroundStyle(.white)
-                let secondary = Text(verbatim: " \(registryName)").foregroundStyle(secondaryColor)
+                let secondary = Text(verbatim: " \(canonicalName)").foregroundStyle(secondaryColor)
                 (primary + secondary)
                     .font(.system(size: 9))
                     .bold()
             }
             else
             {
-                Text(registryName)
+                Text(canonicalName)
                     .font(.system(size: 9))
                     .bold()
                     .foregroundStyle(nodeViewModel.nodeType.color())

--- a/Fabric/Views/Nodes/NodeTitleView.swift
+++ b/Fabric/Views/Nodes/NodeTitleView.swift
@@ -15,11 +15,11 @@ struct NodeTitleView: View
     @State private var renamingText: String = ""
     @FocusState private var renameFieldFocused: Bool
 
-    private var canonicalName: String { nodeViewModel.canonicalName }
+    private var title: String { nodeViewModel.title }
 
     // Nil when the node has neither a rename nor a generated name, so the title
     // is its type name alone.
-    private var primaryLabel: String? { nodeViewModel.titleLabel }
+    private var primaryLabel: String? { nodeViewModel.subtitle }
 
     /// Opaque across the title, fading to clear over the last ~1 character so an
     /// over-long title dissolves at the node's right edge rather than hard-clipping.
@@ -52,9 +52,9 @@ struct NodeTitleView: View
                 HStack(spacing: 0)
                 {
                     // Placeholder previews the empty-commit outcome: with no
-                    // rename, titleLabel (the node's own subtitle) shows; the
-                    // canonical name already follows as the suffix Text.
-                    TextField(nodeViewModel.titleLabel ?? "", text: $renamingText)
+                    // rename, the node-derived subtitle shows; the registered
+                    // title already follows as the suffix Text.
+                    TextField(nodeViewModel.subtitle ?? "", text: $renamingText)
                         .textFieldStyle(.plain)
                         .focused($renameFieldFocused)
                         .font(.system(size: 9))
@@ -67,7 +67,7 @@ struct NodeTitleView: View
                             renaming = false
                         }
 
-                    Text(verbatim: " \(canonicalName)")
+                    Text(verbatim: " \(title)")
                         .font(.system(size: 9))
                         .bold()
                         .foregroundStyle(secondaryColor)
@@ -79,14 +79,14 @@ struct NodeTitleView: View
                 // copy — the literal-interpolation initializer would do a doomed
                 // localization lookup on every render.
                 let primary = Text(primaryLabel).foregroundStyle(.white)
-                let secondary = Text(verbatim: " \(canonicalName)").foregroundStyle(secondaryColor)
+                let secondary = Text(verbatim: " \(title)").foregroundStyle(secondaryColor)
                 (primary + secondary)
                     .font(.system(size: 9))
                     .bold()
             }
             else
             {
-                Text(canonicalName)
+                Text(title)
                     .font(.system(size: 9))
                     .bold()
                     .foregroundStyle(nodeViewModel.nodeType.color())

--- a/Fabric/Views/Nodes/NodeViewModel.swift
+++ b/Fabric/Views/Nodes/NodeViewModel.swift
@@ -61,31 +61,31 @@ import Satin
     }
     private var _userName: String?
 
-    /// `Node.name`, resolved from the observable rename above rather than read
+    /// `Node.title`, resolved from the observable rename above rather than read
     /// through to the node, so SwiftUI invalidates on a rename.
-    public var name: String
+    public var title: String
     {
-        _userName ?? registryName
+        _userName ?? canonicalName
     }
 
-    /// `Node.customName`, cached and kept fresh by nameSubject.
-    public private(set) var customName: String?
+    /// `Node.subtitle`, cached and kept fresh by subtitleSubject.
+    public private(set) var subtitle: String?
 
-    /// What title UI shows ahead of the type name: the rename, else the node's
-    /// own generated name. Nil when it has neither — or when the label equals
-    /// the registry name, which the title renders anyway — and the title is the
+    /// What title UI shows ahead of the canonical name: the rename, else the
+    /// node's own subtitle. Nil when it has neither — or when the label equals
+    /// the canonical name, which the title renders anyway — and the title is the
     /// bare type name.
-    public var customLabel: String?
+    public var titleLabel: String?
     {
-        let label = _userName ?? customName
-        return label == registryName ? nil : label
+        let label = _userName ?? subtitle
+        return label == canonicalName ? nil : label
     }
 
     // MARK: - Forwarded node metadata
 
     public var nodeType: Node.NodeType { node.nodeType }
 
-    public var registryName: String { node.registryName }
+    public var canonicalName: String { node.canonicalName }
 
     // MARK: - Ports + nodeSize (stored; updated when ports change)
 
@@ -112,7 +112,7 @@ import Satin
         self.node         = node
         self._offset      = node.offset
         self._userName    = node.userName
-        self.customName   = node.customName
+        self.subtitle     = node.subtitle
         self.ports        = node.ports
         self.nodeSize     = node.nodeSize
 
@@ -136,16 +136,16 @@ import Satin
             }
             .store(in: &cancellables)
 
-        // Sync cached name when nodes with dynamic names (e.g. MathExpressionNode,
-        // StringFormatterNode) change their computed name after user edits.
-        node.nameSubject
+        // Sync the cached subtitle when nodes that describe themselves (e.g.
+        // MathExpressionNode, StringFormatterNode) change it after user edits.
+        node.subtitleSubject
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in
                 guard let self else { return }
-                // Equality-gated: force-sending upstreams re-assign name-feeding
+                // Equality-gated: force-sending upstreams re-assign subtitle-feeding
                 // ports every frame; only a real change may touch the observable.
-                let newName = node.customName
-                if newName != self.customName { self.customName = newName }
+                let newSubtitle = node.subtitle
+                if newSubtitle != self.subtitle { self.subtitle = newSubtitle }
             }
             .store(in: &cancellables)
     }

--- a/Fabric/Views/Nodes/NodeViewModel.swift
+++ b/Fabric/Views/Nodes/NodeViewModel.swift
@@ -50,7 +50,14 @@ import Satin
     public var userName: String?
     {
         get { _userName }
-        set { _userName = newValue; node.userName = newValue }
+        // Normalized like Node's own setter, so the mirror can't hold an
+        // empty rename the node discarded.
+        set
+        {
+            let name = newValue?.isEmpty == true ? nil : newValue
+            _userName = name
+            node.userName = name
+        }
     }
     private var _userName: String?
 
@@ -58,8 +65,7 @@ import Satin
     /// through to the node, so SwiftUI invalidates on a rename.
     public var name: String
     {
-        if let u = _userName, !u.isEmpty { return u }
-        return registryName
+        _userName ?? registryName
     }
 
     /// `Node.customName`, cached and kept fresh by nameSubject.
@@ -70,8 +76,7 @@ import Satin
     /// type name.
     public var customLabel: String?
     {
-        if let u = _userName, !u.isEmpty { return u }
-        return customName
+        _userName ?? customName
     }
 
     // MARK: - Forwarded node metadata

--- a/Fabric/Views/Nodes/NodeViewModel.swift
+++ b/Fabric/Views/Nodes/NodeViewModel.swift
@@ -54,24 +54,31 @@ import Satin
     }
     private var _userName: String?
 
+    /// `Node.name`, resolved from the observable rename above rather than read
+    /// through to the node, so SwiftUI invalidates on a rename.
     public var name: String
     {
         if let u = _userName, !u.isEmpty { return u }
-        return _nodeName
+        return typeName
     }
 
-    private var _nodeName: String
+    /// `Node.customName`, cached and kept fresh by nameSubject.
+    public private(set) var customName: String?
+
+    /// What title UI shows ahead of the type name: the rename, else the node's
+    /// own generated name. Nil when it has neither and the title is the bare
+    /// type name.
+    public var customLabel: String?
+    {
+        if let u = _userName, !u.isEmpty { return u }
+        return customName
+    }
 
     // MARK: - Forwarded node metadata
 
     public var nodeType: Node.NodeType { node.nodeType }
 
-    public var typeName: String { type(of: node).name }
-
-    /// True when the resolved label (user rename or node-generated title)
-    /// differs from the type name, i.e. there is a primary label to show
-    /// alongside it.
-    public var hasCustomLabel: Bool { name != typeName }
+    public var typeName: String { node.typeName }
 
     // MARK: - Ports + nodeSize (stored; updated when ports change)
 
@@ -98,7 +105,7 @@ import Satin
         self.node         = node
         self._offset      = node.offset
         self._userName    = node.userName
-        self._nodeName    = node.displayName ?? type(of: node).name
+        self.customName   = node.customName
         self.ports        = node.ports
         self.nodeSize     = node.nodeSize
 
@@ -124,12 +131,10 @@ import Satin
 
         // Sync cached name when nodes with dynamic names (e.g. MathExpressionNode,
         // StringFormatterNode) change their computed name after user edits.
-        // Cache displayName (not node.name) so a user rename never becomes the
-        // fallback shown after the rename is cleared.
         node.nameSubject
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in
-                self?._nodeName = node.displayName ?? type(of: node).name
+                self?.customName = node.customName
             }
             .store(in: &cancellables)
     }

--- a/Fabric/Views/Nodes/NodeViewModel.swift
+++ b/Fabric/Views/Nodes/NodeViewModel.swift
@@ -57,35 +57,21 @@ import Satin
             let name = newValue?.isEmpty == true ? nil : newValue
             _userName = name
             node.userName = name
+            let resolvedSubtitle = node.subtitle
+            if resolvedSubtitle != self.subtitle { self.subtitle = resolvedSubtitle }
         }
     }
     private var _userName: String?
 
-    /// `Node.title`, resolved from the observable rename above rather than read
-    /// through to the node, so SwiftUI invalidates on a rename.
-    public var title: String
-    {
-        _userName ?? canonicalName
-    }
+    /// `Node.title`, cached and refreshed with the node's other naming state.
+    public private(set) var title: String
 
     /// `Node.subtitle`, cached and kept fresh by subtitleSubject.
     public private(set) var subtitle: String?
 
-    /// What title UI shows ahead of the canonical name: the rename, else the
-    /// node's own subtitle. Nil when it has neither — or when the label equals
-    /// the canonical name, which the title renders anyway — and the title is the
-    /// bare type name.
-    public var titleLabel: String?
-    {
-        let label = _userName ?? subtitle
-        return label == canonicalName ? nil : label
-    }
-
     // MARK: - Forwarded node metadata
 
     public var nodeType: Node.NodeType { node.nodeType }
-
-    public var canonicalName: String { node.canonicalName }
 
     // MARK: - Ports + nodeSize (stored; updated when ports change)
 
@@ -112,6 +98,7 @@ import Satin
         self.node         = node
         self._offset      = node.offset
         self._userName    = node.userName
+        self.title        = node.title
         self.subtitle     = node.subtitle
         self.ports        = node.ports
         self.nodeSize     = node.nodeSize
@@ -136,14 +123,18 @@ import Satin
             }
             .store(in: &cancellables)
 
-        // Sync the cached subtitle when nodes that describe themselves (e.g.
-        // MathExpressionNode, StringFormatterNode) change it after user edits.
+        // Sync the cached title, rename, and resolved subtitle whenever the
+        // node's naming state changes.
         node.subtitleSubject
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in
                 guard let self else { return }
                 // Equality-gated: force-sending upstreams re-assign subtitle-feeding
                 // ports every frame; only a real change may touch the observable.
+                let newUserName = node.userName
+                if newUserName != self._userName { self._userName = newUserName }
+                let newTitle = node.title
+                if newTitle != self.title { self.title = newTitle }
                 let newSubtitle = node.subtitle
                 if newSubtitle != self.subtitle { self.subtitle = newSubtitle }
             }

--- a/Fabric/Views/Nodes/NodeViewModel.swift
+++ b/Fabric/Views/Nodes/NodeViewModel.swift
@@ -139,7 +139,11 @@ import Satin
         node.nameSubject
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in
-                self?.customName = node.customName
+                guard let self else { return }
+                // Equality-gated: force-sending upstreams re-assign name-feeding
+                // ports every frame; only a real change may touch the observable.
+                let newName = node.customName
+                if newName != self.customName { self.customName = newName }
             }
             .store(in: &cancellables)
     }

--- a/Fabric/Views/Nodes/NodeViewModel.swift
+++ b/Fabric/Views/Nodes/NodeViewModel.swift
@@ -59,7 +59,7 @@ import Satin
     public var name: String
     {
         if let u = _userName, !u.isEmpty { return u }
-        return typeName
+        return registryName
     }
 
     /// `Node.customName`, cached and kept fresh by nameSubject.
@@ -78,7 +78,7 @@ import Satin
 
     public var nodeType: Node.NodeType { node.nodeType }
 
-    public var typeName: String { node.typeName }
+    public var registryName: String { node.registryName }
 
     // MARK: - Ports + nodeSize (stored; updated when ports change)
 

--- a/Fabric/Views/Nodes/NodeViewModel.swift
+++ b/Fabric/Views/Nodes/NodeViewModel.swift
@@ -72,11 +72,13 @@ import Satin
     public private(set) var customName: String?
 
     /// What title UI shows ahead of the type name: the rename, else the node's
-    /// own generated name. Nil when it has neither and the title is the bare
-    /// type name.
+    /// own generated name. Nil when it has neither — or when the label equals
+    /// the registry name, which the title renders anyway — and the title is the
+    /// bare type name.
     public var customLabel: String?
     {
-        _userName ?? customName
+        let label = _userName ?? customName
+        return label == registryName ? nil : label
     }
 
     // MARK: - Forwarded node metadata

--- a/Tests/MathExpressionNodeTests.swift
+++ b/Tests/MathExpressionNodeTests.swift
@@ -86,7 +86,7 @@ import MathExpressionEngine
         node.stringExpression = "sin("
         #expect(names(node.inputPorts()) == ["x", "y"]) // unchanged
         #expect(node._settingsModel.diagnostics.contains { $0.severity == .error })
-        #expect(node.customName?.hasPrefix("⚠") == true)
+        #expect(node.subtitle?.hasPrefix("⚠") == true)
     }
 
     /// Torture-tests for the node-title heuristic, drawn from the language spec:
@@ -175,7 +175,7 @@ import MathExpressionEngine
         let node = MathExpressionNode(context: context)
 
         node.stringExpression = "in x: floot"
-        #expect(node.customName == "⚠ \(MathExpressionNode.name)")
+        #expect(node.subtitle == "⚠ \(MathExpressionNode.name)")
     }
 
     @Test func retypeReplacesPortWithNewType() throws

--- a/Tests/MathExpressionNodeTests.swift
+++ b/Tests/MathExpressionNodeTests.swift
@@ -86,7 +86,7 @@ import MathExpressionEngine
         node.stringExpression = "sin("
         #expect(names(node.inputPorts()) == ["x", "y"]) // unchanged
         #expect(node._settingsModel.diagnostics.contains { $0.severity == .error })
-        #expect(node.name.hasPrefix("⚠"))
+        #expect(node.customName?.hasPrefix("⚠") == true)
     }
 
     /// Torture-tests for the node-title heuristic, drawn from the language spec:
@@ -175,7 +175,7 @@ import MathExpressionEngine
         let node = MathExpressionNode(context: context)
 
         node.stringExpression = "in x: floot"
-        #expect(node.name == "⚠ \(MathExpressionNode.name)")
+        #expect(node.customName == "⚠ \(MathExpressionNode.name)")
     }
 
     @Test func retypeReplacesPortWithNewType() throws

--- a/Tests/NodeNamingTests.swift
+++ b/Tests/NodeNamingTests.swift
@@ -1,0 +1,235 @@
+import Foundation
+import Metal
+import Satin
+import Testing
+@testable import Fabric
+
+private final class NamingTestNode: Node
+{
+    override class var name: String { "Naming Test" }
+    override class var nodeType: Node.NodeType { .Utility }
+    override class var nodeExecutionMode: Node.ExecutionMode { .Processor }
+    override class var nodeTimeMode: Node.TimeMode { .None }
+    override class var nodeDescription: String { "Exercises the Node naming contract" }
+
+    private var nodeDerivedSubtitle: String?
+    private var nodeDerivedTitle: String?
+
+    override func deriveTitle() -> String
+    {
+        nodeDerivedTitle ?? Self.name
+    }
+
+    override func deriveSubtitle() -> String?
+    {
+        nodeDerivedSubtitle
+    }
+
+    func setDerivedSubtitle(_ subtitle: String?)
+    {
+        nodeDerivedSubtitle = subtitle
+        subtitleSubject.send()
+    }
+
+    func setDerivedTitle(_ title: String?)
+    {
+        nodeDerivedTitle = title
+        subtitleSubject.send()
+    }
+}
+
+@Suite struct NodeNamingTests
+{
+    private func makeContext() -> Context?
+    {
+        guard let device = MTLCreateSystemDefaultDevice() else { return nil }
+        return Context(
+            device: device,
+            sampleCount: 1,
+            colorPixelFormat: .bgra8Unorm,
+            depthPixelFormat: .depth32Float,
+            stencilPixelFormat: .invalid
+        )
+    }
+
+    @Test("Title defaults to the registered node name and ignores user renames")
+    func titleDefaultsToRegisteredName() throws
+    {
+        guard let context = makeContext() else { return }
+        let node = NamingTestNode(context: context)
+
+        #expect(node.title == NamingTestNode.name)
+
+        node.userName = "Renamed Instance"
+        #expect(node.title == NamingTestNode.name)
+    }
+
+    @Test("An instance can derive a more specific title")
+    func titleCanBeInstanceSpecific() throws
+    {
+        guard let context = makeContext() else { return }
+        let node = NamingTestNode(context: context)
+
+        node.setDerivedTitle("Instance Title")
+        #expect(node.title == "Instance Title")
+
+        node.setDerivedTitle("")
+        #expect(node.title == NamingTestNode.name)
+    }
+
+    @Test("Shader-backed BaseImageNode uses its shader name as its title")
+    func baseImageNodeUsesShaderNameAsTitle() throws
+    {
+        guard let context = makeContext() else { return }
+        let registry = try NodeRegistry()
+        let wrapper = try #require(registry.availableNodes.first { wrapper in
+            wrapper.nodeClass == BaseImageNode.self && wrapper.fileURL != nil
+        })
+        let node = try wrapper.initializeNode(context: context)
+
+        #expect(node.title == wrapper.nodeName)
+        #expect(node.subtitle == nil)
+
+        node.userName = "Renamed Effect"
+        #expect(node.title == wrapper.nodeName)
+        #expect(node.subtitle == "Renamed Effect")
+    }
+
+    @Test("Subtitle normalizes node-derived values")
+    func subtitleNormalizesDerivedValues() throws
+    {
+        guard let context = makeContext() else { return }
+        let node = NamingTestNode(context: context)
+
+        #expect(node.subtitle == nil)
+
+        node.setDerivedSubtitle("Derived Context")
+        #expect(node.subtitle == "Derived Context")
+
+        node.setDerivedSubtitle("")
+        #expect(node.subtitle == nil)
+
+        node.setDerivedSubtitle(NamingTestNode.name)
+        #expect(node.subtitle == nil)
+    }
+
+    @Test("User rename overrides the derived subtitle and clearing reveals the latest value")
+    func userRenameOverridesDerivedSubtitle() throws
+    {
+        guard let context = makeContext() else { return }
+        let node = NamingTestNode(context: context)
+
+        node.setDerivedSubtitle("First Derived Context")
+        node.userName = "Renamed Instance"
+        #expect(node.subtitle == "Renamed Instance")
+
+        node.setDerivedSubtitle("Latest Derived Context")
+        #expect(node.subtitle == "Renamed Instance")
+
+        node.userName = nil
+        #expect(node.subtitle == "Latest Derived Context")
+
+        node.userName = ""
+        #expect(node.userName == nil)
+        #expect(node.subtitle == "Latest Derived Context")
+    }
+
+    @Test("Debug description combines the title and resolved subtitle")
+    func debugDescriptionUsesResolvedSubtitle() throws
+    {
+        guard let context = makeContext() else { return }
+        let node = NamingTestNode(context: context)
+
+        #expect(node.debugDescription == "Naming Test")
+
+        node.setDerivedSubtitle("Derived Context")
+        #expect(node.debugDescription == "Naming Test (Derived Context)")
+
+        node.userName = "Renamed Instance"
+        #expect(node.debugDescription == "Naming Test (Renamed Instance)")
+    }
+
+    @Test("Decoded empty user rename is normalized to nil")
+    func decodedEmptyUserNameIsNormalized() throws
+    {
+        guard let context = makeContext() else { return }
+        let node = NamingTestNode(context: context)
+        node.userName = "Temporary Rename"
+
+        let encodedData = try JSONEncoder().encode(node)
+        var encodedObject = try #require(
+            JSONSerialization.jsonObject(with: encodedData) as? [String: Any]
+        )
+        encodedObject["userName"] = ""
+
+        let decoder = JSONDecoder()
+        decoder.context = DecoderContext(documentContext: context)
+        let decodedNode = try decoder.decode(
+            NamingTestNode.self,
+            from: JSONSerialization.data(withJSONObject: encodedObject)
+        )
+
+        #expect(decodedNode.userName == nil)
+        #expect(decodedNode.title == NamingTestNode.name)
+        #expect(decodedNode.subtitle == nil)
+    }
+
+    @Test("NodeViewModel mirrors rename and derived subtitle changes")
+    func viewModelMirrorsResolvedSubtitle() async throws
+    {
+        guard let context = makeContext() else { return }
+        let node = NamingTestNode(context: context)
+        node.setDerivedSubtitle("Initial Context")
+        let nodeViewModel = NodeViewModel(node: node)
+
+        #expect(nodeViewModel.title == NamingTestNode.name)
+        #expect(nodeViewModel.subtitle == "Initial Context")
+
+        nodeViewModel.userName = "Renamed Instance"
+        #expect(nodeViewModel.title == NamingTestNode.name)
+        #expect(nodeViewModel.subtitle == "Renamed Instance")
+
+        node.setDerivedSubtitle("Latest Context")
+        nodeViewModel.userName = nil
+        #expect(nodeViewModel.subtitle == "Latest Context")
+
+        node.setDerivedSubtitle("Subject Update")
+        for _ in 0..<50 where nodeViewModel.subtitle != "Subject Update"
+        {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(nodeViewModel.subtitle == "Subject Update")
+
+        node.userName = "Direct Node Rename"
+        for _ in 0..<50 where nodeViewModel.subtitle != "Direct Node Rename"
+        {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(nodeViewModel.userName == "Direct Node Rename")
+        #expect(nodeViewModel.subtitle == "Direct Node Rename")
+
+        node.userName = nil
+        for _ in 0..<50 where nodeViewModel.subtitle != "Subject Update"
+        {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(nodeViewModel.userName == nil)
+        #expect(nodeViewModel.subtitle == "Subject Update")
+    }
+
+    @Test("NodeViewModel mirrors instance title changes")
+    func viewModelMirrorsInstanceTitleChanges() async throws
+    {
+        guard let context = makeContext() else { return }
+        let node = NamingTestNode(context: context)
+        let nodeViewModel = NodeViewModel(node: node)
+
+        node.setDerivedTitle("Updated Instance Title")
+        for _ in 0..<50 where nodeViewModel.title != "Updated Instance Title"
+        {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        #expect(nodeViewModel.title == "Updated Instance Title")
+    }
+}


### PR DESCRIPTION
Prompted by hard-to-parse logs where e.g. the math expression was logged as the name. 

Two new fields on `Node` –
- `typeName` used in logs etc. where performance + brevity important. 
- `debugName` used in logs etc. elsewhere.
