### PR TITLE
Fix/clear node

### DIFF
--- a/Fabric/Graph/GraphRenderer.swift
+++ b/Fabric/Graph/GraphRenderer.swift
@@ -165,6 +165,17 @@ public class GraphRenderer : ViewRenderer
 
     public func executeAndDraw(graph: Graph, executionInfo: GraphExecutionInfo, renderPassDescriptor: MTLRenderPassDescriptor, commandBuffer: MTLCommandBuffer) throws
     {
+        let clearColor = self.renderEncoder.clearColor
+        let colorLoadAction = self.renderEncoder.colorLoadAction
+        let depthLoadAction = self.renderEncoder.depthLoadAction
+        let stencilLoadAction = self.renderEncoder.stencilLoadAction
+        defer {
+            self.renderEncoder.clearColor = clearColor
+            self.renderEncoder.colorLoadAction = colorLoadAction
+            self.renderEncoder.depthLoadAction = depthLoadAction
+            self.renderEncoder.stencilLoadAction = stencilLoadAction
+        }
+
         let needsSceneSync = graph.consumePendingConnectionSceneSync()
 
         try self.execute(graph: graph,

--- a/Fabric/Nodes/Object/SubGraph/DeferredSubgraphNode.swift
+++ b/Fabric/Nodes/Object/SubGraph/DeferredSubgraphNode.swift
@@ -78,7 +78,6 @@ public class DeferredSubgraphNode: SubgraphNode
         return  [
             ("inputWidth", ParameterPort(parameter: IntParameter("Width", 1920, .inputfield, "Output texture width in pixels"))),
             ("inputHeight", ParameterPort(parameter: IntParameter("Height", 1080, .inputfield, "Output texture height in pixels"))),
-            ("inputClearColor", ParameterPort(parameter: Float4Parameter("Clear Color", simd_float4(repeating:0), .colorpicker, "Background color for the render target"))),
             ("outputColorTexture", NodePort<FabricImage>(name: "Color Texture", kind: .Outlet, description: "Rendered color output from the subgraph")),
             ("outputDepthTexture", NodePort<FabricImage>(name: "Depth Texture", kind: .Outlet, description: "Rendered depth buffer from the subgraph")),
         ] + ports
@@ -87,7 +86,6 @@ public class DeferredSubgraphNode: SubgraphNode
     // Proxy Port
     public var inputWidth: ParameterPort<Int> { port(named: "inputWidth") }
     public var inputHeight: ParameterPort<Int> { port(named: "inputHeight") }
-    public var inputClearColor: ParameterPort<simd_float4> { port(named: "inputClearColor") }
     public var outputColorTexture: NodePort<FabricImage> { port(named: "outputColorTexture") }
     public var outputDepthTexture: NodePort<FabricImage> { port(named: "outputDepthTexture") }
     
@@ -172,7 +170,6 @@ public class DeferredSubgraphNode: SubgraphNode
         self.graphRenderer.renderEncoder.emissiveTextureStorageMode = .private
         
         self.graphRenderer.resize(size: (Float(self.inputWidth.value ?? 1920), Float(self.inputHeight.value ?? 1080 )), scaleFactor: 1.0)
-        self.graphRenderer.renderEncoder.clearColor = .init(self.inputClearColor.value ?? simd_float4(repeating: 0))
         self.rendererNeedsSetup = false
     }
 
@@ -298,12 +295,6 @@ public class DeferredSubgraphNode: SubgraphNode
             }
         }
        
-        if self.inputClearColor.valueDidChange,
-           let clearColor = self.inputClearColor.value
-        {
-            self.graphRenderer.renderEncoder.clearColor = .init( clearColor )
-        }
-                    
         guard let width = self.inputWidth.value,
               let height = self.inputHeight.value
         else { return }

--- a/Fabric/Nodes/Plugin/FabricCoreNodesPlugin.swift
+++ b/Fabric/Nodes/Plugin/FabricCoreNodesPlugin.swift
@@ -361,6 +361,7 @@ public final class FabricCoreNodesPlugin: NSObject, FabricPlugin
     private static var utilityClasses: [Node.Type]
     {
         var classes: [Node.Type] = [
+            ClearNode.self,
             LogNode.self,
             VisualizeNode.self,
             JavaScriptNode.self,

--- a/Fabric/Nodes/Utility/ClearNode.swift
+++ b/Fabric/Nodes/Utility/ClearNode.swift
@@ -1,0 +1,43 @@
+//
+//  ClearNode.swift
+//  Fabric
+//
+
+import Metal
+import Satin
+import simd
+
+public final class ClearNode: Node
+{
+    override public class var name: String { "Clear" }
+    override public class var nodeType: Node.NodeType { .Utility }
+    override public class var nodeExecutionMode: Node.ExecutionMode { .Consumer }
+    override public class var nodeTimeMode: Node.TimeMode { .None }
+    override public class var nodeDescription: String { "Sets the initial render target clear color and optionally clears depth and stencil. Clear happens before scene rendering and does not participate in Render Order." }
+
+    override public class func registerPorts(context: Context) -> [(name: String, port: Port)]
+    {
+        let ports = super.registerPorts(context: context)
+
+        return ports + [
+            ("inputClearColor", ParameterPort(parameter: Float4Parameter("Clear Color", .zero, .colorpicker, "Color used to initialize the render target"))),
+            ("inputClearDepth", ParameterPort(parameter: BoolParameter("Clear Depth", true, .button, "Clear the depth attachment before scene rendering"))),
+            ("inputClearStencil", ParameterPort(parameter: BoolParameter("Clear Stencil", false, .button, "Clear the stencil attachment before scene rendering"))),
+        ]
+    }
+
+    public var inputClearColor: ParameterPort<simd_float4> { port(named: "inputClearColor") }
+    public var inputClearDepth: ParameterPort<Bool> { port(named: "inputClearDepth") }
+    public var inputClearStencil: ParameterPort<Bool> { port(named: "inputClearStencil") }
+
+    override public func execute(renderer: GraphRenderer,
+                                 executionInfo: GraphExecutionInfo,
+                                 renderPassDescriptor: MTLRenderPassDescriptor,
+                                 commandBuffer: MTLCommandBuffer) throws
+    {
+        renderer.renderEncoder.setClearColor(self.inputClearColor.value ?? .zero)
+        renderer.renderEncoder.colorLoadAction = .clear
+        renderer.renderEncoder.depthLoadAction = (self.inputClearDepth.value ?? true) ? .clear : .dontCare
+        renderer.renderEncoder.stencilLoadAction = (self.inputClearStencil.value ?? false) ? .clear : .dontCare
+    }
+}

--- a/Fabric/Nodes/Utility/ClearNode.swift
+++ b/Fabric/Nodes/Utility/ClearNode.swift
@@ -9,7 +9,7 @@ import simd
 
 public final class ClearNode: Node
 {
-    override public class var name: String { "Clear" }
+    override public class var name: String { "Background Color" }
     override public class var nodeType: Node.NodeType { .Utility }
     override public class var nodeExecutionMode: Node.ExecutionMode { .Consumer }
     override public class var nodeTimeMode: Node.TimeMode { .None }
@@ -20,7 +20,7 @@ public final class ClearNode: Node
         let ports = super.registerPorts(context: context)
 
         return ports + [
-            ("inputClearColor", ParameterPort(parameter: Float4Parameter("Clear Color", .zero, .colorpicker, "Color used to initialize the render target"))),
+            ("inputClearColor", ParameterPort(parameter: Float4Parameter("Background Color Color", .zero, .colorpicker, "Color used for background clearing on the current color render target"))),
             ("inputClearDepth", ParameterPort(parameter: BoolParameter("Clear Depth", true, .button, "Clear the depth attachment before scene rendering"))),
             ("inputClearStencil", ParameterPort(parameter: BoolParameter("Clear Stencil", false, .button, "Clear the stencil attachment before scene rendering"))),
         ]


### PR DESCRIPTION
This PR adds a QC like `Clear` node to Fabric. 

Given Fabric isnt immediate mode rendering in OpenGL, there are some differences with this node

a) Clear node is setting the clear color within the render pass encoders next encode pass
b) clear does not have a render order, and does not actually clear anything
c) multiple clear patches -> the last one to execute wins. 

Some possible improvements should we want

a) it might make sense to call this 'background color' vs clear? I think i am leaning to that as it also disambiguates it doing work it isnt (ie actually clearing buffers).
b) if we do need or want a full screen overlay / clear with a color (or even blending), or full screen draw a color function, we could make a custom pass object - but it would need to respect Satin's scene graph execution ordering. 
c) Toby suggested making this a property of the camera, which, I dunno, strikes me as odd but i also dont claim to have all the answers. Maybe users can tell us?

At a minimum, this does do what it needs to do, and we can iterate on it in the future? 

This PR concretely:

* Adds a Clear Node
* Adds it to the standard plugin registry
* Updates Graph Renderer to cache the initialized clear value so on Clear Node deletion, we revert to the standard GraphRenderer's clear color.