### PR TITLE
Feature – Preview toggable between in-editor and separate window

### DIFF
--- a/Fabric Editor/FabricApp.swift
+++ b/Fabric Editor/FabricApp.swift
@@ -176,14 +176,6 @@ struct DocumentCommands:Commands
 struct ViewCommands: Commands {
     @FocusedBinding(\.document) var document: FabricDocument?
 
-    /// The store tracks whichever window last became active — editor or
-    /// output — and is observable, so menus re-evaluate on window switches.
-    /// The focused-document binding can go stale while an AppKit output
-    /// window is key, so it is only a fallback.
-    private var activeDocument: FabricDocument? {
-        ActiveFabricDocumentStore.shared.activeDocument ?? self.document
-    }
-
     var body: some Commands {
         CommandGroup(after: .toolbar) {
             let graph = document?.editingContext.currentGraph
@@ -212,17 +204,16 @@ struct ViewCommands: Commands {
             .disabled(document == nil)
 
             Divider()
+        }
 
-            // Read the mode here in the body, not inside the binding's
-            // getter, so observation registers it and the menu re-evaluates
-            // when the active document or its mode changes.
-            let outputPresenter = self.activeDocument?.outputPresenter
-            let outputMode = outputPresenter?.mode ?? .separateWindow
-
+        CommandGroup(after: .windowArrangement) {
             Menu("Output") {
+                // The getter reads live rather than a value captured at body
+                // evaluation, so the checkmark is current whenever the menu
+                // opens even if Commands bodies aren't observation-tracked.
                 Picker("Destination", selection: Binding(
-                    get: { outputMode },
-                    set: { outputPresenter?.mode = $0 }
+                    get: { OutputSettings.shared.mode },
+                    set: { OutputSettings.shared.mode = $0 }
                 )) {
                     Text("In-Editor").tag(OutputPresentationMode.editorCanvas)
                     Text("Window").tag(OutputPresentationMode.separateWindow)
@@ -230,9 +221,6 @@ struct ViewCommands: Commands {
                 .pickerStyle(.inline)
                 .labelsHidden()
             }
-            .disabled(outputPresenter == nil)
-
-            Divider()
         }
     }
 }

--- a/Fabric Editor/FabricApp.swift
+++ b/Fabric Editor/FabricApp.swift
@@ -31,15 +31,6 @@ struct FabricApp: App {
             ContentView(document: file.$document)
                 .focusedSceneValue(\.document, file.$document)
 
-                .onAppear {
-                    // THIS SHIT HAS TO BE ON MAIN THREAD FOR APPKIT
-                    file.document.setupOutputWindow()
-                }
-                .onDisappear {
-                    // THIS SHIT HAS TO BE ON MAIN THREAD FOR APPKIT
-                    file.document.closeOutputWindow()
-                }
-                
         }
         .commands {
             AboutCommands()
@@ -185,6 +176,14 @@ struct DocumentCommands:Commands
 struct ViewCommands: Commands {
     @FocusedBinding(\.document) var document: FabricDocument?
 
+    /// The store tracks whichever window last became active — editor or
+    /// output — and is observable, so menus re-evaluate on window switches.
+    /// The focused-document binding can go stale while an AppKit output
+    /// window is key, so it is only a fallback.
+    private var activeDocument: FabricDocument? {
+        ActiveFabricDocumentStore.shared.activeDocument ?? self.document
+    }
+
     var body: some Commands {
         CommandGroup(after: .toolbar) {
             let graph = document?.editingContext.currentGraph
@@ -211,6 +210,27 @@ struct ViewCommands: Commands {
             }
             .keyboardShortcut("l", modifiers: [.command, .option])
             .disabled(document == nil)
+
+            Divider()
+
+            // Read the mode here in the body, not inside the binding's
+            // getter, so observation registers it and the menu re-evaluates
+            // when the active document or its mode changes.
+            let outputPresenter = self.activeDocument?.outputPresenter
+            let outputMode = outputPresenter?.mode ?? .separateWindow
+
+            Menu("Output") {
+                Picker("Destination", selection: Binding(
+                    get: { outputMode },
+                    set: { outputPresenter?.mode = $0 }
+                )) {
+                    Text("In-Editor").tag(OutputPresentationMode.editorCanvas)
+                    Text("Window").tag(OutputPresentationMode.separateWindow)
+                }
+                .pickerStyle(.inline)
+                .labelsHidden()
+            }
+            .disabled(outputPresenter == nil)
 
             Divider()
         }

--- a/Fabric Editor/FabricDocument.swift
+++ b/Fabric Editor/FabricDocument.swift
@@ -12,7 +12,7 @@ import Metal
 import Fabric
 import Satin
 
-@MainActor @Observable
+@MainActor
 final class ActiveFabricDocumentStore
 {
     static let shared = ActiveFabricDocumentStore()

--- a/Fabric Editor/FabricDocument.swift
+++ b/Fabric Editor/FabricDocument.swift
@@ -12,7 +12,7 @@ import Metal
 import Fabric
 import Satin
 
-@MainActor
+@MainActor @Observable
 final class ActiveFabricDocumentStore
 {
     static let shared = ActiveFabricDocumentStore()
@@ -44,7 +44,7 @@ class FabricDocument: FileDocument
     let renderer:GraphRenderer
     let editingContext: GraphCanvasContext
 
-    @ObservationIgnored var outputWindowManager:DocumentOutputWindowManager? = nil
+    @ObservationIgnored var outputPresenter: OutputPresenter? = nil
     @MainActor lazy var movieExportCoordinator = MovieExportCoordinator()
     
     init()
@@ -196,19 +196,20 @@ class FabricDocument: FileDocument
     }
 
     @MainActor
-    func setupOutputWindow()
+    func setupOutputPresentation()
     {
-        self.outputWindowManager = DocumentOutputWindowManager()
-        self.outputWindowManager?.ownerDocument = self
-        self.outputWindowManager?.setGraphRenderer(self.renderer)
-        self.outputWindowManager?.setWindowName(self.graphName)
+        guard self.outputPresenter == nil else { return }
+
+        self.outputPresenter = OutputPresenter(ownerDocument: self, renderer: self.renderer)
+        self.outputPresenter?.setWindowTitle(self.graphName)
         ActiveFabricDocumentStore.shared.activeDocument = self
     }
-    
+
     @MainActor
-    func closeOutputWindow()
+    func teardownOutputPresentation()
     {
-        self.outputWindowManager?.closeOutputWindow()
+        self.outputPresenter?.teardown()
+        self.outputPresenter = nil
         if ActiveFabricDocumentStore.shared.activeDocument === self {
             ActiveFabricDocumentStore.shared.activeDocument = nil
         }
@@ -217,7 +218,7 @@ class FabricDocument: FileDocument
     @MainActor
     func exportSnapshotImage()
     {
-        let snapshotExportTime = self.outputWindowManager?.snapshotExportTime() ?? 0
+        let snapshotExportTime = self.renderer.lastGraphExecutionTime
         let savePanel = NSSavePanel()
         savePanel.allowedContentTypes = [.png]
         savePanel.canCreateDirectories = true

--- a/Fabric Editor/FabricDocument.swift
+++ b/Fabric Editor/FabricDocument.swift
@@ -45,6 +45,7 @@ class FabricDocument: FileDocument
     let editingContext: GraphCanvasContext
 
     @ObservationIgnored var outputPresenter: OutputPresenter? = nil
+    private var outputPresentationHostCount = 0
     @MainActor lazy var movieExportCoordinator = MovieExportCoordinator()
     
     init()
@@ -198,6 +199,7 @@ class FabricDocument: FileDocument
     @MainActor
     func setupOutputPresentation()
     {
+        self.outputPresentationHostCount += 1
         guard self.outputPresenter == nil else { return }
 
         self.outputPresenter = OutputPresenter(ownerDocument: self, renderer: self.renderer)
@@ -208,6 +210,12 @@ class FabricDocument: FileDocument
     @MainActor
     func teardownOutputPresentation()
     {
+        // Editor re-parenting (window tab merge, scene restore) runs the new
+        // host view's onAppear before the old one's onDisappear; only the
+        // last host leaving may tear the shared presenter down.
+        self.outputPresentationHostCount = max(0, self.outputPresentationHostCount - 1)
+        guard self.outputPresentationHostCount == 0 else { return }
+
         self.outputPresenter?.teardown()
         self.outputPresenter = nil
         if ActiveFabricDocumentStore.shared.activeDocument === self {

--- a/Fabric Editor/Views/ContentView.swift
+++ b/Fabric Editor/Views/ContentView.swift
@@ -234,11 +234,7 @@ struct ContentView: View {
                 {
                     ToolbarItem(placement: .automatic)
                     {
-                        Button(outputPresenter.playbackControlLabel,
-                               systemImage: outputPresenter.playbackControlSymbolName)
-                        {
-                            outputPresenter.togglePlayback()
-                        }
+                        OutputPlaybackToolbarButton(presenter: outputPresenter)
                     }
                 }
 
@@ -259,6 +255,38 @@ struct ContentView: View {
                 self.outputPresenter = nil
                 self.document.teardownOutputPresentation()
             }
+            .background(ActiveDocumentTracker(document: self.document))
+        }
+    }
+}
+
+/// Keeps `ActiveFabricDocumentStore` pointed at the document whose editor
+/// window is key. The output window's `windowDidBecomeMain` also does this,
+/// but in editor-canvas mode no output window exists. A separate struct so
+/// window-focus changes invalidate this view, not the whole editor.
+struct ActiveDocumentTracker: View {
+    let document: FabricDocument
+    @Environment(\.controlActiveState) private var controlActiveState
+
+    var body: some View {
+        Color.clear
+            .onChange(of: self.controlActiveState) { _, newState in
+                guard newState == .key else { return }
+                ActiveFabricDocumentStore.shared.activeDocument = self.document
+            }
+    }
+}
+
+/// Reading playback state here rather than in `ContentView.body` keeps a
+/// play/pause toggle from re-evaluating the whole editor.
+struct OutputPlaybackToolbarButton: View {
+    let presenter: OutputPresenter
+
+    var body: some View {
+        Button(self.presenter.playbackControlLabel,
+               systemImage: self.presenter.playbackControlSymbolName)
+        {
+            self.presenter.togglePlayback()
         }
     }
 }

--- a/Fabric Editor/Views/ContentView.swift
+++ b/Fabric Editor/Views/ContentView.swift
@@ -20,7 +20,6 @@ struct ContentView: View {
     
     @Binding var document: FabricDocument
     @Environment(\.undoManager) private var undoManager
-    @Environment(\.appearsActive) private var appearsActive
 
     @State private var canvasHitTestingEnabled = true
     
@@ -231,7 +230,7 @@ struct ContentView: View {
             }
             .toolbar
             {
-                if let outputPresenter = self.outputPresenter, outputPresenter.mode == .editorCanvas
+                if let outputPresenter = self.outputPresenter, OutputSettings.shared.mode == .editorCanvas
                 {
                     ToolbarItem(placement: .automatic)
                     {
@@ -260,14 +259,6 @@ struct ContentView: View {
                 self.outputPresenter = nil
                 self.document.teardownOutputPresentation()
             }
-            // The output window keeps the store current via windowDidBecomeMain;
-            // editor windows do it here, so menus track whichever document the
-            // user is actually in.
-            .onChange(of: self.appearsActive) { _, isActive in
-                if isActive {
-                    ActiveFabricDocumentStore.shared.activeDocument = self.document
-                }
-            }
         }
     }
 }
@@ -279,7 +270,7 @@ struct CanvasBackdropView: View {
     let radialGradientEndRadius: CGFloat
 
     var body: some View {
-        if let outputPresenter, outputPresenter.mode == .editorCanvas
+        if let outputPresenter, OutputSettings.shared.mode == .editorCanvas
         {
             OutputCanvasHostView(presenter: outputPresenter)
                 .allowsHitTesting(false)

--- a/Fabric Editor/Views/ContentView.swift
+++ b/Fabric Editor/Views/ContentView.swift
@@ -20,6 +20,7 @@ struct ContentView: View {
     
     @Binding var document: FabricDocument
     @Environment(\.undoManager) private var undoManager
+    @Environment(\.appearsActive) private var appearsActive
 
     @State private var canvasHitTestingEnabled = true
     
@@ -30,6 +31,10 @@ struct ContentView: View {
 
     @State private var columnVisibility = NavigationSplitViewVisibility.doubleColumn
     @State private var inspectorVisibility:Bool = true
+
+    // Seeded in onAppear once the document's AppKit-side output hosting
+    // exists; the document itself is not observable, this is.
+    @State private var outputPresenter: OutputPresenter?
 
     // The editor's single keyboard-focus authority. SwiftUI writes it on every
     // real focus change (canvas, registry search/list — or nil when e.g. a node
@@ -85,7 +90,8 @@ struct ContentView: View {
 
                 ZStack
                 {
-                    RadialGradient(colors: [.clear, .black.opacity(0.75)], center: .center, startRadius: 0, endRadius: self.radialGradientEndRadius)
+                    CanvasBackdropView(outputPresenter: self.outputPresenter,
+                                       radialGradientEndRadius: self.radialGradientEndRadius)
 
                     ScrollViewReader { proxy in
                         ScrollView([.horizontal, .vertical])
@@ -225,6 +231,18 @@ struct ContentView: View {
             }
             .toolbar
             {
+                if let outputPresenter = self.outputPresenter, outputPresenter.mode == .editorCanvas
+                {
+                    ToolbarItem(placement: .automatic)
+                    {
+                        Button(outputPresenter.playbackControlLabel,
+                               systemImage: outputPresenter.playbackControlSymbolName)
+                        {
+                            outputPresenter.togglePlayback()
+                        }
+                    }
+                }
+
                 ToolbarItem(placement: .automatic)
                 {
                     Button("Parameters", systemImage: "sidebar.right") {
@@ -232,6 +250,43 @@ struct ContentView: View {
                     }
                 }
             }
+            .onAppear {
+                // AppKit window creation has to happen on the main thread
+                // once the scene is up; onAppear guarantees both.
+                self.document.setupOutputPresentation()
+                self.outputPresenter = self.document.outputPresenter
+            }
+            .onDisappear {
+                self.outputPresenter = nil
+                self.document.teardownOutputPresentation()
+            }
+            // The output window keeps the store current via windowDidBecomeMain;
+            // editor windows do it here, so menus track whichever document the
+            // user is actually in.
+            .onChange(of: self.appearsActive) { _, isActive in
+                if isActive {
+                    ActiveFabricDocumentStore.shared.activeDocument = self.document
+                }
+            }
+        }
+    }
+}
+
+/// The node canvas background: live rendered output when the presenter is in
+/// editor-canvas mode, otherwise the decorative gradient.
+struct CanvasBackdropView: View {
+    let outputPresenter: OutputPresenter?
+    let radialGradientEndRadius: CGFloat
+
+    var body: some View {
+        if let outputPresenter, outputPresenter.mode == .editorCanvas
+        {
+            OutputCanvasHostView(presenter: outputPresenter)
+                .allowsHitTesting(false)
+        }
+        else
+        {
+            RadialGradient(colors: [.clear, .black.opacity(0.75)], center: .center, startRadius: 0, endRadius: self.radialGradientEndRadius)
         }
     }
 }

--- a/Fabric Editor/Views/DocumentWindowManager.swift
+++ b/Fabric Editor/Views/DocumentWindowManager.swift
@@ -44,7 +44,11 @@ class DocumentOutputWindowManager : NSObject
 
         viewController.view.frame = window.contentView?.bounds ?? .zero
         window.contentViewController = viewController
-        window.makeKeyAndOrderFront(nil)
+
+        // orderFront, not makeKeyAndOrderFront: the mode is app-wide, so
+        // every open document presents at once and none of their output
+        // windows should steal the keyboard from the editor.
+        window.orderFront(nil)
     }
 
     /// Completion fires once the window has given the view controller back —
@@ -101,7 +105,7 @@ class DocumentOutputWindowManager : NSObject
         }
 
         let window = NSWindow(contentRect: NSRect(x: 100, y: 100, width: 600, height: 600),
-                              styleMask: [.titled, .closable, .miniaturizable, .resizable, .unifiedTitleAndToolbar],
+                              styleMask: [.titled, .miniaturizable, .resizable, .unifiedTitleAndToolbar],
                               backing: .buffered, defer: false)
         window.isReleasedWhenClosed = false
         window.level = .normal
@@ -131,15 +135,6 @@ extension DocumentOutputWindowManager: NSWindowDelegate
     func windowDidBecomeMain(_ notification: Notification)
     {
         ActiveFabricDocumentStore.shared.activeDocument = self.ownerDocument
-    }
-
-    func windowShouldClose(_ sender: NSWindow) -> Bool
-    {
-        // The red close button routes here via performClose; move the output
-        // into the editor canvas instead of tearing rendering down. Document
-        // teardown uses close() directly, which skips this delegate method.
-        self.presenter?.mode = .editorCanvas
-        return false
     }
 
     func windowDidExitFullScreen(_ notification: Notification)

--- a/Fabric Editor/Views/DocumentWindowManager.swift
+++ b/Fabric Editor/Views/DocumentWindowManager.swift
@@ -31,12 +31,15 @@ class DocumentOutputWindowManager : NSObject
     // never pay for a window they may not show.
     private var outputWindow: NSWindow?
     private var windowTitle = ""
+    private var pendingWithdrawCompletion: (() -> Void)?
 
     // Toolbar shit
     private weak var playPauseItem: NSToolbarItem?
 
     func present(_ viewController: NSViewController)
     {
+        self.pendingWithdrawCompletion = nil
+
         let window = self.makeWindowIfNeeded()
 
         viewController.view.frame = window.contentView?.bounds ?? .zero
@@ -44,10 +47,25 @@ class DocumentOutputWindowManager : NSObject
         window.makeKeyAndOrderFront(nil)
     }
 
-    func withdraw()
+    /// Completion fires once the window has given the view controller back —
+    /// immediately, unless the window must exit full screen first.
+    func withdraw(completion: @escaping () -> Void = {})
     {
-        self.outputWindow?.orderOut(nil)
-        self.outputWindow?.contentViewController = nil
+        guard let window = self.outputWindow else {
+            completion()
+            return
+        }
+
+        if window.styleMask.contains(.fullScreen)
+        {
+            self.pendingWithdrawCompletion = completion
+            window.toggleFullScreen(nil)
+            return
+        }
+
+        window.orderOut(nil)
+        window.contentViewController = nil
+        completion()
     }
 
     func setWindowTitle(_ title: String)
@@ -69,6 +87,7 @@ class DocumentOutputWindowManager : NSObject
 
     func closeWindow()
     {
+        self.pendingWithdrawCompletion = nil
         self.outputWindow?.delegate = nil
         self.outputWindow?.contentViewController = nil
         self.outputWindow?.close()
@@ -121,6 +140,21 @@ extension DocumentOutputWindowManager: NSWindowDelegate
         // teardown uses close() directly, which skips this delegate method.
         self.presenter?.mode = .editorCanvas
         return false
+    }
+
+    func windowDidExitFullScreen(_ notification: Notification)
+    {
+        guard let completion = self.pendingWithdrawCompletion else { return }
+        self.pendingWithdrawCompletion = nil
+        self.withdraw(completion: completion)
+    }
+
+    func window(_ window: NSWindow, willUseFullScreenPresentationOptions proposedOptions: NSApplication.PresentationOptions = []) -> NSApplication.PresentationOptions
+    {
+        // Without this, a window with a toolbar keeps its title bar strip on
+        // screen in full screen; hiding it with the menu bar leaves nothing
+        // but the rendered output.
+        proposedOptions.union(.autoHideToolbar)
     }
 }
 

--- a/Fabric Editor/Views/DocumentWindowManager.swift
+++ b/Fabric Editor/Views/DocumentWindowManager.swift
@@ -32,6 +32,7 @@ class DocumentOutputWindowManager : NSObject
     private var outputWindow: NSWindow?
     private var windowTitle = ""
     private var pendingWithdrawCompletion: (() -> Void)?
+    private var isExitingFullScreen = false
 
     // Toolbar shit
     private weak var playPauseItem: NSToolbarItem?
@@ -60,10 +61,17 @@ class DocumentOutputWindowManager : NSObject
             return
         }
 
-        if window.styleMask.contains(.fullScreen)
+        if window.styleMask.contains(.fullScreen) || self.isExitingFullScreen
         {
+            // A second withdraw can arrive while the exit animation runs;
+            // toggling again would bounce the window back into full screen,
+            // so only the parked completion is replaced.
             self.pendingWithdrawCompletion = completion
-            window.toggleFullScreen(nil)
+            if !self.isExitingFullScreen
+            {
+                self.isExitingFullScreen = true
+                window.toggleFullScreen(nil)
+            }
             return
         }
 
@@ -91,10 +99,29 @@ class DocumentOutputWindowManager : NSObject
 
     func closeWindow()
     {
+        guard let window = self.outputWindow else {
+            self.pendingWithdrawCompletion = nil
+            self.isExitingFullScreen = false
+            return
+        }
+
+        if window.styleMask.contains(.fullScreen) || self.isExitingFullScreen
+        {
+            // Closing a full-screen window in place strands its Space; exit
+            // first and finish from windowDidExitFullScreen.
+            self.pendingWithdrawCompletion = { [weak self] in self?.closeWindow() }
+            if !self.isExitingFullScreen
+            {
+                self.isExitingFullScreen = true
+                window.toggleFullScreen(nil)
+            }
+            return
+        }
+
         self.pendingWithdrawCompletion = nil
-        self.outputWindow?.delegate = nil
-        self.outputWindow?.contentViewController = nil
-        self.outputWindow?.close()
+        window.delegate = nil
+        window.contentViewController = nil
+        window.close()
         self.outputWindow = nil
     }
 
@@ -139,6 +166,7 @@ extension DocumentOutputWindowManager: NSWindowDelegate
 
     func windowDidExitFullScreen(_ notification: Notification)
     {
+        self.isExitingFullScreen = false
         guard let completion = self.pendingWithdrawCompletion else { return }
         self.pendingWithdrawCompletion = nil
         self.withdraw(completion: completion)

--- a/Fabric Editor/Views/DocumentWindowManager.swift
+++ b/Fabric Editor/Views/DocumentWindowManager.swift
@@ -7,8 +7,6 @@
 
 import Foundation
 import AppKit
-import Metal
-import simd
 import Fabric
 import Satin
 
@@ -19,70 +17,88 @@ private enum ToolbarID
     static let playPause = NSToolbarItem.Identifier("playPause")
 }
 
+/// Manages the separate output window. The window does not own rendering:
+/// `OutputPresenter` lends it the document's `MetalViewController` while the
+/// presentation mode is `.separateWindow`, and takes it back for the editor
+/// canvas otherwise.
+@MainActor
 class DocumentOutputWindowManager : NSObject
 {
     weak var ownerDocument: FabricDocument?
-    private var outputwindow: NSWindow? = nil
-    private var outputViewController: MetalViewController? = nil
-    private weak var graphRenderer: GraphRenderer? = nil
-    private var didPresentFatalRuntimeError = false
-    private var lastRecoverableRuntimeError: (any FabricErrorProtocol)?
+    weak var presenter: OutputPresenter?
+
+    // Created on first present(), so documents opened in editor-canvas mode
+    // never pay for a window they may not show.
+    private var outputWindow: NSWindow?
+    private var windowTitle = ""
 
     // Toolbar shit
     private weak var playPauseItem: NSToolbarItem?
 
-    override init()
+    func present(_ viewController: NSViewController)
     {
-        self.outputwindow = NSWindow(contentRect: NSRect(x: 100, y: 100, width: 600, height: 600),
-                                     styleMask: [.titled, .miniaturizable, .resizable, .unifiedTitleAndToolbar],
-                                     backing: .buffered, defer: false)
-        self.outputwindow?.isReleasedWhenClosed = false
-        self.outputwindow?.makeKeyAndOrderFront(nil)
-        self.outputwindow?.level = .normal
+        let window = self.makeWindowIfNeeded()
 
-        super.init()
-
-        self.outputwindow?.delegate = self
-        self.installToolbar()
+        viewController.view.frame = window.contentView?.bounds ?? .zero
+        window.contentViewController = viewController
+        window.makeKeyAndOrderFront(nil)
     }
 
-    private func installToolbar()
+    func withdraw()
     {
-        let tb = NSToolbar(identifier: ToolbarID.output)
-        tb.delegate = self
-        tb.displayMode = .iconOnly
-        tb.sizeMode = .regular
-        tb.allowsUserCustomization = false
-
-        self.outputwindow?.toolbar = tb
-        self.outputwindow?.toolbarStyle = .unified
+        self.outputWindow?.orderOut(nil)
+        self.outputWindow?.contentViewController = nil
     }
 
-    func setGraphRenderer(_ graphRenderer: GraphRenderer)
+    func setWindowTitle(_ title: String)
     {
-        self.graphRenderer = graphRenderer
-        graphRenderer.errorDelegate = self
-
-        let vc = MetalViewController(renderer: graphRenderer)
-        vc.view.frame = self.outputwindow?.contentView?.bounds ?? .zero
-
-        self.outputViewController = vc
-        self.outputwindow?.contentViewController = vc
+        self.windowTitle = title
+        self.outputWindow?.title = title
     }
 
-    func setWindowName(_ name: String)
+    func reflectPlaybackState()
     {
-        self.outputwindow?.title = name
+        guard let presenter = self.presenter else { return }
+
+        self.playPauseItem?.image = NSImage(
+            systemSymbolName: presenter.playbackControlSymbolName,
+            accessibilityDescription: presenter.playbackControlLabel
+        )
+        self.playPauseItem?.label = presenter.playbackControlLabel
     }
 
-    func snapshotExportTime() -> TimeInterval
+    func closeWindow()
     {
-        return self.graphRenderer?.lastGraphExecutionTime ?? 0
+        self.outputWindow?.delegate = nil
+        self.outputWindow?.contentViewController = nil
+        self.outputWindow?.close()
+        self.outputWindow = nil
     }
 
-    func closeOutputWindow()
+    private func makeWindowIfNeeded() -> NSWindow
     {
-        self.outputwindow?.close()
+        if let window = self.outputWindow {
+            return window
+        }
+
+        let window = NSWindow(contentRect: NSRect(x: 100, y: 100, width: 600, height: 600),
+                              styleMask: [.titled, .closable, .miniaturizable, .resizable, .unifiedTitleAndToolbar],
+                              backing: .buffered, defer: false)
+        window.isReleasedWhenClosed = false
+        window.level = .normal
+        window.title = self.windowTitle
+        window.delegate = self
+
+        let toolbar = NSToolbar(identifier: ToolbarID.output)
+        toolbar.delegate = self
+        toolbar.displayMode = .iconOnly
+        toolbar.sizeMode = .regular
+        toolbar.allowsUserCustomization = false
+        window.toolbar = toolbar
+        window.toolbarStyle = .unified
+
+        self.outputWindow = window
+        return window
     }
 
     deinit
@@ -98,60 +114,13 @@ extension DocumentOutputWindowManager: NSWindowDelegate
         ActiveFabricDocumentStore.shared.activeDocument = self.ownerDocument
     }
 
-    func windowWillClose(_ notification: Notification)
+    func windowShouldClose(_ sender: NSWindow) -> Bool
     {
-        self.graphRenderer?.errorDelegate = nil
-        self.outputwindow?.contentViewController = nil  // triggers MetalViewController.cleanup() → renderer.cleanup()
-        self.outputViewController = nil
-        self.graphRenderer = nil
-    }
-}
-
-extension DocumentOutputWindowManager: ErrorRenderDelegate
-{
-    func renderer(_ renderer: Renderer, didFailWith error: any Error)
-    {
-        MainActor.assumeIsolated {
-            self.handleRuntimeError(error)
-        }
-    }
-
-    private func handleRuntimeError(_ error: any Error)
-    {
-        let fabricError = self.fabricError(from: error)
-
-        switch fabricError.severity {
-        case .recoverable:
-            self.lastRecoverableRuntimeError = fabricError
-            print("Recoverable Fabric runtime error: \(fabricError.localizedDescription)")
-
-        case .fatal:
-            guard !self.didPresentFatalRuntimeError else { return }
-            self.didPresentFatalRuntimeError = true
-            self.graphRenderer?.metalView.isPaused = true
-            self.presentFatalRuntimeErrorAlert(fabricError)
-        }
-    }
-
-    private func fabricError(from error: any Error) -> any FabricErrorProtocol
-    {
-        if let fabricError = error as? any FabricErrorProtocol {
-            return fabricError
-        }
-
-        return FabricError(.execution(.failed),
-                           severity: .fatal,
-                           message: error.localizedDescription,
-                           underlyingError: error)
-    }
-
-    private func presentFatalRuntimeErrorAlert(_ error: any FabricErrorProtocol)
-    {
-        let alert = NSAlert()
-        alert.alertStyle = .critical
-        alert.messageText = "Rendering Stopped"
-        alert.informativeText = error.localizedDescription
-        alert.runModal()
+        // The red close button routes here via performClose; move the output
+        // into the editor canvas instead of tearing rendering down. Document
+        // teardown uses close() directly, which skips this delegate method.
+        self.presenter?.mode = .editorCanvas
+        return false
     }
 }
 
@@ -182,12 +151,11 @@ extension DocumentOutputWindowManager: NSToolbarDelegate
         {
         case ToolbarID.playPause:
             let item = NSToolbarItem(itemIdentifier: itemIdentifier)
-            item.label = "Pause"
             item.toolTip = "Start or stop the output render loop"
-            item.image = NSImage(systemSymbolName: "pause.fill", accessibilityDescription: nil)
             item.target = self
             item.action = #selector(togglePlayback)
             self.playPauseItem = item
+            self.reflectPlaybackState()
             return item
 
         default:
@@ -197,13 +165,6 @@ extension DocumentOutputWindowManager: NSToolbarDelegate
 
     @objc private func togglePlayback()
     {
-        guard let metalView = self.graphRenderer?.metalView else { return }
-        metalView.isPaused.toggle()
-
-        self.playPauseItem?.image = NSImage(
-            systemSymbolName: metalView.isPaused ? "play.fill" : "pause.fill",
-            accessibilityDescription: nil
-        )
-        self.playPauseItem?.label = metalView.isPaused ? "Play" : "Pause"
+        self.presenter?.togglePlayback()
     }
 }

--- a/Fabric Editor/Views/OutputCanvasHostView.swift
+++ b/Fabric Editor/Views/OutputCanvasHostView.swift
@@ -1,0 +1,50 @@
+//
+//  OutputCanvasHostView.swift
+//  Fabric Editor
+//
+//  Created by Toby Harris on 8/11/26.
+//
+
+import SwiftUI
+import AppKit
+
+/// Hosts the presenter's Metal view as the node canvas background. The
+/// preview is display-only: the container opts out of hit testing entirely so
+/// canvas interaction is untouched.
+struct OutputCanvasHostView: NSViewRepresentable
+{
+    let presenter: OutputPresenter
+
+    final class PassthroughContainerView: NSView
+    {
+        override func hitTest(_ point: NSPoint) -> NSView? { nil }
+    }
+
+    final class Coordinator
+    {
+        weak var presenter: OutputPresenter?
+    }
+
+    func makeCoordinator() -> Coordinator
+    {
+        Coordinator()
+    }
+
+    func makeNSView(context: Context) -> PassthroughContainerView
+    {
+        PassthroughContainerView()
+    }
+
+    func updateNSView(_ nsView: PassthroughContainerView, context: Context)
+    {
+        context.coordinator.presenter = self.presenter
+        self.presenter.attachCanvasContainer(nsView)
+    }
+
+    static func dismantleNSView(_ nsView: PassthroughContainerView, coordinator: Coordinator)
+    {
+        MainActor.assumeIsolated {
+            coordinator.presenter?.detachCanvasContainer(nsView)
+        }
+    }
+}

--- a/Fabric Editor/Views/OutputPresenter.swift
+++ b/Fabric Editor/Views/OutputPresenter.swift
@@ -57,6 +57,10 @@ final class OutputPresenter
             guard self.isPaused != oldValue else { return }
             self.viewController.metalView.isPaused = self.isPaused
             self.windowManager.reflectPlaybackState()
+
+            // Resuming re-arms the fatal-error alert; without this a second
+            // fatal error after a user resume would be silently swallowed.
+            if !self.isPaused { self.didPresentFatalRuntimeError = false }
         }
     }
 
@@ -71,6 +75,10 @@ final class OutputPresenter
 
     @ObservationIgnored private var didPresentFatalRuntimeError = false
     @ObservationIgnored private var isActive = true
+
+    // Observation fires on willSet, so same-value writes to the app-wide
+    // mode still wake every presenter; re-hosting is gated on this instead.
+    @ObservationIgnored private var appliedMode: OutputPresentationMode?
 
     init(ownerDocument: FabricDocument, renderer: GraphRenderer)
     {
@@ -96,27 +104,33 @@ final class OutputPresenter
         self.isPaused.toggle()
     }
 
-    /// Full teardown when the document's editor window goes away. The
-    /// `MetalViewController` cleans its renderer up when the presenter is
-    /// released along with the document.
+    /// Full teardown when the document's editor window goes away. Renderer
+    /// cleanup is explicit rather than left to the view controller's deinit:
+    /// SwiftUI value copies can keep the presenter alive past the document,
+    /// and a renderer still marked set-up makes any re-created controller
+    /// skip its own setup.
     func teardown()
     {
         self.isActive = false
         self.renderer?.errorDelegate = nil
-        self.viewController.view.removeFromSuperview()
+        self.viewController.viewIfLoaded?.removeFromSuperview()
         self.canvasContainer = nil
         self.windowManager.closeWindow()
+        self.viewController.cleanup()
     }
 
     // MARK: - Canvas hosting
 
     /// `OutputCanvasHostView` hands its container over once it exists; the
-    /// container appears after the mode flips, never before.
+    /// container appears after the mode flips, never before, so the install
+    /// that `applyMode` started is completed here.
     func attachCanvasContainer(_ container: NSView)
     {
         guard self.canvasContainer !== container else { return }
         self.canvasContainer = container
-        self.applyMode()
+
+        guard self.isActive, self.appliedMode == .editorCanvas else { return }
+        self.withdrawWindowThenInstallInCanvas()
     }
 
     func detachCanvasContainer(_ container: NSView)
@@ -128,7 +142,10 @@ final class OutputPresenter
     /// Re-arming observation of the app-wide mode; each presenter applies
     /// changes to its own hosts. The outer closure must capture weakly: the
     /// observation registrar holds it until the mode next changes, which may
-    /// be long after this document closes.
+    /// be long after this document closes. The hop through `Task` is
+    /// required, not a runloop dodge: `onChange` fires on willSet, so
+    /// synchronous work here would read the outgoing mode and re-arm
+    /// against it.
     private func startObservingMode()
     {
         withObservationTracking {
@@ -146,18 +163,28 @@ final class OutputPresenter
     {
         guard self.isActive else { return }
 
-        switch OutputSettings.shared.mode
+        let mode = OutputSettings.shared.mode
+        guard mode != self.appliedMode else { return }
+        self.appliedMode = mode
+
+        switch mode
         {
         case .separateWindow:
-            self.viewController.view.removeFromSuperview()
+            self.viewController.viewIfLoaded?.removeFromSuperview()
             self.windowManager.present(self.viewController)
 
         case .editorCanvas:
-            // Withdrawal completes asynchronously when the window has to
-            // exit full screen first.
-            self.windowManager.withdraw { [weak self] in
-                self?.installInCanvas()
-            }
+            self.withdrawWindowThenInstallInCanvas()
+        }
+    }
+
+    /// Withdrawal completes asynchronously when the window has to exit full
+    /// screen first; repeating it while that exit is in flight just replaces
+    /// the parked install.
+    private func withdrawWindowThenInstallInCanvas()
+    {
+        self.windowManager.withdraw { [weak self] in
+            self?.installInCanvas()
         }
     }
 

--- a/Fabric Editor/Views/OutputPresenter.swift
+++ b/Fabric Editor/Views/OutputPresenter.swift
@@ -1,0 +1,185 @@
+//
+//  OutputPresenter.swift
+//  Fabric Editor
+//
+//  Created by Toby Harris on 8/11/26.
+//
+
+import AppKit
+import SwiftUI
+import Fabric
+import Satin
+
+/// Where a document's rendered output is hosted.
+enum OutputPresentationMode: String
+{
+    case separateWindow
+    case editorCanvas
+}
+
+/// Owns the document's single `MetalViewController` and moves it between the
+/// two hosts: the output window and the editor canvas background. Renderer,
+/// Metal view, and the display link that drives graph execution are shared
+/// across both, so playback state and the drawable pipeline carry over a mode
+/// change.
+@MainActor @Observable
+final class OutputPresenter
+{
+    private static let modeDefaultsKey = "outputPresentationMode"
+
+    var mode: OutputPresentationMode
+    {
+        didSet
+        {
+            guard self.mode != oldValue else { return }
+            UserDefaults.standard.set(self.mode.rawValue, forKey: Self.modeDefaultsKey)
+            self.applyMode()
+        }
+    }
+
+    var isPaused: Bool = false
+    {
+        didSet
+        {
+            guard self.isPaused != oldValue else { return }
+            self.viewController.metalView.isPaused = self.isPaused
+            self.windowManager.reflectPlaybackState()
+        }
+    }
+
+    // The one place the playback control's face is defined; both toolbars use it.
+    var playbackControlLabel: String { self.isPaused ? "Play" : "Pause" }
+    var playbackControlSymbolName: String { self.isPaused ? "play.fill" : "pause.fill" }
+
+    @ObservationIgnored private let viewController: MetalViewController
+    @ObservationIgnored private let windowManager: DocumentOutputWindowManager
+    @ObservationIgnored private weak var renderer: GraphRenderer?
+    @ObservationIgnored private weak var canvasContainer: NSView?
+
+    @ObservationIgnored private var didPresentFatalRuntimeError = false
+
+    init(ownerDocument: FabricDocument, renderer: GraphRenderer)
+    {
+        let storedMode = UserDefaults.standard.string(forKey: Self.modeDefaultsKey)
+        self.mode = storedMode.flatMap(OutputPresentationMode.init(rawValue:)) ?? .separateWindow
+
+        self.renderer = renderer
+        self.viewController = MetalViewController(renderer: renderer)
+        self.windowManager = DocumentOutputWindowManager()
+
+        renderer.errorDelegate = self
+        self.windowManager.ownerDocument = ownerDocument
+        self.windowManager.presenter = self
+
+        self.applyMode()
+    }
+
+    func setWindowTitle(_ title: String)
+    {
+        self.windowManager.setWindowTitle(title)
+    }
+
+    func togglePlayback()
+    {
+        self.isPaused.toggle()
+    }
+
+    /// Full teardown when the document's editor window goes away. The
+    /// `MetalViewController` cleans its renderer up when the presenter is
+    /// released along with the document.
+    func teardown()
+    {
+        self.renderer?.errorDelegate = nil
+        self.viewController.view.removeFromSuperview()
+        self.canvasContainer = nil
+        self.windowManager.closeWindow()
+    }
+
+    // MARK: - Canvas hosting
+
+    /// `OutputCanvasHostView` hands its container over once it exists; the
+    /// container appears after the mode flips, never before.
+    func attachCanvasContainer(_ container: NSView)
+    {
+        guard self.canvasContainer !== container else { return }
+        self.canvasContainer = container
+        self.applyMode()
+    }
+
+    func detachCanvasContainer(_ container: NSView)
+    {
+        guard self.canvasContainer === container else { return }
+        self.canvasContainer = nil
+    }
+
+    private func applyMode()
+    {
+        switch self.mode
+        {
+        case .separateWindow:
+            self.viewController.view.removeFromSuperview()
+            self.windowManager.present(self.viewController)
+
+        case .editorCanvas:
+            self.windowManager.withdraw()
+            self.installInCanvas()
+        }
+    }
+
+    private func installInCanvas()
+    {
+        guard let container = self.canvasContainer else { return }
+
+        let view = self.viewController.view
+        view.frame = container.bounds
+        view.autoresizingMask = [.width, .height]
+        container.addSubview(view)
+    }
+}
+
+extension OutputPresenter: ErrorRenderDelegate
+{
+    nonisolated func renderer(_ renderer: Renderer, didFailWith error: any Error)
+    {
+        MainActor.assumeIsolated {
+            self.handleRuntimeError(error)
+        }
+    }
+
+    private func handleRuntimeError(_ error: any Error)
+    {
+        let fabricError = self.fabricError(from: error)
+
+        switch fabricError.severity {
+        case .recoverable:
+            print("Recoverable Fabric runtime error: \(fabricError.localizedDescription)")
+
+        case .fatal:
+            guard !self.didPresentFatalRuntimeError else { return }
+            self.didPresentFatalRuntimeError = true
+            self.isPaused = true
+            self.presentFatalRuntimeErrorAlert(fabricError)
+        }
+    }
+
+    private func fabricError(from error: any Error) -> any FabricErrorProtocol
+    {
+        if let fabricError = error as? any FabricErrorProtocol {
+            return fabricError
+        }
+
+        return FabricError(.execution(.failed),
+                           severity: .fatal,
+                           message: error.localizedDescription,
+                           underlyingError: error)
+    }
+
+    private func presentFatalRuntimeErrorAlert(_ error: any FabricErrorProtocol)
+    {
+        let alert = NSAlert()
+        alert.alertStyle = .critical
+        alert.messageText = "Rendering Stopped"
+        alert.informativeText = error.localizedDescription
+        alert.runModal()
+    }
+}

--- a/Fabric Editor/Views/OutputPresenter.swift
+++ b/Fabric Editor/Views/OutputPresenter.swift
@@ -121,8 +121,11 @@ final class OutputPresenter
             self.windowManager.present(self.viewController)
 
         case .editorCanvas:
-            self.windowManager.withdraw()
-            self.installInCanvas()
+            // Withdrawal completes asynchronously when the window has to
+            // exit full screen first.
+            self.windowManager.withdraw { [weak self] in
+                self?.installInCanvas()
+            }
         }
     }
 

--- a/Fabric Editor/Views/OutputPresenter.swift
+++ b/Fabric Editor/Views/OutputPresenter.swift
@@ -10,11 +10,36 @@ import SwiftUI
 import Fabric
 import Satin
 
-/// Where a document's rendered output is hosted.
+/// Where rendered output is hosted.
 enum OutputPresentationMode: String
 {
     case separateWindow
     case editorCanvas
+}
+
+/// The app-wide output presentation mode, persisted across launches. Every
+/// document's presenter observes it and re-hosts accordingly.
+@MainActor @Observable
+final class OutputSettings
+{
+    static let shared = OutputSettings()
+
+    private static let modeDefaultsKey = "outputPresentationMode"
+
+    var mode: OutputPresentationMode
+    {
+        didSet
+        {
+            guard self.mode != oldValue else { return }
+            UserDefaults.standard.set(self.mode.rawValue, forKey: Self.modeDefaultsKey)
+        }
+    }
+
+    private init()
+    {
+        let storedMode = UserDefaults.standard.string(forKey: Self.modeDefaultsKey)
+        self.mode = storedMode.flatMap(OutputPresentationMode.init(rawValue:)) ?? .separateWindow
+    }
 }
 
 /// Owns the document's single `MetalViewController` and moves it between the
@@ -25,18 +50,6 @@ enum OutputPresentationMode: String
 @MainActor @Observable
 final class OutputPresenter
 {
-    private static let modeDefaultsKey = "outputPresentationMode"
-
-    var mode: OutputPresentationMode
-    {
-        didSet
-        {
-            guard self.mode != oldValue else { return }
-            UserDefaults.standard.set(self.mode.rawValue, forKey: Self.modeDefaultsKey)
-            self.applyMode()
-        }
-    }
-
     var isPaused: Bool = false
     {
         didSet
@@ -57,12 +70,10 @@ final class OutputPresenter
     @ObservationIgnored private weak var canvasContainer: NSView?
 
     @ObservationIgnored private var didPresentFatalRuntimeError = false
+    @ObservationIgnored private var isActive = true
 
     init(ownerDocument: FabricDocument, renderer: GraphRenderer)
     {
-        let storedMode = UserDefaults.standard.string(forKey: Self.modeDefaultsKey)
-        self.mode = storedMode.flatMap(OutputPresentationMode.init(rawValue:)) ?? .separateWindow
-
         self.renderer = renderer
         self.viewController = MetalViewController(renderer: renderer)
         self.windowManager = DocumentOutputWindowManager()
@@ -72,6 +83,7 @@ final class OutputPresenter
         self.windowManager.presenter = self
 
         self.applyMode()
+        self.startObservingMode()
     }
 
     func setWindowTitle(_ title: String)
@@ -89,6 +101,7 @@ final class OutputPresenter
     /// released along with the document.
     func teardown()
     {
+        self.isActive = false
         self.renderer?.errorDelegate = nil
         self.viewController.view.removeFromSuperview()
         self.canvasContainer = nil
@@ -112,9 +125,28 @@ final class OutputPresenter
         self.canvasContainer = nil
     }
 
+    /// Re-arming observation of the app-wide mode; each presenter applies
+    /// changes to its own hosts. The outer closure must capture weakly: the
+    /// observation registrar holds it until the mode next changes, which may
+    /// be long after this document closes.
+    private func startObservingMode()
+    {
+        withObservationTracking {
+            _ = OutputSettings.shared.mode
+        } onChange: { [weak self] in
+            Task { @MainActor in
+                guard let self, self.isActive else { return }
+                self.applyMode()
+                self.startObservingMode()
+            }
+        }
+    }
+
     private func applyMode()
     {
-        switch self.mode
+        guard self.isActive else { return }
+
+        switch OutputSettings.shared.mode
         {
         case .separateWindow:
             self.viewController.view.removeFromSuperview()


### PR DESCRIPTION
Adds an app-wide setting for the output to render in a window (as before) or in the editor itself, replacing the node canvas’s background gradient. Windowed output when full-screen loses the toolbar for fully full-fullscreen-ness. Default remains windowed output. Per-document was explored but proved cumbersome (see first commit).

<img width="912" height="649" alt="Screenshot 2026-08-20 at 22 35 08" src="https://github.com/user-attachments/assets/2a127d60-867e-4836-82a3-445d8b5a9b26" />
