### PR TITLE
Feature – Per node error isolation

### DIFF
--- a/Fabric/Graph/GraphRenderer.swift
+++ b/Fabric/Graph/GraphRenderer.swift
@@ -213,8 +213,6 @@ public class GraphRenderer : ViewRenderer
         let graphTraceFrame = beginGraphExecutionTrace()
 
         for (orderIndex, node) in scheduledNodes.enumerated() {
-            guard capturedError == nil else { break }
-
             if self.graphRequiresResize {
                 node.resize(size: self.renderEncoder.size, scaleFactor: self.resizeScaleFactor)
             }
@@ -229,6 +227,8 @@ public class GraphRenderer : ViewRenderer
 #if DEBUG
             commandBuffer.pushDebugGroup(node.name)
 #endif
+            var executionError: (any Error)?
+
             do
             {
                 try node.execute(renderer: self,
@@ -238,16 +238,31 @@ public class GraphRenderer : ViewRenderer
             }
             catch
             {
-                capturedError = error
+                executionError = error
             }
 #if DEBUG
             commandBuffer.popDebugGroup()
 #endif
 
-            endNodeExecutionTrace(nodeTrace, result: capturedError == nil ? .executed : .error)
+            endNodeExecutionTrace(nodeTrace, result: executionError == nil ? .executed : .error)
 
             if clearFlags {
                 node.markClean()
+            }
+
+            // Failures are isolated to the node that threw: the pass keeps
+            // going and the first error is rethrown once it completes. Stopping
+            // here instead would skip every node scheduled later, and their
+            // flags would then be cleared anyway by an ancestor's markClean
+            // cascade — silently destroying whatever single-frame signal was
+            // pending on them (a value edge, a one-shot). Only a non-recoverable
+            // error is worth abandoning the rest of the pass for.
+            if let executionError
+            {
+                if capturedError == nil { capturedError = executionError }
+
+                let severity = (executionError as? any FabricErrorProtocol)?.severity
+                if severity != .recoverable { break }
             }
         }
 

--- a/Fabric/Nodes/Image/Analysis/LucasKanadeOpticalFlowNode.swift
+++ b/Fabric/Nodes/Image/Analysis/LucasKanadeOpticalFlowNode.swift
@@ -244,6 +244,10 @@ public class LucasKanadeOpticalFlowNode: Node
                               severity: .recoverable,
                               message: "Could not create Lucas-Kanade flow compute encoder")
         }
+        // Image allocation below can throw; the encoder has to close on that
+        // path too, or the next node on this command buffer cannot make one.
+        defer { flowEncoder.endEncoding() }
+
         flowEncoder.label = "LK Flow"
         let barrier: () -> Void = { flowEncoder.memoryBarrier(scope: .textures) }
 
@@ -328,8 +332,6 @@ public class LucasKanadeOpticalFlowNode: Node
             flowEncoder.popDebugGroup()
             outputImage = temporallySmoothedFlow
         }
-
-        flowEncoder.endEncoding()
 
         outputFlow.send(outputImage)
     }

--- a/Fabric/Nodes/Image/ImageResampleNode.swift
+++ b/Fabric/Nodes/Image/ImageResampleNode.swift
@@ -207,6 +207,10 @@ public final class ImageResampleNode: Node
                               message: "Could not create Image Resample compute encoder")
         }
 
+        // The encoding calls below can throw; the encoder has to close on that
+        // path too, or the next node on this command buffer cannot make one.
+        defer { computeEncoder.endEncoding() }
+
         destinationImage.texture.label = "Image Resample \(outputWidth)×\(outputHeight)"
         computeEncoder.label = "Image Resample – \(method.rawValue)"
 
@@ -227,8 +231,6 @@ public final class ImageResampleNode: Node
                 computeEncoder: computeEncoder
             )
         }
-
-        computeEncoder.endEncoding()
 
         destinationImage.isFlipped = sourceImage.isFlipped
         outputImage.send(destinationImage)

--- a/Fabric/Nodes/Object/SubGraph/SubgraphNode.swift
+++ b/Fabric/Nodes/Object/SubGraph/SubgraphNode.swift
@@ -320,12 +320,16 @@ open class SubgraphNode: BaseObjectNode
                                   renderPassDescriptor: MTLRenderPassDescriptor,
                                   commandBuffer: MTLCommandBuffer) throws    {
         
+        // The inner pass runs every node it can and rethrows the first failure
+        // afterwards, so outlets of the nodes that did run must still reach the
+        // parent graph — the parent's markClean cascade clears their flags
+        // whether or not this call threw.
+        defer { self.forwardPortValues(force:true) }
+
         try renderer.execute(graph: self.subGraph,
                              executionInfo: executionInfo,
                              renderPassDescriptor: renderPassDescriptor,
                              commandBuffer: commandBuffer,
                              clearFlags: false)
-        
-        self.forwardPortValues(force:true)
     }
 }


### PR DESCRIPTION
A single node throwing aborts further node execution for that frame. If it’s recoverable, node execution should continue. This PR does that.