### PR TITLE
Features/fabric image transform

### DIFF
--- a/Fabric.xcodeproj/project.pbxproj
+++ b/Fabric.xcodeproj/project.pbxproj
@@ -221,7 +221,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_VIEW = TRUE;
 				DEVELOPMENT_ASSET_PATHS = "\"Fabric Editor/Preview Content\"";
@@ -241,7 +241,7 @@
 					"@executable_path/../Frameworks/Fabric.framework/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.6;
-				MARKETING_VERSION = 0.0.13;
+				MARKETING_VERSION = 0.1;
 				OTHER_CODE_SIGN_FLAGS = "--deep";
 				PRODUCT_BUNDLE_IDENTIFIER = graphics.fabric.FabricEditor;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -264,7 +264,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_VIEW = TRUE;
 				DEVELOPMENT_ASSET_PATHS = "\"Fabric Editor/Preview Content\"";
@@ -284,7 +284,7 @@
 					"@executable_path/../Frameworks/Fabric.framework/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.6;
-				MARKETING_VERSION = 0.0.13;
+				MARKETING_VERSION = 0.1;
 				OTHER_CODE_SIGN_FLAGS = "--deep";
 				PRODUCT_BUNDLE_IDENTIFIER = graphics.fabric.FabricEditor;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Fabric/Effects/Analysis/FXAA.metal
+++ b/Fabric/Effects/Analysis/FXAA.metal
@@ -7,6 +7,7 @@ using namespace metal;
 #define SAMPLER_TYPE texture2d<half>
 
 #include "../../lygia/sampler.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 static inline float luma(float3 rgb) {
     return dot(rgb, float3(0.299f, 0.587f, 0.114f));
@@ -14,11 +15,15 @@ static inline float luma(float3 rgb) {
 
 fragment half4 postFragment(
     VertexData in [[stage_in]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> tex [[texture(FragmentTextureCustom0)]]
 ) {
     float2 uv = in.texcoord;
 
-    float2 texSize = float2(tex.get_width(), tex.get_height());
+    float2 texSize = fabricPresentationSize(
+        imageTransforms[0],
+        float2(tex.get_width(), tex.get_height())
+    );
     float2 rcpFrame = 1.0f / texSize;
 
     // Rebuild pixel-space position
@@ -35,11 +40,11 @@ fragment half4 postFragment(
     float2 uvSW = (posM + float2(0.0f, 1.0f)) * rcpFrame;
     float2 uvSE = (posM + float2(1.0f, 1.0f)) * rcpFrame;
 
-    float3 rgbNW = float3(SAMPLER_FNC(tex, uvNW).rgb);
-    float3 rgbNE = float3(SAMPLER_FNC(tex, uvNE).rgb);
-    float3 rgbSW = float3(SAMPLER_FNC(tex, uvSW).rgb);
-    float3 rgbSE = float3(SAMPLER_FNC(tex, uvSE).rgb);
-    float3 rgbM  = float3(SAMPLER_FNC(tex, uvM ).rgb);
+    float3 rgbNW = float3(SAMPLER_FNC(tex, fabricTextureCoordinate(imageTransforms[0], uvNW)).rgb);
+    float3 rgbNE = float3(SAMPLER_FNC(tex, fabricTextureCoordinate(imageTransforms[0], uvNE)).rgb);
+    float3 rgbSW = float3(SAMPLER_FNC(tex, fabricTextureCoordinate(imageTransforms[0], uvSW)).rgb);
+    float3 rgbSE = float3(SAMPLER_FNC(tex, fabricTextureCoordinate(imageTransforms[0], uvSE)).rgb);
+    float3 rgbM  = float3(SAMPLER_FNC(tex, fabricTextureCoordinate(imageTransforms[0], uvM)).rgb);
 
     float lumaNW = luma(rgbNW);
     float lumaNE = luma(rgbNE);
@@ -73,13 +78,13 @@ fragment half4 postFragment(
     float2 dirUV = dir * rcpFrame;
 
     half4 rgbA = 0.5h * (
-        SAMPLER_FNC(tex, uvM + dirUV * (1.0f/3.0f - 0.5f)) +
-        SAMPLER_FNC(tex, uvM + dirUV * (2.0f/3.0f - 0.5f))
+        SAMPLER_FNC(tex, fabricTextureCoordinate(imageTransforms[0], uvM + dirUV * (1.0f/3.0f - 0.5f))) +
+        SAMPLER_FNC(tex, fabricTextureCoordinate(imageTransforms[0], uvM + dirUV * (2.0f/3.0f - 0.5f)))
     );
 
     half4 rgbB = rgbA * 0.5h + 0.25h * (
-        SAMPLER_FNC(tex, uvM + dirUV * (0.0f/3.0f - 0.5f)) +
-        SAMPLER_FNC(tex, uvM + dirUV * (3.0f/3.0f - 0.5f))
+        SAMPLER_FNC(tex, fabricTextureCoordinate(imageTransforms[0], uvM + dirUV * (0.0f/3.0f - 0.5f))) +
+        SAMPLER_FNC(tex, fabricTextureCoordinate(imageTransforms[0], uvM + dirUV * (3.0f/3.0f - 0.5f)))
     );
 
     float lumaB = luma(float3(rgbB.rgb));

--- a/Fabric/Effects/Blur/LinearizeDepth.metal
+++ b/Fabric/Effects/Blur/LinearizeDepth.metal
@@ -12,6 +12,7 @@
 #include "../../lygia/sampler.msl"
 #include "../../lygia/sample/clamp2edge.msl"
 #include "../../lygia/space/linearizeDepth.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
     float near; // input, Near
@@ -20,8 +21,10 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<float, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    float color = linearizeDepth( sampleClamp2edge(renderTex, in.texcoord).r, uniforms.near, uniforms.far);
+    const float2 imageUV = fabricTextureCoordinate(imageTransforms[0], in.texcoord);
+    float color = linearizeDepth(sampleClamp2edge(renderTex, imageUV).r, uniforms.near, uniforms.far);
     return half4( half3(color), 1.0);
 }

--- a/Fabric/Effects/ColorAdjust/BrightnessContrastSaturation.metal
+++ b/Fabric/Effects/ColorAdjust/BrightnessContrastSaturation.metal
@@ -12,6 +12,7 @@
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/brightnessContrast.msl"
 #include "../../lygia/color/luminance.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 
 typedef struct {
@@ -22,9 +23,10 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    half4 color = SAMPLER_FNC( renderTex, in.texcoord );
+    half4 color = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
 
     half4 bc = brightnessContrast(color, uniforms.brightness, uniforms.contrast);
     

--- a/Fabric/Effects/ColorAdjust/Channel Mixer.metal
+++ b/Fabric/Effects/ColorAdjust/Channel Mixer.metal
@@ -7,6 +7,7 @@ using namespace metal;
 #define SAMPLER_TYPE texture2d<half>
 
 #include "../../lygia/sampler.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 
 // Uniforms → Fabric UI controls
@@ -19,11 +20,12 @@ typedef struct {
 
 fragment half4 postFragment( VertexData                        in        [[stage_in]],
                              constant PostUniforms            &uniforms  [[buffer( FragmentBufferMaterialUniforms )]],
+                             constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
                              texture2d<half, access::sample>   tex        [[texture( FragmentTextureCustom0 )]] )
 {
     float2 uv = in.texcoord;
 
-    half4 input0 = SAMPLER_FNC(tex, uv);
+    half4 input0 = SAMPLER_FNC(tex, fabricTextureCoordinate(imageTransforms[0], uv));
     half3 rgb = input0.rgb;
 
     // Channel mixing

--- a/Fabric/Effects/ColorAdjust/Exposure.metal
+++ b/Fabric/Effects/ColorAdjust/Exposure.metal
@@ -11,6 +11,7 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/exposure.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 
 typedef struct {
@@ -19,9 +20,10 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    half4 color = SAMPLER_FNC( renderTex, in.texcoord );
+    half4 color = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
 
     return half4( exposure( float4(color), uniforms.e) );
 }

--- a/Fabric/Effects/ColorAdjust/Gamma.metal
+++ b/Fabric/Effects/ColorAdjust/Gamma.metal
@@ -11,6 +11,7 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/levels/gamma.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 
 typedef struct {
@@ -19,9 +20,10 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    half4 color = SAMPLER_FNC( renderTex, in.texcoord );
+    half4 color = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
 
     return half4( levelsGamma( float4(color), uniforms.g) );
 }

--- a/Fabric/Effects/ColorAdjust/Hue.metal
+++ b/Fabric/Effects/ColorAdjust/Hue.metal
@@ -12,6 +12,7 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/hueShift.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
     float hue; // slider, 0.0, 1.0, 0.0, Hue
@@ -19,9 +20,10 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    half4 color = SAMPLER_FNC( renderTex, in.texcoord );
+    half4 color = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
 
     return half4( hueShift( float4(color), uniforms.hue) );
 }

--- a/Fabric/Effects/ColorAdjust/Levels.metal
+++ b/Fabric/Effects/ColorAdjust/Levels.metal
@@ -11,6 +11,7 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/levels.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 
 typedef struct {
@@ -22,9 +23,10 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    half4 color = SAMPLER_FNC( renderTex, in.texcoord );
+    half4 color = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
 
     return half4( levelsOutputRange(  levelsInputRange(float4(color), uniforms.iMin, uniforms.iMax), uniforms.oMin, uniforms.oMax) );
 }

--- a/Fabric/Effects/ColorAdjust/LinearRGBToSRGB.metal
+++ b/Fabric/Effects/ColorAdjust/LinearRGBToSRGB.metal
@@ -11,6 +11,7 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/space/rgb2srgb.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 
 typedef struct {
@@ -18,9 +19,10 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    half4 color = SAMPLER_FNC( renderTex, in.texcoord );
+    half4 color = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
 
     return half4( rgb2srgb( color ) );
 }

--- a/Fabric/Effects/ColorAdjust/Posterize.metal
+++ b/Fabric/Effects/ColorAdjust/Posterize.metal
@@ -9,6 +9,7 @@
 #define SAMPLER_TYPE texture2d<half>
 
 #include "../../lygia/sampler.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
     float levels; // slider, 2, 256, 8, Levels Per Channel
@@ -17,10 +18,11 @@ typedef struct {
 fragment half4 postFragment(
     VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer(FragmentBufferMaterialUniforms)]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture(FragmentTextureCustom0)]]
 )
 {
-    const half4 color = SAMPLER_FNC(renderTex, in.texcoord);
+    const half4 color = SAMPLER_FNC(renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
     const float numberOfSteps = round(clamp(uniforms.levels, 2.0, 256.0) - 1.0);
     const float3 posterizedRGB = round( float3(color.rgb) * numberOfSteps) / numberOfSteps;
 

--- a/Fabric/Effects/ColorAdjust/SRGBToLinearRGB.metal
+++ b/Fabric/Effects/ColorAdjust/SRGBToLinearRGB.metal
@@ -11,6 +11,7 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/space/srgb2rgb.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 
 typedef struct {
@@ -18,9 +19,10 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    half4 color = SAMPLER_FNC( renderTex, in.texcoord );
+    half4 color = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
 
     return half4( srgb2rgb( color ) );
 }

--- a/Fabric/Effects/ColorAdjust/Vibrance.metal
+++ b/Fabric/Effects/ColorAdjust/Vibrance.metal
@@ -11,6 +11,7 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/vibrance.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 
 typedef struct {
@@ -19,9 +20,10 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    half4 color = SAMPLER_FNC( renderTex, in.texcoord );
+    half4 color = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
 
     return half4( vibrance( float4(color), uniforms.v) );
 }

--- a/Fabric/Effects/ColorAdjust/White Balance.metal
+++ b/Fabric/Effects/ColorAdjust/White Balance.metal
@@ -11,6 +11,7 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/whiteBalance.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 
 typedef struct {
@@ -20,9 +21,10 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    half4 color = SAMPLER_FNC( renderTex, in.texcoord );
+    half4 color = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
 
     return half4( whiteBalance( float4(color), uniforms.temp, uniforms.tint) );
 }

--- a/Fabric/Effects/ColorEffect/DuoTone.metal
+++ b/Fabric/Effects/ColorEffect/DuoTone.metal
@@ -10,6 +10,7 @@
 #define SAMPLER_TYPE texture2d<half>
 
 #include "../../lygia/sampler.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
     float3 low; // color, 0.0, 1.0, 1.0, Dark Color
@@ -18,9 +19,10 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    half4 color = SAMPLER_FNC( renderTex, in.texcoord );
+    half4 color = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
     half3 rgb = mix( half3(uniforms.low),
                      half3(uniforms.high),
                     color.rgb);

--- a/Fabric/Effects/ColorEffect/Invert.metal
+++ b/Fabric/Effects/ColorEffect/Invert.metal
@@ -10,15 +10,18 @@
 #define SAMPLER_TYPE texture2d<half>
 
 #include "../../lygia/sampler.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
 } PostUniforms;
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    half4 color = SAMPLER_FNC( renderTex, in.texcoord );
+    const float2 imageUV = fabricTextureCoordinate(imageTransforms[0], in.texcoord);
+    half4 color = SAMPLER_FNC(renderTex, imageUV);
 
     return half4(1.0 - color.rgb, color.a);
 }

--- a/Fabric/Effects/ColorEffect/Threshold.metal
+++ b/Fabric/Effects/ColorEffect/Threshold.metal
@@ -11,6 +11,7 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/luminance.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
     float threshold; // slider, 0.0, 1.0, 0.5, Threshold
@@ -18,9 +19,10 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    half4 color = SAMPLER_FNC( renderTex, in.texcoord );
+    half4 color = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
     half luma = luminance(color);
     half thresh = luma < uniforms.threshold ? 0.0 : 1.0;
     

--- a/Fabric/Effects/ColorSpace/CMYK to RGB.metal
+++ b/Fabric/Effects/ColorSpace/CMYK to RGB.metal
@@ -11,15 +11,17 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/space/cmyk2rgb.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
 } PostUniforms;
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    half4 color = SAMPLER_FNC( renderTex, in.texcoord );
+    half4 color = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
 
     return half4(cmyk2rgb( color ), color.a);
 }

--- a/Fabric/Effects/ColorSpace/Channel Subsample.metal
+++ b/Fabric/Effects/ColorSpace/Channel Subsample.metal
@@ -6,6 +6,7 @@
 //
 
 #include <metal_stdlib>
+#include "../../Shaders/FabricImageTextureTransform.metal"
 using namespace metal;
 
 typedef struct {
@@ -39,52 +40,74 @@ static uint2 subsampledCoordinate(
     return min(blockOrigin + centerOffset, textureSize - 1);
 }
 
+static uint2 storedTextureCoordinate(
+    uint2 presentationCoordinate,
+    uint2 presentationSize,
+    uint2 textureSize,
+    float4x4 textureTransform
+) {
+    const float2 presentationUV =
+        (float2(presentationCoordinate) + 0.5) / float2(presentationSize);
+    const float2 storedUV = fabricTextureCoordinate(textureTransform, presentationUV);
+    return min(uint2(storedUV * float2(textureSize)), textureSize - 1);
+}
+
 fragment half4 postFragment(
     VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer(FragmentBufferMaterialUniforms)]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::read> renderTex [[texture(FragmentTextureCustom0)]]
 ) {
     const uint2 textureSize = uint2(
         renderTex.get_width(),
         renderTex.get_height()
     );
-    const uint2 coordinate = min(
-        uint2(in.texcoord * float2(textureSize)),
-        textureSize - 1
+    const uint2 presentationSize = uint2(
+        fabricPresentationSize(imageTransforms[0], float2(textureSize))
+    );
+    const uint2 presentationCoordinate = min(
+        uint2(in.texcoord * float2(presentationSize)),
+        presentationSize - 1
+    );
+    const uint2 coordinate = storedTextureCoordinate(
+        presentationCoordinate,
+        presentationSize,
+        textureSize,
+        imageTransforms[0]
     );
 
     const half4 source = renderTex.read(coordinate);
 
     const uint2 channel1Coordinate = subsampledCoordinate(
-        coordinate,
-        textureSize,
+        presentationCoordinate,
+        presentationSize,
         uniforms.channel1Horizontal,
         uniforms.channel1Vertical
     );
     const uint2 channel2Coordinate = subsampledCoordinate(
-        coordinate,
-        textureSize,
+        presentationCoordinate,
+        presentationSize,
         uniforms.channel2Horizontal,
         uniforms.channel2Vertical
     );
     const uint2 channel3Coordinate = subsampledCoordinate(
-        coordinate,
-        textureSize,
+        presentationCoordinate,
+        presentationSize,
         uniforms.channel3Horizontal,
         uniforms.channel3Vertical
     );
     const uint2 channel4Coordinate = subsampledCoordinate(
-        coordinate,
-        textureSize,
+        presentationCoordinate,
+        presentationSize,
         uniforms.channel4Horizontal,
         uniforms.channel4Vertical
     );
 
     const half4 subsampled = half4(
-        renderTex.read(channel1Coordinate).r,
-        renderTex.read(channel2Coordinate).g,
-        renderTex.read(channel3Coordinate).b,
-        renderTex.read(channel4Coordinate).a
+        renderTex.read(storedTextureCoordinate(channel1Coordinate, presentationSize, textureSize, imageTransforms[0])).r,
+        renderTex.read(storedTextureCoordinate(channel2Coordinate, presentationSize, textureSize, imageTransforms[0])).g,
+        renderTex.read(storedTextureCoordinate(channel3Coordinate, presentationSize, textureSize, imageTransforms[0])).b,
+        renderTex.read(storedTextureCoordinate(channel4Coordinate, presentationSize, textureSize, imageTransforms[0])).a
     );
 
     return mix(source, subsampled, half(clamp(uniforms.amount, 0.0, 1.0)));

--- a/Fabric/Effects/ColorSpace/Color Clamp.metal
+++ b/Fabric/Effects/ColorSpace/Color Clamp.metal
@@ -10,6 +10,7 @@
 #define SAMPLER_TYPE texture2d<half>
 
 #include "../../lygia/sampler.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
     
@@ -19,9 +20,10 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    half4 color = SAMPLER_FNC( renderTex, in.texcoord );
+    half4 color = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
 
     return clamp( color, uniforms.min, uniforms.max );
 }

--- a/Fabric/Effects/ColorSpace/HSV to RGB.metal
+++ b/Fabric/Effects/ColorSpace/HSV to RGB.metal
@@ -11,15 +11,17 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/space/hsv2rgb.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
 } PostUniforms;
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    half4 color = SAMPLER_FNC( renderTex, in.texcoord );
+    half4 color = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
 
     return hsv2rgb( color );
 }

--- a/Fabric/Effects/ColorSpace/LAB to RGB.metal
+++ b/Fabric/Effects/ColorSpace/LAB to RGB.metal
@@ -11,15 +11,17 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/space/lab2rgb.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
 } PostUniforms;
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    half4 color = SAMPLER_FNC( renderTex, in.texcoord );
+    half4 color = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
 
     return lab2rgb( color );
 }

--- a/Fabric/Effects/ColorSpace/LAB to XYZ.metal
+++ b/Fabric/Effects/ColorSpace/LAB to XYZ.metal
@@ -11,15 +11,17 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/space/lab2xyz.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
 } PostUniforms;
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    half4 color = SAMPLER_FNC( renderTex, in.texcoord );
+    half4 color = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
 
     return lab2xyz( color );
 }

--- a/Fabric/Effects/ColorSpace/RGB to CMYK.metal
+++ b/Fabric/Effects/ColorSpace/RGB to CMYK.metal
@@ -11,15 +11,17 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/space/rgb2cmyk.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
 } PostUniforms;
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    half4 color = SAMPLER_FNC( renderTex, in.texcoord );
+    half4 color = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
 
     return rgb2cmyk( color.rgb );
 }

--- a/Fabric/Effects/ColorSpace/RGB to HSV.metal
+++ b/Fabric/Effects/ColorSpace/RGB to HSV.metal
@@ -11,15 +11,17 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/space/rgb2hsv.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
 } PostUniforms;
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    half4 color = SAMPLER_FNC( renderTex, in.texcoord );
+    half4 color = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
 
     return rgb2hsv( color );
 }

--- a/Fabric/Effects/ColorSpace/RGB to LAB.metal
+++ b/Fabric/Effects/ColorSpace/RGB to LAB.metal
@@ -11,15 +11,17 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/space/rgb2lab.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
 } PostUniforms;
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    half4 color = SAMPLER_FNC( renderTex, in.texcoord );
+    half4 color = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
 
     return rgb2lab( color );
 }

--- a/Fabric/Effects/ColorSpace/RGB to XYZ.metal
+++ b/Fabric/Effects/ColorSpace/RGB to XYZ.metal
@@ -11,15 +11,17 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/space/rgb2xyz.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
 } PostUniforms;
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    half4 color = SAMPLER_FNC( renderTex, in.texcoord );
+    half4 color = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
 
     return rgb2xyz( color );
 }

--- a/Fabric/Effects/ColorSpace/RGB to YIQ.metal
+++ b/Fabric/Effects/ColorSpace/RGB to YIQ.metal
@@ -11,15 +11,17 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/space/rgb2yiq.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
 } PostUniforms;
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    half4 color = SAMPLER_FNC( renderTex, in.texcoord );
+    half4 color = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
 
     return rgb2yiq( color );
 }

--- a/Fabric/Effects/ColorSpace/RGB to YPbPr.metal
+++ b/Fabric/Effects/ColorSpace/RGB to YPbPr.metal
@@ -11,15 +11,17 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/space/rgb2YPbPr.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
 } PostUniforms;
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    half4 color = SAMPLER_FNC( renderTex, in.texcoord );
+    half4 color = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
 
     return rgb2YPbPr( color );
 }

--- a/Fabric/Effects/ColorSpace/RGB to YUV.metal
+++ b/Fabric/Effects/ColorSpace/RGB to YUV.metal
@@ -11,15 +11,17 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/space/rgb2yuv.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
 } PostUniforms;
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    half4 color = SAMPLER_FNC( renderTex, in.texcoord );
+    half4 color = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
 
     return rgb2yuv( color );
 }

--- a/Fabric/Effects/ColorSpace/XYZ to LAB.metal
+++ b/Fabric/Effects/ColorSpace/XYZ to LAB.metal
@@ -11,15 +11,17 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/space/xyz2lab.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
 } PostUniforms;
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    half4 color = SAMPLER_FNC( renderTex, in.texcoord );
+    half4 color = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
 
     return xyz2lab( color );
 }

--- a/Fabric/Effects/ColorSpace/XYZ to RGB.metal
+++ b/Fabric/Effects/ColorSpace/XYZ to RGB.metal
@@ -11,15 +11,17 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/space/xyz2rgb.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
 } PostUniforms;
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    half4 color = SAMPLER_FNC( renderTex, in.texcoord );
+    half4 color = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
 
     return xyz2rgb( color );
 }

--- a/Fabric/Effects/ColorSpace/YIQ to RGB.metal
+++ b/Fabric/Effects/ColorSpace/YIQ to RGB.metal
@@ -11,15 +11,17 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/space/yiq2rgb.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
 } PostUniforms;
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    half4 color = SAMPLER_FNC( renderTex, in.texcoord );
+    half4 color = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
 
     return yiq2rgb( color );
 }

--- a/Fabric/Effects/ColorSpace/YPbPr to RGB.metal
+++ b/Fabric/Effects/ColorSpace/YPbPr to RGB.metal
@@ -11,15 +11,17 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/space/YPbPr2rgb.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
 } PostUniforms;
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    half4 color = SAMPLER_FNC( renderTex, in.texcoord );
+    half4 color = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
 
     return YPbPr2rgb( color );
 }

--- a/Fabric/Effects/ColorSpace/YUV to RGB.metal
+++ b/Fabric/Effects/ColorSpace/YUV to RGB.metal
@@ -11,15 +11,17 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/space/yuv2rgb.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
 } PostUniforms;
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    half4 color = SAMPLER_FNC( renderTex, in.texcoord );
+    half4 color = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
 
     return yuv2rgb( color );
 }

--- a/Fabric/Effects/ColorToneMap/Aces.metal
+++ b/Fabric/Effects/ColorToneMap/Aces.metal
@@ -11,6 +11,7 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/tonemap/aces.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 
 typedef struct {
@@ -18,9 +19,10 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    half4 color = SAMPLER_FNC( renderTex, in.texcoord );
+    half4 color = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
 
     return tonemapACES( color );
 }

--- a/Fabric/Effects/ColorToneMap/Filmic.metal
+++ b/Fabric/Effects/ColorToneMap/Filmic.metal
@@ -11,6 +11,7 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/tonemap/filmic.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 
 typedef struct {
@@ -18,9 +19,10 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    half4 color = SAMPLER_FNC( renderTex, in.texcoord );
+    half4 color = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
 
     return tonemapFilmic( color );
 }

--- a/Fabric/Effects/ColorToneMap/Reinhard Jodie.metal
+++ b/Fabric/Effects/ColorToneMap/Reinhard Jodie.metal
@@ -11,6 +11,7 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/tonemap/reinhardJodie.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 
 typedef struct {
@@ -18,9 +19,10 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    half4 color = SAMPLER_FNC( renderTex, in.texcoord );
+    half4 color = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
 
     return tonemapReinhardJodie( color );
 }

--- a/Fabric/Effects/ColorToneMap/Reinhard.metal
+++ b/Fabric/Effects/ColorToneMap/Reinhard.metal
@@ -11,6 +11,7 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/tonemap/reinhard.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 
 typedef struct {
@@ -18,9 +19,10 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    half4 color = SAMPLER_FNC( renderTex, in.texcoord );
+    half4 color = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
 
     return tonemapReinhard( color );
 }

--- a/Fabric/Effects/ColorToneMap/Uncharted 2.metal
+++ b/Fabric/Effects/ColorToneMap/Uncharted 2.metal
@@ -11,6 +11,7 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/tonemap/uncharted2.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 
 typedef struct {
@@ -18,9 +19,10 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    half4 color = SAMPLER_FNC( renderTex, in.texcoord );
+    half4 color = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
 
     return tonemapUncharted2( color );
 }

--- a/Fabric/Effects/ColorToneMap/Uncharted.metal
+++ b/Fabric/Effects/ColorToneMap/Uncharted.metal
@@ -11,6 +11,7 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/tonemap/uncharted.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 
 typedef struct {
@@ -18,9 +19,10 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    half4 color = SAMPLER_FNC( renderTex, in.texcoord );
+    half4 color = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
 
     return tonemapUncharted( color );
 }

--- a/Fabric/Effects/Descimate/CMYK Dot Screen.metal
+++ b/Fabric/Effects/Descimate/CMYK Dot Screen.metal
@@ -10,6 +10,7 @@ using namespace metal;
 #include "../../lygia/color/space/cmyk2rgb.msl"
 #include "../../lygia/color/space/rgb2cmyk.msl"
 #include "../../lygia/math/radians.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 // Uniforms -> Fabric UI
 typedef struct {
@@ -59,11 +60,12 @@ static inline float2 amHalftone(float channel, float angleDeg, float scale, floa
 
 fragment half4 postFragment( VertexData                        in        [[stage_in]],
                              constant PostUniforms            &u         [[buffer( FragmentBufferMaterialUniforms )]],
+                             constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
                              texture2d<half, access::sample>   tex0      [[texture( FragmentTextureCustom0 )]] )
 {
     float2 uv = in.texcoord;
 
-    half4 src = SAMPLER_FNC(tex0, uv);
+    half4 src = SAMPLER_FNC(tex0, fabricTextureCoordinate(imageTransforms[0], uv));
     float3 rgb = float3(src.rgb);
 
     // Convert to CMYK (C,M,Y,K)

--- a/Fabric/Effects/Descimate/Cross Hatch.metal
+++ b/Fabric/Effects/Descimate/Cross Hatch.metal
@@ -8,6 +8,7 @@ using namespace metal;
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/math/mod.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 
 typedef struct {
@@ -47,18 +48,27 @@ static inline float2 rotate2D(float2 p, float a) {
     return float2(c * p.x - s * p.y, s * p.x + c * p.y);
 }
 
-static inline float lumaSample(texture2d<half, access::sample> tex, float2 uv) {
-    half4 c = SAMPLER_FNC(tex, clamp(uv, 0.0f, 1.0f));
+static inline float lumaSample(
+    texture2d<half, access::sample> tex,
+    float4x4 textureTransform,
+    float2 uv
+) {
+    const float2 textureCoordinate = fabricTextureCoordinate(
+        textureTransform,
+        clamp(uv, 0.0f, 1.0f)
+    );
+    half4 c = SAMPLER_FNC(tex, textureCoordinate);
     return luma(float3(c.rgb));
 }
 
 fragment half4 postFragment( VertexData                       in   [[stage_in]],
                              constant PostUniforms           &u    [[buffer( FragmentBufferMaterialUniforms )]],
+                             constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
                              texture2d<half, access::sample>  tex0 [[texture( FragmentTextureCustom0 )]] )
 {
     float2 uv = in.texcoord;
 
-    half4 src = SAMPLER_FNC(tex0, uv);
+    half4 src = SAMPLER_FNC(tex0, fabricTextureCoordinate(imageTransforms[0], uv));
     float lum = luma(float3(src.rgb));
 
     // Duotone ramp based on luma:
@@ -80,7 +90,10 @@ fragment half4 postFragment( VertexData                       in   [[stage_in]],
     half4 ink   = fgLayer;
 
     // Pixel-space coords for hatch pattern
-    float2 texSize = float2(tex0.get_width(), tex0.get_height());
+    float2 texSize = fabricPresentationSize(
+        imageTransforms[0],
+        float2(tex0.get_width(), tex0.get_height())
+    );
     float2 coord   = uv * texSize;
 
     // Rotate hatch space around center
@@ -114,20 +127,20 @@ fragment half4 postFragment( VertexData                       in   [[stage_in]],
     // Sobel-ish edge detection (same as prior)
     float2 texel = 1.0f / max(texSize, float2(1.0f));
     float gx = 0.0f;
-    gx += -1.0f * lumaSample(tex0, uv + texel * float2(-1.0f, -1.0f));
-    gx += -2.0f * lumaSample(tex0, uv + texel * float2(-1.0f,  0.0f));
-    gx += -1.0f * lumaSample(tex0, uv + texel * float2(-1.0f,  1.0f));
-    gx +=  1.0f * lumaSample(tex0, uv + texel * float2( 1.0f, -1.0f));
-    gx +=  2.0f * lumaSample(tex0, uv + texel * float2( 1.0f,  0.0f));
-    gx +=  1.0f * lumaSample(tex0, uv + texel * float2( 1.0f,  1.0f));
+    gx += -1.0f * lumaSample(tex0, imageTransforms[0], uv + texel * float2(-1.0f, -1.0f));
+    gx += -2.0f * lumaSample(tex0, imageTransforms[0], uv + texel * float2(-1.0f,  0.0f));
+    gx += -1.0f * lumaSample(tex0, imageTransforms[0], uv + texel * float2(-1.0f,  1.0f));
+    gx +=  1.0f * lumaSample(tex0, imageTransforms[0], uv + texel * float2( 1.0f, -1.0f));
+    gx +=  2.0f * lumaSample(tex0, imageTransforms[0], uv + texel * float2( 1.0f,  0.0f));
+    gx +=  1.0f * lumaSample(tex0, imageTransforms[0], uv + texel * float2( 1.0f,  1.0f));
 
     float gy = 0.0f;
-    gy += -1.0f * lumaSample(tex0, uv + texel * float2(-1.0f, -1.0f));
-    gy += -2.0f * lumaSample(tex0, uv + texel * float2( 0.0f, -1.0f));
-    gy += -1.0f * lumaSample(tex0, uv + texel * float2( 1.0f, -1.0f));
-    gy +=  1.0f * lumaSample(tex0, uv + texel * float2(-1.0f,  1.0f));
-    gy +=  2.0f * lumaSample(tex0, uv + texel * float2( 0.0f,  1.0f));
-    gy +=  1.0f * lumaSample(tex0, uv + texel * float2( 1.0f,  1.0f));
+    gy += -1.0f * lumaSample(tex0, imageTransforms[0], uv + texel * float2(-1.0f, -1.0f));
+    gy += -2.0f * lumaSample(tex0, imageTransforms[0], uv + texel * float2( 0.0f, -1.0f));
+    gy += -1.0f * lumaSample(tex0, imageTransforms[0], uv + texel * float2( 1.0f, -1.0f));
+    gy +=  1.0f * lumaSample(tex0, imageTransforms[0], uv + texel * float2(-1.0f,  1.0f));
+    gy +=  2.0f * lumaSample(tex0, imageTransforms[0], uv + texel * float2( 0.0f,  1.0f));
+    gy +=  1.0f * lumaSample(tex0, imageTransforms[0], uv + texel * float2( 1.0f,  1.0f));
 
     float g = (gx * gx + gy * gy) * u.edgeStrength;
     float edgeInk = clamp(g, 0.0f, 1.0f);

--- a/Fabric/Effects/Descimate/Hexagonal Pixelate.metal
+++ b/Fabric/Effects/Descimate/Hexagonal Pixelate.metal
@@ -10,6 +10,7 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/math/mod.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
     float amount; // slider, 0.00000001, 1.0, 0.05, Amount
@@ -18,12 +19,15 @@ typedef struct {
 fragment half4 postFragment(
     VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer(FragmentBufferMaterialUniforms)]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture(FragmentTextureCustom0)]]
 )
 {
-    const float width = float(renderTex.get_width());
-    const float height = float(renderTex.get_height());
-    const float aspect = width / height;
+    const float2 presentationSize = fabricPresentationSize(
+        imageTransforms[0],
+        float2(renderTex.get_width(), renderTex.get_height())
+    );
+    const float aspect = presentationSize.x / presentationSize.y;
     const float amount = max(uniforms.amount, 0.00000001);
     const float tilings = 1.0 / amount;
 
@@ -48,5 +52,5 @@ fragment half4 postFragment(
     sampleUV.x /= aspect;
     sampleUV = clamp(sampleUV + 0.5, 0.01, 0.99);
 
-    return SAMPLER_FNC(renderTex, sampleUV);
+    return SAMPLER_FNC(renderTex, fabricTextureCoordinate(imageTransforms[0], sampleUV));
 }

--- a/Fabric/Effects/Descimate/Pixelate.metal
+++ b/Fabric/Effects/Descimate/Pixelate.metal
@@ -13,6 +13,7 @@
 
 // From Satin, not Lygia FWIW
 #include "Library/Repeat.metal"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 
 typedef struct {
@@ -21,10 +22,15 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
 
-    const float aspect = float(renderTex.get_width()) / float(renderTex.get_height());
+    const float2 presentationSize = fabricPresentationSize(
+        imageTransforms[0],
+        float2(renderTex.get_width(), renderTex.get_height())
+    );
+    const float aspect = presentationSize.x / presentationSize.y;
     
     float2 uv = in.texcoord;
     uv.x *= aspect;
@@ -35,5 +41,5 @@ fragment half4 postFragment( VertexData in [[stage_in]],
     float2 suv = float2(cell) * div;
     suv.x /= aspect;
 
-    return SAMPLER_FNC( renderTex, suv );
+    return SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], suv));
 }

--- a/Fabric/Effects/Descimate/Polar Pixellatte.metal
+++ b/Fabric/Effects/Descimate/Polar Pixellatte.metal
@@ -16,6 +16,7 @@
 #include "../../lygia/space/sqTile.msl"
 // From Satin, not Lygia FWIW
 #include "Library/Repeat.metal"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 
 typedef struct {
@@ -26,10 +27,14 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
 	
-	float2 texSize = float2(renderTex.get_width(), renderTex.get_height());
+    float2 texSize = fabricPresentationSize(
+        imageTransforms[0],
+        float2(renderTex.get_width(), renderTex.get_height())
+    );
     float2 aspect  = float2(texSize.x / texSize.y, 1.0);
 
     // origin in normalized UV (0..1). If you don’t have it yet, use center:
@@ -66,7 +71,7 @@ fragment half4 postFragment( VertexData in [[stage_in]],
     // (optional) clamp to avoid sampling outside
     uv = clamp(uv, 0.0, 1.0);
 
-    half4 color = SAMPLER_FNC(renderTex, uv);
+    half4 color = SAMPLER_FNC(renderTex, fabricTextureCoordinate(imageTransforms[0], uv));
     return color;
 
 }

--- a/Fabric/Effects/Descimate/Triangular Pixelate.metal
+++ b/Fabric/Effects/Descimate/Triangular Pixelate.metal
@@ -9,6 +9,7 @@
 #define SAMPLER_TYPE texture2d<half>
 
 #include "../../lygia/sampler.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
     float amount; // slider, 0.00000001, 1.0, 0.03, Amount
@@ -17,13 +18,16 @@ typedef struct {
 fragment half4 postFragment(
     VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer(FragmentBufferMaterialUniforms)]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture(FragmentTextureCustom0)]]
 )
 {
-    const float width = float(renderTex.get_width());
-    const float height = float(renderTex.get_height());
+    const float2 presentationSize = fabricPresentationSize(
+        imageTransforms[0],
+        float2(renderTex.get_width(), renderTex.get_height())
+    );
     const float amount = max(uniforms.amount, 0.00000001);
-    const float2 pixelating = float2(1.0, width / height) * amount;
+    const float2 pixelating = float2(1.0, presentationSize.x / presentationSize.y) * amount;
 
     float2 uv = (in.texcoord - 0.5) / pixelating;
 
@@ -44,5 +48,5 @@ fragment half4 postFragment(
     uv -= sampleOffsetTransform * trianglePosition + float2(-0.25, 0.25);
 
     const float2 sampleUV = clamp(uv * pixelating + 0.5, 0.01, 0.99);
-    return SAMPLER_FNC(renderTex, sampleUV);
+    return SAMPLER_FNC(renderTex, fabricTextureCoordinate(imageTransforms[0], sampleUV));
 }

--- a/Fabric/Effects/Distort/Dent.metal
+++ b/Fabric/Effects/Distort/Dent.metal
@@ -8,6 +8,7 @@ using namespace metal;
 #define SAMPLER sampler( min_filter::linear, mag_filter::linear, address::mirrored_repeat )
 
 #include "../../lygia/sampler.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 // Optional, only if you need it elsewhere
 // #include "Library/Repeat.metal"
@@ -20,6 +21,7 @@ typedef struct {
 
 fragment half4 postFragment( VertexData                 in        [[stage_in]],
                              constant PostUniforms     &uniforms  [[buffer( FragmentBufferMaterialUniforms )]],
+                             constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
                              texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
     // Normalized UVs in [0, 1]
@@ -45,5 +47,5 @@ fragment half4 postFragment( VertexData                 in        [[stage_in]],
     // Back to [0, 1] UV space
     float2 uv = normCoord * 0.5 + 0.5;
 
-    return SAMPLER_FNC(renderTex, uv);
+    return SAMPLER_FNC(renderTex, fabricTextureCoordinate(imageTransforms[0], uv));
 }

--- a/Fabric/Effects/Distort/Pinch.metal
+++ b/Fabric/Effects/Distort/Pinch.metal
@@ -8,6 +8,7 @@ using namespace metal;
 #define SAMPLER sampler( min_filter::linear, mag_filter::linear, address::mirrored_repeat )
 
 #include "../../lygia/sampler.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 // Uniforms -> Fabric UI sliders
 typedef struct {
@@ -17,6 +18,7 @@ typedef struct {
 
 fragment half4 postFragment( VertexData                        in        [[stage_in]],
                              constant PostUniforms            &uniforms  [[buffer( FragmentBufferMaterialUniforms )]],
+                             constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
                              texture2d<half, access::sample>   renderTex [[texture( FragmentTextureCustom0 )]] )
 {
     // Normalized coordinates [0, 1]
@@ -49,5 +51,5 @@ fragment half4 postFragment( VertexData                        in        [[stage
     float2 uv = normCoord * 0.5 + 0.5;
 
     // Sample with Lygia sampler helper
-    return SAMPLER_FNC(renderTex, uv);
+    return SAMPLER_FNC(renderTex, fabricTextureCoordinate(imageTransforms[0], uv));
 }

--- a/Fabric/Effects/Distort/Twirl.metal
+++ b/Fabric/Effects/Distort/Twirl.metal
@@ -8,6 +8,7 @@ using namespace metal;
 #define SAMPLER sampler( min_filter::linear, mag_filter::linear, address::mirrored_repeat )
 
 #include "../../lygia/sampler.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 
 // Uniforms -> Fabric UI sliders
@@ -19,6 +20,7 @@ typedef struct {
 
 fragment half4 postFragment( VertexData                        in        [[stage_in]],
                              constant PostUniforms            &uniforms  [[buffer( FragmentBufferMaterialUniforms )]],
+                             constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
                              texture2d<half, access::sample>   renderTex [[texture( FragmentTextureCustom0 )]] )
 {
     // Normalized coordinates [0, 1]
@@ -48,5 +50,5 @@ fragment half4 postFragment( VertexData                        in        [[stage
     float2 uv = normCoord * 0.5f + 0.5f;
 
     // Sample with Lygia sampler helper
-    return SAMPLER_FNC(renderTex, uv);
+    return SAMPLER_FNC(renderTex, fabricTextureCoordinate(imageTransforms[0], uv));
 }

--- a/Fabric/Effects/Distort/Wobble.metal
+++ b/Fabric/Effects/Distort/Wobble.metal
@@ -8,6 +8,7 @@ using namespace metal;
 #define SAMPLER sampler( min_filter::linear, mag_filter::linear, address::mirrored_repeat )
 
 #include "../../lygia/sampler.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 // Derived from Metal's built-in constants
 constant float C_PI    = M_PI_F;
@@ -24,6 +25,7 @@ typedef struct {
 
 fragment half4 postFragment( VertexData                        in        [[stage_in]],
                              constant PostUniforms            &uniforms  [[buffer( FragmentBufferMaterialUniforms )]],
+                             constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
                              texture2d<half, access::sample>   renderTex [[texture( FragmentTextureCustom0 )]] )
 {
     float2 uv = in.texcoord; // normalized [0, 1]
@@ -71,5 +73,5 @@ fragment half4 postFragment( VertexData                        in        [[stage
     // Final UV with wobble
     float2 wobbleUV = uv + perturb;
 
-    return SAMPLER_FNC(renderTex, wobbleUV);
+    return SAMPLER_FNC(renderTex, fabricTextureCoordinate(imageTransforms[0], wobbleUV));
 }

--- a/Fabric/Effects/Film/CineGrain.metal
+++ b/Fabric/Effects/Film/CineGrain.metal
@@ -8,6 +8,7 @@
 #define SAMPLER_TYPE texture2d<half>
 
 #include "../../lygia/sampler.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
     float intensity; // slider, 0.0, 1.0, 0.1, Intensity
@@ -109,9 +110,13 @@ static inline float grainSample(float2 pixelPosition, float seed, constant PostU
 
 fragment half4 postFragment(VertexData in [[stage_in]],
                             constant PostUniforms &uniforms [[buffer(FragmentBufferMaterialUniforms)]],
+                            constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
                             texture2d<half, access::sample> renderTex [[texture(FragmentTextureCustom0)]])
 {
-    float2 resolution = float2(renderTex.get_width(), renderTex.get_height());
+    float2 resolution = fabricPresentationSize(
+        imageTransforms[0],
+        float2(renderTex.get_width(), renderTex.get_height())
+    );
     float2 pixelPosition = in.texcoord * resolution;
     float grainSize = max(uniforms.grainSize, 0.001f);
     float seed = uniforms.time;
@@ -128,7 +133,7 @@ fragment half4 postFragment(VertexData in [[stage_in]],
         grain += grainSample(pixelPosition + float2(0.0f, -radius), seed, uniforms) * 0.190f;
     }
 
-    half4 sampledColor = SAMPLER_FNC(renderTex, in.texcoord);
+    half4 sampledColor = SAMPLER_FNC(renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
     float3 color = float3(sampledColor.rgb);
 
     float luma = dot(color, float3(0.2126f, 0.7152f, 0.0722f));

--- a/Fabric/Effects/Film/FastGrain.metal
+++ b/Fabric/Effects/Film/FastGrain.metal
@@ -9,6 +9,7 @@
 #define SAMPLER_TYPE texture2d<half>
 
 #include "../../lygia/sampler.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
     float amount; // slider, 0.0, 1.0, 0.05, Amount
@@ -40,11 +41,15 @@ static inline float3 fastGrainNoise(float2 grainCell, float seed, float amount, 
 
 fragment half4 postFragment(VertexData in [[stage_in]],
                             constant PostUniforms &uniforms [[buffer(FragmentBufferMaterialUniforms)]],
+                            constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
                             texture2d<half, access::sample> renderTex [[texture(FragmentTextureCustom0)]])
 {
-    half4 sampledColor = SAMPLER_FNC(renderTex, in.texcoord);
+    half4 sampledColor = SAMPLER_FNC(renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
     float3 sceneColor = float3(sampledColor.rgb);
-    float2 textureSize = float2(renderTex.get_width(), renderTex.get_height());
+    float2 textureSize = fabricPresentationSize(
+        imageTransforms[0],
+        float2(renderTex.get_width(), renderTex.get_height())
+    );
     float grainSize = max(uniforms.grainSize, 0.5f);
     float2 grainCell = floor(in.texcoord * textureSize / grainSize);
 

--- a/Fabric/Effects/Film/Halation Extract.metal
+++ b/Fabric/Effects/Film/Halation Extract.metal
@@ -8,6 +8,7 @@
 #define SAMPLER_TYPE texture2d<half>
 
 #include "../../lygia/sampler.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
     float threshold; // slider, 0.0, 2.0, 0.75, Threshold
@@ -17,9 +18,10 @@ typedef struct {
 
 fragment half4 postFragment(VertexData in [[stage_in]],
                             constant PostUniforms &uniforms [[buffer(FragmentBufferMaterialUniforms)]],
+                            constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
                             texture2d<half, access::sample> renderTex [[texture(FragmentTextureCustom0)]])
 {
-    half4 color = SAMPLER_FNC(renderTex, in.texcoord);
+    half4 color = SAMPLER_FNC(renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
     float3 sourceColor = float3(color.rgb);
     float luma = dot(sourceColor, float3(0.2126f, 0.7152f, 0.0722f));
     float softness = max(uniforms.softness, 0.0001f);

--- a/Fabric/Effects/Film/Halation.metal
+++ b/Fabric/Effects/Film/Halation.metal
@@ -9,6 +9,7 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/blend.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
     float4 tint; // color, 1.0, 0.35, 0.12, 1.0, Tint
@@ -18,11 +19,12 @@ typedef struct {
 
 fragment half4 postFragment(VertexData in [[stage_in]],
                             constant PostUniforms &uniforms [[buffer(FragmentBufferMaterialUniforms)]],
+                            constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
                             texture2d<half, access::sample> sourceTex [[texture(FragmentTextureCustom0)]],
                             texture2d<half, access::sample> halationTex [[texture(FragmentTextureCustom1)]])
 {
-    half4 source = SAMPLER_FNC(sourceTex, in.texcoord);
-    half4 halation = SAMPLER_FNC(halationTex, in.texcoord);
+    half4 source = SAMPLER_FNC(sourceTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
+    half4 halation = SAMPLER_FNC(halationTex, fabricTextureCoordinate(imageTransforms[1], in.texcoord));
     
     half3 bias = half3(uniforms.tint.rgb * uniforms.tint.a * uniforms.amount);
     

--- a/Fabric/Effects/Film/Technicolor 1.metal
+++ b/Fabric/Effects/Film/Technicolor 1.metal
@@ -13,6 +13,7 @@ using namespace metal;
 #define SAMPLER_TYPE texture2d<half>
 
 #include "../../lygia/sampler.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 // Uniforms → Fabric UI slider
 typedef struct {
@@ -21,11 +22,12 @@ typedef struct {
 
 fragment half4 postFragment( VertexData                        in        [[stage_in]],
                              constant PostUniforms            &uniforms  [[buffer( FragmentBufferMaterialUniforms )]],
+                             constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
                              texture2d<half, access::sample>   tex        [[texture( FragmentTextureCustom0 )]] )
 {
     float2 uv = in.texcoord;
 
-    half4 input0 = SAMPLER_FNC(tex, uv);
+    half4 input0 = SAMPLER_FNC(tex, fabricTextureCoordinate(imageTransforms[0], uv));
 
     // Filters (note bluegreenfilter.b = 0.7)
     const half4 redfilter       = half4(1.0h, 0.0h, 0.0h, 1.0h);

--- a/Fabric/Effects/Film/Technicolor 2.metal
+++ b/Fabric/Effects/Film/Technicolor 2.metal
@@ -13,6 +13,7 @@ using namespace metal;
 #define SAMPLER_TYPE texture2d<half>
 
 #include "../../lygia/sampler.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 // Uniforms → Fabric UI sliders
 typedef struct {
@@ -21,11 +22,12 @@ typedef struct {
 
 fragment half4 postFragment( VertexData                        in        [[stage_in]],
                              constant PostUniforms            &uniforms  [[buffer( FragmentBufferMaterialUniforms )]],
+                             constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
                              texture2d<half, access::sample>   tex        [[texture( FragmentTextureCustom0 )]] )
 {
     float2 uv = in.texcoord;
 
-    half4 input0 = SAMPLER_FNC(tex, uv);
+    half4 input0 = SAMPLER_FNC(tex, fabricTextureCoordinate(imageTransforms[0], uv));
 
     // Filters (Metal half4 constants)
     const half4 redfilter        = half4(1.0h, 0.0h, 0.0h, 1.0h);

--- a/Fabric/Effects/Film/Technicolor 3.metal
+++ b/Fabric/Effects/Film/Technicolor 3.metal
@@ -13,6 +13,7 @@ using namespace metal;
 #define SAMPLER_TYPE texture2d<half>
 
 #include "../../lygia/sampler.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 // Uniforms → Fabric UI slider
 typedef struct {
@@ -21,11 +22,12 @@ typedef struct {
 
 fragment half4 postFragment( VertexData                        in        [[stage_in]],
                              constant PostUniforms            &uniforms  [[buffer( FragmentBufferMaterialUniforms )]],
+                             constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
                              texture2d<half, access::sample>   tex        [[texture( FragmentTextureCustom0 )]] )
 {
     float2 uv = in.texcoord;
 
-    half4 input0 = SAMPLER_FNC(tex, uv);
+    half4 input0 = SAMPLER_FNC(tex, fabricTextureCoordinate(imageTransforms[0], uv));
     half3 rgb = input0.rgb;
 
     // Primary mattes

--- a/Fabric/Effects/Film/Technicolor 3W.metal
+++ b/Fabric/Effects/Film/Technicolor 3W.metal
@@ -13,6 +13,7 @@ using namespace metal;
 #define SAMPLER_TYPE texture2d<half>
 
 #include "../../lygia/sampler.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 // Uniforms → Fabric UI slider
 typedef struct {
@@ -21,11 +22,12 @@ typedef struct {
 
 fragment half4 postFragment( VertexData                        in        [[stage_in]],
                              constant PostUniforms            &uniforms  [[buffer( FragmentBufferMaterialUniforms )]],
+                             constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
                              texture2d<half, access::sample>   tex        [[texture( FragmentTextureCustom0 )]] )
 {
     float2 uv = in.texcoord;
 
-    half4 input0 = SAMPLER_FNC(tex, uv);
+    half4 input0 = SAMPLER_FNC(tex, fabricTextureCoordinate(imageTransforms[0], uv));
 
     // Filters
     const half4 redfilter        = half4(1.0h, 0.0h, 0.0h, 1.0h);

--- a/Fabric/Effects/Film/Vignette.metal
+++ b/Fabric/Effects/Film/Vignette.metal
@@ -12,6 +12,7 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/distort/grain.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
     float radius; // slider, 0.0, 1.0, 0.5, Radius
@@ -20,6 +21,7 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
     constexpr sampler s = sampler( min_filter::linear, mag_filter::linear );
@@ -27,7 +29,8 @@ fragment half4 postFragment( VertexData in [[stage_in]],
     float v = uniforms.radius - distance(in.texcoord, float2(0.5));
     v = smoothstep(-uniforms.smoothness, uniforms.smoothness, v);
     
-    half4 color = renderTex.sample( s, in.texcoord );
+    const float2 imageUV = fabricTextureCoordinate(imageTransforms[0], in.texcoord);
+    half4 color = renderTex.sample(s, imageUV);
 
     return color * v;
 }

--- a/Fabric/Effects/Film/White Diffusion.metal
+++ b/Fabric/Effects/Film/White Diffusion.metal
@@ -17,6 +17,7 @@ using namespace metal;
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/filter/gaussianBlur.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 // Uniforms → Fabric UI sliders
 typedef struct {
@@ -32,8 +33,40 @@ constant half4 kLumCoeff = half4(0.299h, 0.587h, 0.114h, 0.0h);
 // sqrt(2) from Metal's constants
 constant float kSqrt2 = M_SQRT2_F;
 
+static half4 fabricGaussianBlur(
+    texture2d<half, access::sample> texture,
+    float4x4 textureTransform,
+    float2 coordinate,
+    float2 pixelScale,
+    int kernelSize
+) {
+    half4 accumulatedColor = half4(0.0h);
+    float accumulatedWeight = 0.0;
+    const float kernelSizeFloat = float(kernelSize);
+    const float gaussianNormalization = 0.15915494;
+
+    for (int vertical = 0; vertical < kernelSize; ++vertical) {
+        const float verticalOffset = -0.5 * (kernelSizeFloat - 1.0) + float(vertical);
+        for (int horizontal = 0; horizontal < kernelSize; ++horizontal) {
+            const float horizontalOffset = -0.5 * (kernelSizeFloat - 1.0) + float(horizontal);
+            const float2 kernelOffset = float2(horizontalOffset, verticalOffset);
+            const float weight = (gaussianNormalization / kernelSizeFloat)
+                * gaussian(kernelOffset, kernelSizeFloat);
+            const float2 sampleCoordinate = fabricTextureCoordinate(
+                textureTransform,
+                coordinate + kernelOffset * pixelScale
+            );
+            accumulatedColor += half(weight) * sampleClamp2edge(texture, sampleCoordinate);
+            accumulatedWeight += weight;
+        }
+    }
+
+    return accumulatedColor / half(accumulatedWeight);
+}
+
 fragment half4 postFragment( VertexData                        in        [[stage_in]],
                              constant PostUniforms            &uniforms  [[buffer( FragmentBufferMaterialUniforms )]],
+                             constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
                              texture2d<half, access::sample>   renderTex [[texture( FragmentTextureCustom0 )]] )
 {
     float2 uv = in.texcoord;
@@ -61,27 +94,36 @@ fragment half4 postFragment( VertexData                        in        [[stage
 //    uv8 = clamp(uv8, 0.0f, 1.0f);
 //
 //    // Samples
-    half4 input0 = SAMPLER_FNC(renderTex, uv);
-//    half4 input1 = SAMPLER_FNC(renderTex, uv1);
-//    half4 input2 = SAMPLER_FNC(renderTex, uv2);
-//    half4 input3 = SAMPLER_FNC(renderTex, uv3);
-//    half4 input4 = SAMPLER_FNC(renderTex, uv4);
-//    half4 input5 = SAMPLER_FNC(renderTex, uv5);
-//    half4 input6 = SAMPLER_FNC(renderTex, uv6);
-//    half4 input7 = SAMPLER_FNC(renderTex, uv7);
-//    half4 input8 = SAMPLER_FNC(renderTex, uv8);
+    half4 input0 = SAMPLER_FNC(renderTex, fabricTextureCoordinate(imageTransforms[0], uv));
+//    half4 input1 = SAMPLER_FNC(renderTex, fabricTextureCoordinate(imageTransforms[0], uv1));
+//    half4 input2 = SAMPLER_FNC(renderTex, fabricTextureCoordinate(imageTransforms[0], uv2));
+//    half4 input3 = SAMPLER_FNC(renderTex, fabricTextureCoordinate(imageTransforms[0], uv3));
+//    half4 input4 = SAMPLER_FNC(renderTex, fabricTextureCoordinate(imageTransforms[0], uv4));
+//    half4 input5 = SAMPLER_FNC(renderTex, fabricTextureCoordinate(imageTransforms[0], uv5));
+//    half4 input6 = SAMPLER_FNC(renderTex, fabricTextureCoordinate(imageTransforms[0], uv6));
+//    half4 input7 = SAMPLER_FNC(renderTex, fabricTextureCoordinate(imageTransforms[0], uv7));
+//    half4 input8 = SAMPLER_FNC(renderTex, fabricTextureCoordinate(imageTransforms[0], uv8));
 //
 //    // Blur (note original used *0.125 with 9 taps)
 //    half4 blurresult = (input0 + input1 + input2 + input3 +
 //                        input4 + input5 + input6 + input7 + input8) * 0.125h;
 
-    float2 resolution = float2(renderTex.get_width(), renderTex.get_height());
+    float2 resolution = fabricPresentationSize(
+        imageTransforms[0],
+        float2(renderTex.get_width(), renderTex.get_height())
+    );
     float2 pixel = 1.0/resolution;
 
     float ix = floor( b );
     float kernel_size = max(1.0, ix );
     
-    half4 blurresult = gaussianBlur( renderTex, in.texcoord,  pixel, int(kernel_size));
+    half4 blurresult = fabricGaussianBlur(
+        renderTex,
+        imageTransforms[0],
+        in.texcoord,
+        pixel,
+        int(kernel_size)
+    );
 
     // Luma of original and blurred
     half4 origLuma = half4(dot(input0, kLumCoeff));

--- a/Fabric/Effects/Lens/Barrel.metal
+++ b/Fabric/Effects/Lens/Barrel.metal
@@ -16,6 +16,7 @@
 #include "../../lygia/sampler.msl"
 #include "../../lygia/distort/barrel.msl"
 #include "../../lygia/distort/pincushion.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 
 typedef struct {
@@ -23,20 +24,36 @@ typedef struct {
     float barrel; // slider, 0.0, 0.2, 0.0
 } PostUniforms;
 
+static half3 fabricBarrel(
+    texture2d<half, access::sample> texture,
+    float4x4 textureTransform,
+    float2 coordinate,
+    float distance
+) {
+    half3 accumulatedColor = half3(0.0h);
+    for (int octave = 0; octave < 12; ++octave) {
+        const float amount = float(octave) * 0.2;
+        const float2 sampleCoordinate = barrel(coordinate, amount, distance);
+        accumulatedColor += SAMPLER_FNC(
+            texture,
+            fabricTextureCoordinate(textureTransform, sampleCoordinate)
+        ).rgb;
+    }
+    return accumulatedColor / 12.0h;
+}
+
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-
-   	float2 inRatio = float2(renderTex.get_width(), renderTex.get_height());
-   	float2 outRatio = float2(renderTex.get_height(), renderTex.get_width());
 
 	float2 uv = in.texcoord;
 
  	 uv = pincushion(uv, float2(1.0), uniforms.pincushion + 0.001);
 //	half3 cushion = pincushion(renderTex, uv, float2(0.5), uniforms.amount);
 
-	half3 cushion = barrel(renderTex, uv, uniforms.barrel);
+	half3 cushion = fabricBarrel(renderTex, imageTransforms[0], uv, uniforms.barrel);
 
     return half4(cushion, 1.0); 
 }

--- a/Fabric/Effects/Morphology/Dilation.metal
+++ b/Fabric/Effects/Morphology/Dilation.metal
@@ -10,16 +10,54 @@
 #define SAMPLER_TYPE texture2d<half>
 
 #include "../../lygia/sampler.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
     int radius; // slider, 0, DILATION_MAX_RADIUS, 2, Radius
 } PostUniforms;
 
+static half fabricDilation(
+    texture2d<half, access::sample> texture,
+    float4x4 textureTransform,
+    float2 coordinate,
+    float2 pixelScale,
+    int radius
+) {
+    const float inverseRadius = 1.0 / float(radius);
+    half accumulatedValue = 0.0h;
+    float accumulatedWeight = 0.0;
+
+    for (int horizontal = -radius; horizontal <= radius; ++horizontal) {
+        for (int vertical = -radius; vertical <= radius; ++vertical) {
+            const float2 radiusOffset = float2(horizontal, vertical);
+            const float2 kernelCoordinate = radiusOffset * inverseRadius * 2.0;
+            const float2 sampleCoordinate = coordinate + radiusOffset * pixelScale;
+            const float kernelWeight = saturate(1.0 - dot(kernelCoordinate, kernelCoordinate));
+            const half sampleValue = SAMPLER_FNC(
+                texture,
+                fabricTextureCoordinate(textureTransform, sampleCoordinate)
+            ).r;
+            const half weightedValue = sampleValue + half(kernelWeight);
+            if (weightedValue > accumulatedValue) {
+                accumulatedValue = weightedValue;
+                accumulatedWeight = kernelWeight;
+            }
+        }
+    }
+
+    return accumulatedValue - half(accumulatedWeight);
+}
+
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    const float2 pixelScale = float2(1.0 / float(renderTex.get_width()), 1.0 / float(renderTex.get_height()) );
+    const float2 presentationSize = fabricPresentationSize(
+        imageTransforms[0],
+        float2(renderTex.get_width(), renderTex.get_height())
+    );
+    const float2 pixelScale = 1.0 / presentationSize;
 
-    return dilation( renderTex, in.texcoord, pixelScale, uniforms.radius );
+    return fabricDilation(renderTex, imageTransforms[0], in.texcoord, pixelScale, uniforms.radius);
 }

--- a/Fabric/Effects/Morphology/Sobel.metal
+++ b/Fabric/Effects/Morphology/Sobel.metal
@@ -12,6 +12,7 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/filter/edge/sobel.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 
 typedef struct {
@@ -19,13 +20,51 @@ typedef struct {
     float2 offset; // input, 1.0, Offset
 } PostUniforms;
 
+static half fabricSobelSample(
+    texture2d<half, access::sample> texture,
+    float4x4 textureTransform,
+    float2 coordinate
+) {
+    return sampleClamp2edge(
+        texture,
+        fabricTextureCoordinate(textureTransform, coordinate)
+    ).r;
+}
+
+static half fabricSobel(
+    texture2d<half, access::sample> texture,
+    float4x4 textureTransform,
+    float2 coordinate,
+    float2 offset
+) {
+    const half topLeft = fabricSobelSample(texture, textureTransform, coordinate + float2(-offset.x, offset.y));
+    const half left = fabricSobelSample(texture, textureTransform, coordinate + float2(-offset.x, 0.0));
+    const half bottomLeft = fabricSobelSample(texture, textureTransform, coordinate + float2(-offset.x, -offset.y));
+    const half top = fabricSobelSample(texture, textureTransform, coordinate + float2(0.0, offset.y));
+    const half bottom = fabricSobelSample(texture, textureTransform, coordinate + float2(0.0, -offset.y));
+    const half topRight = fabricSobelSample(texture, textureTransform, coordinate + offset);
+    const half right = fabricSobelSample(texture, textureTransform, coordinate + float2(offset.x, 0.0));
+    const half bottomRight = fabricSobelSample(texture, textureTransform, coordinate + float2(offset.x, -offset.y));
+    const half horizontal = topLeft + 2.0h * left + bottomLeft - topRight - 2.0h * right - bottomRight;
+    const half vertical = -topLeft - 2.0h * top - topRight + bottomLeft + 2.0h * bottom + bottomRight;
+    return sqrt(horizontal * horizontal + vertical * vertical);
+}
+
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
-    uint width = renderTex.get_width();
-    uint height = renderTex.get_height();
+    const float2 presentationSize = fabricPresentationSize(
+        imageTransforms[0],
+        float2(renderTex.get_width(), renderTex.get_height())
+    );
 
-    return edgeSobel(renderTex, in.texcoord, uniforms.offset / float2(width, height)) ;
+    return fabricSobel(
+        renderTex,
+        imageTransforms[0],
+        in.texcoord,
+        uniforms.offset / presentationSize
+    );
 }

--- a/Fabric/Effects/ShapeOperator/SDF Onion.metal
+++ b/Fabric/Effects/ShapeOperator/SDF Onion.metal
@@ -10,6 +10,7 @@
 #include "../../lygia/draw/fill.msl"
 #include "../../lygia/draw/stroke.msl"
 #include "../../lygia/sdf/opOnion.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
     float onion; // slider, 0.0, 1.0, 0.0, Onion
@@ -18,10 +19,11 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<float, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
     float2 coords = in.texcoord;
-    float sdf = SAMPLER_FNC( renderTex, coords ).r;
+    float sdf = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], coords)).r;
     sdf = opOnion(sdf, uniforms.onion);
 
     return half4(sdf);

--- a/Fabric/Effects/ShapeOperator/SDF Render.metal
+++ b/Fabric/Effects/ShapeOperator/SDF Render.metal
@@ -10,6 +10,7 @@
 #include "../../lygia/draw/fill.msl"
 #include "../../lygia/draw/stroke.msl"
 #include "../../lygia/sdf/opOnion.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
     float4 fillColor; // color,  Fill Color
@@ -23,11 +24,12 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<float, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
     float4 color = float4(0.0);
 
-    float sdf = SAMPLER_FNC( renderTex, in.texcoord ).r;
+    float sdf = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord)).r;
 //    sdf = opOnion(sdf, uniforms.onion);
 
     float sdfStroke = stroke(sdf, uniforms.borderSize, uniforms.borderWidth);

--- a/Fabric/Effects/ShapeOperator/SDF Tile.metal
+++ b/Fabric/Effects/ShapeOperator/SDF Tile.metal
@@ -11,6 +11,7 @@
 #include "../../lygia/draw/stroke.msl"
 #include "../../lygia/space/sqTile.msl"
 #include "../../lygia/sdf/opRepeat.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
     float tile; // slider, 1.0, 20.0, 1.0, Tile Size
@@ -19,12 +20,13 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<float, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
     float4 color = float4(0.0);
 
     float2 uv = sqTile(in.texcoord, uniforms.tile).xy;
-    float sdf = SAMPLER_FNC( renderTex, uv ).r;
+    float sdf = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], uv)).r;
 
     return half4(sdf);
 }

--- a/Fabric/Effects/Tile/Kaliedoscope.metal
+++ b/Fabric/Effects/Tile/Kaliedoscope.metal
@@ -11,6 +11,7 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/space/kaleidoscope.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 
 typedef struct {
@@ -20,6 +21,7 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]] )
 {
 
@@ -27,7 +29,7 @@ fragment half4 postFragment( VertexData in [[stage_in]],
 
 	float2 uv = kaleidoscope(in.texcoord, segmentCount, uniforms.phase);
 	    
-	half4 color = SAMPLER_FNC( renderTex, uv);
+	half4 color = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], uv));
 
 	return color;
 }

--- a/Fabric/EffectsThreeChannel/Distort/DisplaceWithMask.metal
+++ b/Fabric/EffectsThreeChannel/Distort/DisplaceWithMask.metal
@@ -12,6 +12,7 @@
 
 #include "../../lygia/sample/clamp2edge.msl"
 #include "../../lygia/sampler.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
     float amount; // slider, 0.0, 1.0, 0.0, Displacement Amount
@@ -19,18 +20,19 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]],
     texture2d<half, access::sample> renderTex2 [[texture( FragmentTextureCustom1 )]],
     texture2d<half, access::sample> renderTex3 [[texture( FragmentTextureCustom2 )]]
 )
 {
-    half4 displacement = SAMPLER_FNC( renderTex2, in.texcoord );
+    half4 displacement = SAMPLER_FNC( renderTex2, fabricTextureCoordinate(imageTransforms[1], in.texcoord));
     
-    half mask = SAMPLER_FNC( renderTex3, in.texcoord ).r;
+    half mask = SAMPLER_FNC( renderTex3, fabricTextureCoordinate(imageTransforms[2], in.texcoord)).r;
 
     float2 displaceAmount = float2(displacement.xy) * float2(uniforms.amount) * float2(mask);
     
-    half4 color = SAMPLER_FNC( renderTex, mix(in.texcoord, float2(displacement.xy), displaceAmount) );
+    half4 color = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], mix(in.texcoord, float2(displacement.xy), displaceAmount)));
 
     return color;
 }

--- a/Fabric/EffectsTwoChannel/Analysis/GradientFlow.metal
+++ b/Fabric/EffectsTwoChannel/Analysis/GradientFlow.metal
@@ -14,6 +14,7 @@ using namespace metal;
 #define SAMPLER_TYPE texture2d<half>
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/luminance.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 struct PostUniforms {
     float2 scale; // slider, 0.0, 10.0, 0.0, Scale
@@ -23,12 +24,19 @@ struct PostUniforms {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &u [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> tex0 [[texture( FragmentTextureCustom0 )]],
     texture2d<half, access::sample> tex1 [[texture( FragmentTextureCustom1 )]])
 {
     
-    float2 texSize0 = float2(tex0.get_width(), tex0.get_height());
-    float2 texSize1 = float2(tex1.get_width(), tex1.get_height());
+    float2 texSize0 = fabricPresentationSize(
+        imageTransforms[0],
+        float2(tex0.get_width(), tex0.get_height())
+    );
+    float2 texSize1 = fabricPresentationSize(
+        imageTransforms[1],
+        float2(tex1.get_width(), tex1.get_height())
+    );
 
     // If tex0/tex1 differ in size, this preserves the slightly-odd behavior
     // of applying offsets in each texture's own pixel space.
@@ -42,18 +50,18 @@ fragment half4 postFragment( VertexData in [[stage_in]],
     float2 tc0 = in.texcoord;
     float2 tc1 = in.texcoord;
 
-    half4 a = SAMPLER_FNC(tex0, tc0);
-    half4 b = SAMPLER_FNC(tex1, tc1);
+    half4 a = SAMPLER_FNC(tex0, fabricTextureCoordinate(imageTransforms[0], tc0));
+    half4 b = SAMPLER_FNC(tex1, fabricTextureCoordinate(imageTransforms[1], tc1));
 
     // get the difference
     half4 curdif = b - a;
 
     // calculate the gradient (per-channel), summing gradients from both frames
-    half4 gradx = SAMPLER_FNC(tex1, tc1 + x1) - SAMPLER_FNC(tex1, tc1 - x1);
-    gradx +=       SAMPLER_FNC(tex0, tc0 + x0) - SAMPLER_FNC(tex0, tc0 - x0);
+    half4 gradx = SAMPLER_FNC(tex1, fabricTextureCoordinate(imageTransforms[1], tc1 + x1)) - SAMPLER_FNC(tex1, fabricTextureCoordinate(imageTransforms[1], tc1 - x1));
+    gradx +=       SAMPLER_FNC(tex0, fabricTextureCoordinate(imageTransforms[0], tc0 + x0)) - SAMPLER_FNC(tex0, fabricTextureCoordinate(imageTransforms[0], tc0 - x0));
 
-    half4 grady = SAMPLER_FNC(tex1, tc1 + y1) - SAMPLER_FNC(tex1, tc1 - y1);
-    grady +=       SAMPLER_FNC(tex0, tc0 + y0) - SAMPLER_FNC(tex0, tc0 - y0);
+    half4 grady = SAMPLER_FNC(tex1, fabricTextureCoordinate(imageTransforms[1], tc1 + y1)) - SAMPLER_FNC(tex1, fabricTextureCoordinate(imageTransforms[1], tc1 - y1));
+    grady +=       SAMPLER_FNC(tex0, fabricTextureCoordinate(imageTransforms[0], tc0 + y0)) - SAMPLER_FNC(tex0, fabricTextureCoordinate(imageTransforms[0], tc0 - y0));
 
     half4 gradmag = sqrt((gradx * gradx) + (grady * grady) + half4(u.lambda));
 

--- a/Fabric/EffectsTwoChannel/Analysis/GradientFlowOffset.metal
+++ b/Fabric/EffectsTwoChannel/Analysis/GradientFlowOffset.metal
@@ -16,6 +16,7 @@ using namespace metal;
 #define SAMPLER_TYPE texture2d<half>
 
 #include "../../lygia/sampler.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
     float amt;   // slider, -2.0, 2.0, 1.0, Amount
@@ -23,6 +24,7 @@ typedef struct {
 
 fragment half4 postFragment( VertexData                        in        [[stage_in]],
                              constant PostUniforms            &u         [[buffer( FragmentBufferMaterialUniforms )]],
+                             constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
                              texture2d<half, access::sample>   tex0      [[texture( FragmentTextureCustom0 )]],
                              texture2d<half, access::sample>   tex1      [[texture( FragmentTextureCustom1 )]] )
 {
@@ -31,10 +33,10 @@ fragment half4 postFragment( VertexData                        in        [[stage
     // Sample the flow / velocity field.
     // Expects standard signed-RG format: R = dx (rightward +), G = dy (downward +).
     // Compatible with: LucasKanadeOpticalFlowNode, Satin velocity buffers.
-    half2 flow = SAMPLER_FNC(tex1, uv).rg;
+    half2 flow = SAMPLER_FNC(tex1, fabricTextureCoordinate(imageTransforms[1], uv)).rg;
 
     // Displace the UV coordinate along the flow direction.
     float2 coord = mix(uv, uv + float2(flow), u.amt);
 
-    return SAMPLER_FNC(tex0, coord);
+    return SAMPLER_FNC(tex0, fabricTextureCoordinate(imageTransforms[0], coord));
 }

--- a/Fabric/EffectsTwoChannel/Blur/DepthOfField.metal
+++ b/Fabric/EffectsTwoChannel/Blur/DepthOfField.metal
@@ -19,18 +19,78 @@
 #include "../../lygia/sample/clamp2edge.msl"
 #include "../../lygia/sampler.msl"
 #include "../../lygia/sample/dof.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
     float focusPoint; // slider, 0.0, 1.0, 0.0, Focus
     float focusScale; // slider, 0.0, 1.0, 0.0, Scale
 } PostUniforms;
 
+static half3 fabricSampleDepthOfField(
+    texture2d<half, access::sample> colorTexture,
+    float4x4 colorTextureTransform,
+    texture2d<half, access::sample> depthTexture,
+    float4x4 depthTextureTransform,
+    float2 coordinate,
+    float focusPoint,
+    float focusScale
+) {
+    const float2 colorPresentationSize = fabricPresentationSize(
+        colorTextureTransform,
+        float2(colorTexture.get_width(), colorTexture.get_height())
+    );
+    const float2 pixelScale = 1.0 / colorPresentationSize;
+    const float centerDepth = float(SAMPLER_FNC(
+        depthTexture,
+        fabricTextureCoordinate(depthTextureTransform, coordinate)
+    ).r);
+    const float centerSize = getBlurSize(centerDepth, focusPoint, focusScale);
+    half3 color = SAMPLER_FNC(
+        colorTexture,
+        fabricTextureCoordinate(colorTextureTransform, coordinate)
+    ).rgb;
+
+    float total = 1.0;
+    float radius = SAMPLEDOF_RAD_SCALE;
+    for (float angle = 0.0; radius < SAMPLEDOF_BLUR_SIZE; angle += GOLDEN_ANGLE) {
+        const float2 sampleCoordinate = coordinate
+            + float2(cos(angle), sin(angle)) * pixelScale * radius;
+        const float sampleDepth = float(SAMPLER_FNC(
+            depthTexture,
+            fabricTextureCoordinate(depthTextureTransform, sampleCoordinate)
+        ).r);
+        float sampleSize = getBlurSize(sampleDepth, focusPoint, focusScale);
+        if (sampleDepth > centerDepth) {
+            sampleSize = clamp(sampleSize, 0.0, centerSize * 2.0);
+        }
+        const float percentage = smoothstep(radius - 0.5, radius + 0.5, sampleSize);
+        const half3 sampleColor = SAMPLER_FNC(
+            colorTexture,
+            fabricTextureCoordinate(colorTextureTransform, sampleCoordinate)
+        ).rgb;
+        color += mix(color / half(total), sampleColor, half(percentage));
+        total += 1.0;
+        radius += SAMPLEDOF_RAD_SCALE / radius;
+    }
+
+    return color / half(total);
+}
+
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]],
     texture2d<half, access::sample> renderTex2 [[texture( FragmentTextureCustom1 )]])
 {
-    half3 color = sampleDoF( renderTex, renderTex2, in.texcoord, uniforms.focusPoint, uniforms.focusScale);
+    half3 color = fabricSampleDepthOfField(
+        renderTex,
+        imageTransforms[0],
+        renderTex2,
+        imageTransforms[1],
+        in.texcoord,
+        uniforms.focusPoint,
+        uniforms.focusScale
+    );
 
     return half4(color, 1.0);
 }

--- a/Fabric/EffectsTwoChannel/Composite/CompositeTemplate.msl
+++ b/Fabric/EffectsTwoChannel/Composite/CompositeTemplate.msl
@@ -11,6 +11,7 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/composite.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 //typedef struct {
 //    float amount; // slider, 0.0, 1.0, 0.0, Amount
@@ -19,11 +20,12 @@
 
 fragment half4 postFragment( VertexData in [[stage_in]],
 //    constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> tex0 [[texture( FragmentTextureCustom0 )]],
     texture2d<half, access::sample> tex1 [[texture( FragmentTextureCustom1 )]] )
 {
-    half4 srcColor = SAMPLER_FNC( tex0, in.texcoord );
-    half4 dstColor = SAMPLER_FNC( tex1, in.texcoord );
+    half4 srcColor = SAMPLER_FNC(tex0, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
+    half4 dstColor = SAMPLER_FNC(tex1, fabricTextureCoordinate(imageTransforms[1], in.texcoord));
     
     return COMPOSITE_FUNC(srcColor, dstColor);
 }

--- a/Fabric/EffectsTwoChannel/Distort/Displace.metal
+++ b/Fabric/EffectsTwoChannel/Distort/Displace.metal
@@ -12,6 +12,7 @@
 
 #include "../../lygia/sample/clamp2edge.msl"
 #include "../../lygia/sampler.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
     float amount; // slider, 0.0, 1.0, 0.0, Displacement Amount
@@ -19,12 +20,13 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]],
     texture2d<half, access::sample> renderTex2 [[texture( FragmentTextureCustom1 )]])
 {
-    half4 displacement = SAMPLER_FNC( renderTex2, in.texcoord );
+    half4 displacement = SAMPLER_FNC( renderTex2, fabricTextureCoordinate(imageTransforms[1], in.texcoord));
 
-    half4 color = SAMPLER_FNC( renderTex, mix(in.texcoord, in.texcoord + float2(displacement.xy), float2(uniforms.amount) ) );
+    half4 color = SAMPLER_FNC( renderTex, fabricTextureCoordinate(imageTransforms[0], mix(in.texcoord, in.texcoord + float2(displacement.xy), float2(uniforms.amount) )));
 
     return color;
 }

--- a/Fabric/EffectsTwoChannel/Film/Light Leak.metal
+++ b/Fabric/EffectsTwoChannel/Film/Light Leak.metal
@@ -16,6 +16,7 @@ using namespace metal;
 #include "../../lygia/sampler.msl"
 #include "../../lygia/math/radians.msl"
 #include "../../lygia/math/rotate2d.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 // Uniforms → Fabric UI sliders
 typedef struct {
@@ -26,13 +27,14 @@ typedef struct {
 
 fragment half4 postFragment( VertexData                        in        [[stage_in]],
                              constant PostUniforms            &uniforms  [[buffer( FragmentBufferMaterialUniforms )]],
+                             constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
                              texture2d<half, access::sample>   imageTex  [[texture( FragmentTextureCustom0 )]],
                              texture2d<half, access::sample>   lutTex    [[texture( FragmentTextureCustom1 )]] )
 {
     float2 uv = in.texcoord; // normalized [0, 1]
 
     // Base image sample
-    half4 input0 = SAMPLER_FNC(imageTex, uv);
+    half4 input0 = SAMPLER_FNC(imageTex, fabricTextureCoordinate(imageTransforms[0], uv));
 
     // Rotate sampling point around center (0.5, 0.5)
     float2 point = uv;
@@ -51,7 +53,7 @@ fragment half4 postFragment( VertexData                        in        [[stage
 
     // Sample LUT (1D across X, y=0), wrapping X
     float2 lutUV = point;// float2(fract(point.x), uv.y);
-    half4 leak = SAMPLER_FNC(lutTex, lutUV);
+    half4 leak = SAMPLER_FNC(lutTex, fabricTextureCoordinate(imageTransforms[1], lutUV));
 
     leak *= leakIntensity; //pow(leak * leakIntensity, vec4(1.0/(leakIntensity)));
 //    float safeLeakI = max(leakIntensity, 0.0001f);

--- a/Fabric/EffectsTwoChannel/Mask/ApplyMask.metal
+++ b/Fabric/EffectsTwoChannel/Mask/ApplyMask.metal
@@ -10,6 +10,7 @@
 #define SAMPLER_TYPE texture2d<half>
 
 #include "../../lygia/sampler.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
 //    float amount; // slider, 0.0, 1.0, 0.0, Amount
@@ -18,17 +19,13 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> tex0 [[texture( FragmentTextureCustom0 )]],
     texture2d<half, access::sample> tex1 [[texture( FragmentTextureCustom1 )]] )
 {
 //    half amount = half(uniforms.amount);
-    half4 srcColor = SAMPLER_FNC( tex0, in.texcoord );
-
-    // TODO: Fix
-    float2 flipped = in.texcoord;
-    flipped.y = 1.0 - flipped.y;
-
-    half4 dstColor = SAMPLER_FNC( tex1, flipped );
+    half4 srcColor = SAMPLER_FNC( tex0, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
+    half4 dstColor = SAMPLER_FNC( tex1, fabricTextureCoordinate(imageTransforms[1], in.texcoord));
     srcColor *= dstColor.r;
 //    srcColor.a = dstColor.r;
     

--- a/Fabric/EffectsTwoChannel/Mix/Mix.metal
+++ b/Fabric/EffectsTwoChannel/Mix/Mix.metal
@@ -12,6 +12,7 @@
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/blend.msl"
 #include "../../lygia/color/composite/sourceOver.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
     float amount; // slider, -1.0, 2.0, 0.0, Amount
@@ -20,12 +21,13 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> tex0 [[texture( FragmentTextureCustom0 )]],
     texture2d<half, access::sample> tex1 [[texture( FragmentTextureCustom1 )]] )
 {
     half amount = half(uniforms.amount);
-    half4 srcColor = SAMPLER_FNC( tex0, in.texcoord );
-    half4 dstColor = SAMPLER_FNC( tex1, in.texcoord );
+    half4 srcColor = SAMPLER_FNC(tex0, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
+    half4 dstColor = SAMPLER_FNC(tex1, fabricTextureCoordinate(imageTransforms[1], in.texcoord));
     
     half4 result;
     

--- a/Fabric/EffectsTwoChannel/Mix/MixTemplate.msl
+++ b/Fabric/EffectsTwoChannel/Mix/MixTemplate.msl
@@ -12,6 +12,7 @@
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/blend.msl"
 #include "../../lygia/color/composite/sourceOver.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
     float amount; // slider, 0.0, 1.0, 0.0, Amount
@@ -20,12 +21,13 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> tex0 [[texture( FragmentTextureCustom0 )]],
     texture2d<half, access::sample> tex1 [[texture( FragmentTextureCustom1 )]] )
 {
     half amount = half(uniforms.amount);
-    half4 srcColor = SAMPLER_FNC( tex0, in.texcoord );
-    half4 dstColor = SAMPLER_FNC( tex1, in.texcoord );
+    half4 srcColor = SAMPLER_FNC(tex0, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
+    half4 dstColor = SAMPLER_FNC(tex1, fabricTextureCoordinate(imageTransforms[1], in.texcoord));
     
     half3 blend = BLEND_FUNC(srcColor.rgb, dstColor.rgb);
     half a = compositeSourceOver(srcColor.a, dstColor.a);

--- a/Fabric/EffectsTwoChannel/Mix/Source Over.metal
+++ b/Fabric/EffectsTwoChannel/Mix/Source Over.metal
@@ -9,11 +9,12 @@
 #define SAMPLER_PRECISION half4
 #define SAMPLER_TYPE texture2d<half>
 
-#include "../lygia/sampler.msl"
-#include "../lygia/color/layer.msl"
-#include "../lygia/color/composite/sourceOver.msl"
-#include "../lygia/color/space/gamma2linear.msl"
-#include "../lygia/color/space/linear2gamma.msl"
+#include "../../lygia/sampler.msl"
+#include "../../lygia/color/layer.msl"
+#include "../../lygia/color/composite/sourceOver.msl"
+#include "../../lygia/color/space/gamma2linear.msl"
+#include "../../lygia/color/space/linear2gamma.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
     float amount; // slider, 0.0, 1.0, 0.0, Amount
@@ -22,12 +23,13 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> tex0 [[texture( FragmentTextureCustom0 )]],
     texture2d<half, access::sample> tex1 [[texture( FragmentTextureCustom1 )]] )
 {
     half4 amount = half4(uniforms.amount);
-    half4 srcColor = gamma2linear(SAMPLER_FNC( tex0, in.uv ));
-    half4 dstColor = gamma2linear(SAMPLER_FNC( tex1, in.uv ));
+    half4 srcColor = gamma2linear(SAMPLER_FNC(tex0, fabricTextureCoordinate(imageTransforms[0], in.texcoord)));
+    half4 dstColor = gamma2linear(SAMPLER_FNC(tex1, fabricTextureCoordinate(imageTransforms[1], in.texcoord)));
 
     half4 blend = compositeSourceOver(srcColor, dstColor);
 

--- a/Fabric/EffectsTwoChannel/Mixers/Fade Curve.metal
+++ b/Fabric/EffectsTwoChannel/Mixers/Fade Curve.metal
@@ -10,6 +10,7 @@
 #define SAMPLER_TYPE texture2d<half>
 
 #include "../../lygia/sampler.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
     float amount; // slider, 0.0, 1.0, 0.0, Amount
@@ -19,13 +20,14 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> tex0 [[texture( FragmentTextureCustom0 )]],
     texture2d<half, access::sample> tex1 [[texture( FragmentTextureCustom1 )]] )
 {
     half amount = half(uniforms.amount);
     half additiveAmount = 1.0h + half(uniforms.additiveAmount);
-    half4 srcColor = SAMPLER_FNC( tex0, in.texcoord );
-    half4 dstColor = SAMPLER_FNC( tex1, in.texcoord );
+    half4 srcColor = SAMPLER_FNC( tex0, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
+    half4 dstColor = SAMPLER_FNC( tex1, fabricTextureCoordinate(imageTransforms[1], in.texcoord));
     
     half4 result;
     result.rgb = mix(0.0h, srcColor.rgb, min((1.0h - amount) * additiveAmount, 1.0h)) +

--- a/Fabric/EffectsTwoChannel/ShapeOperator/SDF Blend.metal
+++ b/Fabric/EffectsTwoChannel/ShapeOperator/SDF Blend.metal
@@ -12,6 +12,7 @@
 #include "../../lygia/sampler.msl"
 #include "../../lygia/color/space/gamma2linear.msl"
 #include "../../lygia/color/space/linear2gamma.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 typedef struct {
     float amount; // slider, 0.0, 1.0, 0.0, Amount
@@ -20,15 +21,16 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> sdfa [[texture( FragmentTextureCustom0 )]],
     texture2d<half, access::sample> sdfb [[texture( FragmentTextureCustom1 )]] )
 {    
     float2 coords = in.texcoord;
 
-    float sdf1 = SAMPLER_FNC(sdfa, coords).r;
+    float sdf1 = SAMPLER_FNC(sdfa, fabricTextureCoordinate(imageTransforms[0], coords)).r;
   //  sdf1 = gamma2linear(sdf1);
 
-    float sdf2 = SAMPLER_FNC(sdfb, coords).r;
+    float sdf2 = SAMPLER_FNC(sdfb, fabricTextureCoordinate(imageTransforms[1], coords)).r;
 //    sdf2 = gamma2linear(sdf2);
 
     // Read pixel intensities from the current and reference frames

--- a/Fabric/EffectsTwoChannel/ShapeOperator/SDF Intersect.metal
+++ b/Fabric/EffectsTwoChannel/ShapeOperator/SDF Intersect.metal
@@ -8,6 +8,7 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/sdf/opIntersection.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 
 typedef struct {
@@ -17,13 +18,14 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<float, access::sample> sdfa [[texture( FragmentTextureCustom0 )]],
     texture2d<float, access::sample> sdfb [[texture( FragmentTextureCustom1 )]] )
 {    
     float2 coords = in.texcoord;
 
-    float sdf1 = SAMPLER_FNC(sdfa, coords).r;
-    float sdf2 = SAMPLER_FNC(sdfb, coords).r;
+    float sdf1 = SAMPLER_FNC(sdfa, fabricTextureCoordinate(imageTransforms[0], coords)).r;
+    float sdf2 = SAMPLER_FNC(sdfb, fabricTextureCoordinate(imageTransforms[1], coords)).r;
 
     // Read pixel intensities from the current and reference frames
     return half4(opIntersection(sdf1, sdf2));

--- a/Fabric/EffectsTwoChannel/ShapeOperator/SDF Subtract.metal
+++ b/Fabric/EffectsTwoChannel/ShapeOperator/SDF Subtract.metal
@@ -8,6 +8,7 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/sdf/opSubtraction.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 
 typedef struct {
@@ -17,13 +18,14 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<float, access::sample> sdfa [[texture( FragmentTextureCustom0 )]],
     texture2d<float, access::sample> sdfb [[texture( FragmentTextureCustom1 )]] )
 {    
     float2 coords = in.texcoord;
 
-    float sdf1 = SAMPLER_FNC(sdfa, coords).r;
-    float sdf2 = SAMPLER_FNC(sdfb, coords).r;
+    float sdf1 = SAMPLER_FNC(sdfa, fabricTextureCoordinate(imageTransforms[0], coords)).r;
+    float sdf2 = SAMPLER_FNC(sdfb, fabricTextureCoordinate(imageTransforms[1], coords)).r;
 
     // Read pixel intensities from the current and reference frames
     return half4(opSubtraction(sdf1, sdf2, uniforms.amount));

--- a/Fabric/EffectsTwoChannel/ShapeOperator/SDF Union.metal
+++ b/Fabric/EffectsTwoChannel/ShapeOperator/SDF Union.metal
@@ -8,6 +8,7 @@
 
 #include "../../lygia/sampler.msl"
 #include "../../lygia/sdf/opUnion.msl"
+#include "../../Shaders/FabricImageTextureTransform.metal"
 
 
 typedef struct {
@@ -17,13 +18,14 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<float, access::sample> sdfa [[texture( FragmentTextureCustom0 )]],
     texture2d<float, access::sample> sdfb [[texture( FragmentTextureCustom1 )]] )
 {    
     float2 coords = in.texcoord;
 
-    float sdf1 = SAMPLER_FNC(sdfa, coords).r;
-    float sdf2 = SAMPLER_FNC(sdfb, coords).r;
+    float sdf1 = SAMPLER_FNC(sdfa, fabricTextureCoordinate(imageTransforms[0], coords)).r;
+    float sdf2 = SAMPLER_FNC(sdfb, fabricTextureCoordinate(imageTransforms[1], coords)).r;
 
     // Read pixel intensities from the current and reference frames
     return half4(opUnion(sdf1, sdf2, uniforms.amount));

--- a/Fabric/Graph/GraphExecutionInfo.swift
+++ b/Fabric/Graph/GraphExecutionInfo.swift
@@ -29,15 +29,19 @@ public struct GraphExecutionTiming : Hashable
     /// System absolute time when graph execution as requested
     public let systemTime:TimeInterval
     
+    
+    public let hostMediaTime:TimeInterval
+    
     /// The frame number being requested
     public let frameNumber:Int
     
-    public init(time: TimeInterval, deltaTime: TimeInterval, displayTime: TimeInterval?, systemTime: TimeInterval, frameNumber: Int) {
+    public init(time: TimeInterval, deltaTime: TimeInterval, displayTime: TimeInterval?, systemTime: TimeInterval, hostMediaTime:TimeInterval, frameNumber: Int) {
         self.time = time
         self.deltaTime = deltaTime
         self.displayTime = displayTime
         self.systemTime = systemTime
         self.frameNumber = frameNumber
+        self.hostMediaTime = hostMediaTime
     }
 }
 

--- a/Fabric/Graph/GraphExecutionInfo.swift
+++ b/Fabric/Graph/GraphExecutionInfo.swift
@@ -28,10 +28,10 @@ public struct GraphExecutionTiming : Hashable
     
     /// System absolute time when graph execution as requested
     public let systemTime:TimeInterval
-    
-    
+
+
     public let hostMediaTime:TimeInterval
-    
+
     /// The frame number being requested
     public let frameNumber:Int
     

--- a/Fabric/Graph/GraphExportRenderer.swift
+++ b/Fabric/Graph/GraphExportRenderer.swift
@@ -9,6 +9,7 @@ import Foundation
 import Metal
 import Satin
 import simd
+import QuartzCore
 
 public enum GraphExportRendererError: Error {
     case alreadyStarted
@@ -160,6 +161,7 @@ public final class GraphExportRenderer {
                 deltaTime: deltaTime,
                 displayTime: time,
                 systemTime: Date.timeIntervalSinceReferenceDate,
+                hostMediaTime: CACurrentMediaTime(),
                 frameNumber: frameNumber
             ),
             iterationInfo: nil,

--- a/Fabric/Graph/GraphRenderer.swift
+++ b/Fabric/Graph/GraphRenderer.swift
@@ -674,7 +674,7 @@ public class GraphRenderer : ViewRenderer
             image = try newSharedImage(fromPixelBuffer: pixelBuffer)
         }
         
-        image.isFlipped = CVImageBufferIsFlipped(pixelBuffer)
+        image.isFlipped = !CVImageBufferIsFlipped(pixelBuffer)
         
         return image
     }

--- a/Fabric/Graph/GraphRenderer.swift
+++ b/Fabric/Graph/GraphRenderer.swift
@@ -675,7 +675,7 @@ public class GraphRenderer : ViewRenderer
             image = try newSharedImage(fromPixelBuffer: pixelBuffer)
         }
         
-        image.isFlipped = !CVImageBufferIsFlipped(pixelBuffer)
+        image.textureTransform = FabricImageTextureTransform.coreVideo(pixelBuffer)
         
         return image
     }

--- a/Fabric/Graph/GraphRenderer.swift
+++ b/Fabric/Graph/GraphRenderer.swift
@@ -27,7 +27,7 @@ public class GraphRenderer : ViewRenderer
     private var graphExecutionStartTime = CACurrentMediaTime()
 
     public private(set) var currentExecutionInfo: GraphExecutionInfo = GraphExecutionInfo(
-        timing: GraphExecutionTiming(time: 0, deltaTime: 0, displayTime: nil, systemTime: 0, frameNumber: -1)
+        timing: GraphExecutionTiming(time: 0, deltaTime: 0, displayTime: nil, systemTime: 0, hostMediaTime: 0, frameNumber: -1)
     )
 
     public private(set) var currentCamera: Camera? = nil
@@ -111,6 +111,7 @@ public class GraphRenderer : ViewRenderer
             deltaTime: delta,
             displayTime: now - self.graphExecutionStartTime,
             systemTime: Date.timeIntervalSinceReferenceDate,
+            hostMediaTime: now,
             frameNumber: frameIndex
         )
         currentExecutionInfo = GraphExecutionInfo(timing: timing, eventInfo: pendingEventInfo)

--- a/Fabric/Graph/Types/FabricImage.swift
+++ b/Fabric/Graph/Types/FabricImage.swift
@@ -28,13 +28,12 @@ public final class FabricImage: Identifiable, Equatable
     public private(set) var presentationSize: CGSize
 
     private func calculatePresentationSize() -> CGSize {
-        let transformedSize = simd_abs(
-            textureTransform * simd_float4(Float(texture.width), Float(texture.height), 0, 0)
-        )
-        return CGSize(
-            width: CGFloat(transformedSize.x),
-            height: CGFloat(transformedSize.y)
-        )
+        let transformedSize = simd_abs(textureTransform * simd_float4(Float(texture.width),
+                                                                      Float(texture.height),
+                                                                      0,
+                                                                      0))
+        return CGSize(width: CGFloat(transformedSize.x),
+                      height: CGFloat(transformedSize.y))
     }
 
     // MARK: - Managed/unmanaged
@@ -106,31 +105,26 @@ public final class FabricImage: Identifiable, Equatable
 
         func presentationPoint(fromStoredPoint point: CGPoint) -> CGPoint
         {
-            let storedTextureCoordinate = simd_float4(
-                Float(point.x / storedWidth),
-                1.0 - Float(point.y / storedHeight),
-                0,
-                1
-            )
+            let storedTextureCoordinate = simd_float4(Float(point.x / storedWidth),
+                                                      1.0 - Float(point.y / storedHeight),
+                                                      0,
+                                                      1)
+
             let presentationTextureCoordinate = textureTransform.inverse * storedTextureCoordinate
 
-            return CGPoint(
-                x: CGFloat(presentationTextureCoordinate.x) * presentationWidth,
-                y: (1.0 - CGFloat(presentationTextureCoordinate.y)) * presentationHeight
-            )
+            return CGPoint(x: CGFloat(presentationTextureCoordinate.x) * presentationWidth,
+                           y: (1.0 - CGFloat(presentationTextureCoordinate.y)) * presentationHeight)
         }
 
         let origin = presentationPoint(fromStoredPoint: .zero)
         let horizontalPoint = presentationPoint(fromStoredPoint: CGPoint(x: 1, y: 0))
         let verticalPoint = presentationPoint(fromStoredPoint: CGPoint(x: 0, y: 1))
-        let pixelTransform = CGAffineTransform(
-            a: horizontalPoint.x - origin.x,
-            b: horizontalPoint.y - origin.y,
-            c: verticalPoint.x - origin.x,
-            d: verticalPoint.y - origin.y,
-            tx: origin.x,
-            ty: origin.y
-        )
+        let pixelTransform = CGAffineTransform(a: horizontalPoint.x - origin.x,
+                                               b: horizontalPoint.y - origin.y,
+                                               c: verticalPoint.x - origin.x,
+                                               d: verticalPoint.y - origin.y,
+                                               tx: origin.x,
+                                               ty: origin.y)
 
         return storedImage
             .transformed(by: pixelTransform)
@@ -164,27 +158,21 @@ public enum FabricImageTextureTransform
 
         func storedUV(presentationUV: CGPoint) -> simd_float2
         {
-            let presentationPoint = CGPoint(
-                x: presentationBounds.minX + presentationUV.x * presentationBounds.width,
-                y: presentationBounds.minY + presentationUV.y * presentationBounds.height
-            )
+            let presentationPoint = CGPoint(x: presentationBounds.minX + presentationUV.x * presentationBounds.width,
+                                            y: presentationBounds.minY + presentationUV.y * presentationBounds.height)
             let sourcePoint = presentationPoint.applying(inverseTransform)
-            return simd_float2(
-                Float(sourcePoint.x / sourceSize.width),
-                Float(sourcePoint.y / sourceSize.height)
-            )
+            return simd_float2(Float(sourcePoint.x / sourceSize.width),
+                               Float(sourcePoint.y / sourceSize.height))
         }
 
         let origin = storedUV(presentationUV: .zero)
         let horizontal = storedUV(presentationUV: CGPoint(x: 1, y: 0)) - origin
         let vertical = storedUV(presentationUV: CGPoint(x: 0, y: 1)) - origin
 
-        return simd_float4x4(
-            simd_float4(horizontal.x, horizontal.y, 0, 0),
-            simd_float4(vertical.x, vertical.y, 0, 0),
-            simd_float4(0, 0, 1, 0),
-            simd_float4(origin.x, origin.y, 0, 1)
-        )
+        return simd_float4x4(simd_float4(horizontal.x, horizontal.y, 0, 0),
+                             simd_float4(vertical.x, vertical.y, 0, 0),
+                             simd_float4(0, 0, 1, 0),
+                             simd_float4(origin.x, origin.y, 0, 1))
     }
 
     /// Composes Core Video storage orientation with source presentation

--- a/Fabric/Graph/Types/FabricImage.swift
+++ b/Fabric/Graph/Types/FabricImage.swift
@@ -5,34 +5,37 @@
 //  Created by Anton Marini on 5/5/25.
 //
 import Metal
-
-//
-//public struct FabricImage: Equatable, Identifiable
-//{
-//    public let id = UUID()
-//    public let texture: MTLTexture
-//    public var isFlipped:Bool = false
-//    
-//    // TODO: Until we get a texture pool where we vend texture for effects
-//    // this should be true?
-//    // https://github.com/Fabric-Project/Fabric/issues/34
-//
-//    public var force: Bool = false
-//
-//    public static func == (lhs: FabricImage, rhs: FabricImage) -> Bool {
-////        return false
-//        return lhs.texture === rhs.texture && lhs.id == rhs.id
-//        && (lhs.force || rhs.force) // reference identity
-//    }
-//}
-
-import Metal
+import CoreImage
+import CoreGraphics
+import CoreVideo
+import simd
 
 public final class FabricImage: Identifiable, Equatable
 {
     public let id = UUID()
     public let texture: MTLTexture
-    public var isFlipped: Bool = false
+
+    /// Maps Fabric's canonical Satin UV coordinates into the coordinates
+    /// required to sample the stored texture correctly.
+    public var textureTransform: simd_float4x4 = matrix_identity_float4x4 {
+        didSet {
+            presentationSize = calculatePresentationSize()
+        }
+    }
+
+    /// The image dimensions after applying its texture-coordinate transform.
+    /// Unlike the texture dimensions, this reflects presentation orientation.
+    public private(set) var presentationSize: CGSize
+
+    private func calculatePresentationSize() -> CGSize {
+        let transformedSize = simd_abs(
+            textureTransform * simd_float4(Float(texture.width), Float(texture.height), 0, 0)
+        )
+        return CGSize(
+            width: CGFloat(transformedSize.x),
+            height: CGFloat(transformedSize.y)
+        )
+    }
 
     // MARK: - Managed/unmanaged
 
@@ -43,6 +46,7 @@ public final class FabricImage: Identifiable, Equatable
     private init(texture: MTLTexture, onRelease: ((MTLTexture) -> Void)?)
     {
         self.texture = texture
+        self.presentationSize = CGSize(width: texture.width, height: texture.height)
         self.onRelease = onRelease
     }
 
@@ -80,5 +84,116 @@ public final class FabricImage: Identifiable, Equatable
 
         // 2) OR if you want texture identity:
         return lhs.texture === rhs.texture && lhs.id == rhs.id
+    }
+
+    /// Converts normalized coordinates in the stored texture back into
+    /// Fabric's canonical texture-coordinate space.
+    public func canonicalTextureCoordinate(fromStoredTextureCoordinate coordinate: simd_float2) -> simd_float2
+    {
+        let transformed = textureTransform.inverse * simd_float4(coordinate.x, coordinate.y, 0, 1)
+        return simd_float2(transformed.x, transformed.y)
+    }
+
+    /// A Core Image view of the texture in Fabric's canonical presentation orientation.
+    public var presentationCIImage: CIImage?
+    {
+        guard let storedImage = CIImage(mtlTexture: texture) else { return nil }
+
+        let storedWidth = CGFloat(texture.width)
+        let storedHeight = CGFloat(texture.height)
+        let presentationWidth = presentationSize.width
+        let presentationHeight = presentationSize.height
+
+        func presentationPoint(fromStoredPoint point: CGPoint) -> CGPoint
+        {
+            let storedTextureCoordinate = simd_float4(
+                Float(point.x / storedWidth),
+                1.0 - Float(point.y / storedHeight),
+                0,
+                1
+            )
+            let presentationTextureCoordinate = textureTransform.inverse * storedTextureCoordinate
+
+            return CGPoint(
+                x: CGFloat(presentationTextureCoordinate.x) * presentationWidth,
+                y: (1.0 - CGFloat(presentationTextureCoordinate.y)) * presentationHeight
+            )
+        }
+
+        let origin = presentationPoint(fromStoredPoint: .zero)
+        let horizontalPoint = presentationPoint(fromStoredPoint: CGPoint(x: 1, y: 0))
+        let verticalPoint = presentationPoint(fromStoredPoint: CGPoint(x: 0, y: 1))
+        let pixelTransform = CGAffineTransform(
+            a: horizontalPoint.x - origin.x,
+            b: horizontalPoint.y - origin.y,
+            c: verticalPoint.x - origin.x,
+            d: verticalPoint.y - origin.y,
+            tx: origin.x,
+            ty: origin.y
+        )
+
+        return storedImage
+            .transformed(by: pixelTransform)
+            .cropped(to: CGRect(origin: .zero, size: presentationSize))
+    }
+}
+
+public enum FabricImageTextureTransform
+{
+    /// Converts Core Video's texture-origin convention into Fabric's
+    /// canonical top-left Metal texture-coordinate convention.
+    public static func coreVideo(_ pixelBuffer: CVPixelBuffer) -> simd_float4x4
+    {
+        CVImageBufferIsFlipped(pixelBuffer)
+            ? matrix_identity_float4x4
+            : .textureVerticalFlip
+    }
+
+    /// Converts an affine transform from source pixel coordinates into a
+    /// normalized texture-coordinate sampling transform.
+    ///
+    /// `sourceToPresentationTransform` maps stored source pixels into their
+    /// intended presentation. The returned matrix performs the inverse map:
+    /// canonical presentation UV -> stored source UV.
+    public static func sourceToPresentation(_ sourceToPresentationTransform: CGAffineTransform,
+                                            sourceSize: CGSize) -> simd_float4x4
+    {
+        let sourceBounds = CGRect(origin: .zero, size: sourceSize)
+        let presentationBounds = sourceBounds.applying(sourceToPresentationTransform).standardized
+        let inverseTransform = sourceToPresentationTransform.inverted()
+
+        func storedUV(presentationUV: CGPoint) -> simd_float2
+        {
+            let presentationPoint = CGPoint(
+                x: presentationBounds.minX + presentationUV.x * presentationBounds.width,
+                y: presentationBounds.minY + presentationUV.y * presentationBounds.height
+            )
+            let sourcePoint = presentationPoint.applying(inverseTransform)
+            return simd_float2(
+                Float(sourcePoint.x / sourceSize.width),
+                Float(sourcePoint.y / sourceSize.height)
+            )
+        }
+
+        let origin = storedUV(presentationUV: .zero)
+        let horizontal = storedUV(presentationUV: CGPoint(x: 1, y: 0)) - origin
+        let vertical = storedUV(presentationUV: CGPoint(x: 0, y: 1)) - origin
+
+        return simd_float4x4(
+            simd_float4(horizontal.x, horizontal.y, 0, 0),
+            simd_float4(vertical.x, vertical.y, 0, 0),
+            simd_float4(0, 0, 1, 0),
+            simd_float4(origin.x, origin.y, 0, 1)
+        )
+    }
+
+    /// Composes Core Video storage orientation with source presentation
+    /// metadata such as an AVAssetTrack preferred transform.
+    public static func video(pixelBuffer: CVPixelBuffer,
+                             sourceToPresentationTransform: CGAffineTransform,
+                             sourceSize: CGSize) -> simd_float4x4
+    {
+        coreVideo(pixelBuffer)
+            * sourceToPresentation(sourceToPresentationTransform, sourceSize: sourceSize)
     }
 }

--- a/Fabric/Materials/DisplacementMaterial.metal
+++ b/Fabric/Materials/DisplacementMaterial.metal
@@ -14,6 +14,9 @@ typedef struct {
     float maxPointSize;
     float brightness;
     float lumaVPosMix;
+    float4x4 displacementTextureTransform;
+    float4x4 colorTextureTransform;
+    float4x4 pointSpriteTextureTransform;
 } DisplacementUniforms;
 
 constexpr sampler s( min_filter::linear, mag_filter::linear);
@@ -35,7 +38,9 @@ vertex CustomVertexData displacementVertex(Vertex in [[stage_in]],
 {
     CustomVertexData out;
 
-    const half4 sample = rdTex.sample( s, in.texcoord );
+    const float2 displacementUV =
+        (uniforms.displacementTextureTransform * float4(in.texcoord, 0.0, 1.0)).xy;
+    const half4 sample = rdTex.sample(s, displacementUV);
     const half luma = dot(lumcoeff, sample);
 
     const float3 position = mix(in.position, float3(sample.rgb), uniforms.amount);
@@ -84,8 +89,12 @@ fragment half4 displacementFragment( CustomVertexData in [[stage_in]],
     
 //    const half4 blendFactor = 1.0 - half4(stencilValue) / half4(refValue); // fade out at limit
 
-    const half4 color = colorTex.sample( s, in.uv );
-    const half4 sprite = pointSpriteTex.sample( p, puv ) ;
+    const float2 colorUV =
+        (uniforms.colorTextureTransform * float4(in.uv, 0.0, 1.0)).xy;
+    const float2 pointSpriteUV =
+        (uniforms.pointSpriteTextureTransform * float4(puv, 0.0, 1.0)).xy;
+    const half4 color = colorTex.sample(s, colorUV);
+    const half4 sprite = pointSpriteTex.sample(p, pointSpriteUV);
         
     return sprite * color * uniforms.brightness;
 }

--- a/Fabric/Nodes/Base/BaseImageNode.swift
+++ b/Fabric/Nodes/Base/BaseImageNode.swift
@@ -37,11 +37,9 @@ open class BaseImageNode: Node, NodeFileLoadingProtocol
     private var cachedFileURLName: String?
     private var lastKnownInputCount: Int = 1
     private var cachedImageInputPorts: [NodePort<FabricImage>] = []
-    private lazy var inputTextureTransformBuffer = StructBuffer<simd_float4x4>(
-        device: self.context.device,
-        count: 25,
-        label: "BaseImageNode Input Texture Transforms"
-    )
+    private lazy var inputTextureTransformBuffer = StructBuffer<simd_float4x4>(device: self.context.device,
+                                                                               count: 25,
+                                                                               label: "BaseImageNode Input Texture Transforms")
 
     enum CodingKeys: String, CodingKey
     {

--- a/Fabric/Nodes/Base/BaseImageNode.swift
+++ b/Fabric/Nodes/Base/BaseImageNode.swift
@@ -37,6 +37,11 @@ open class BaseImageNode: Node, NodeFileLoadingProtocol
     private var cachedFileURLName: String?
     private var lastKnownInputCount: Int = 1
     private var cachedImageInputPorts: [NodePort<FabricImage>] = []
+    private lazy var inputTextureTransformBuffer = StructBuffer<simd_float4x4>(
+        device: self.context.device,
+        count: 25,
+        label: "BaseImageNode Input Texture Transforms"
+    )
 
     enum CodingKeys: String, CodingKey
     {
@@ -684,12 +689,17 @@ open class BaseImageNode: Node, NodeFileLoadingProtocol
         }
         
         let inputTexture0 = inputImage.texture
+        let inputImages = self.imageInputPorts().map(\.value)
+        let textures = inputImages.map { $0?.texture }
+        let outputWidth = Int(inputImage.presentationSize.width.rounded())
+        let outputHeight = Int(inputImage.presentationSize.height.rounded())
 
-        let outImage = try renderer.newImage(withWidth: inputTexture0.width, height: inputTexture0.height)
+        let outImage = try renderer.newImage(withWidth: outputWidth, height: outputHeight)
 
-        outImage.isFlipped = inputImage.isFlipped
-        
-        let textures = self.imageInputPorts().map { $0.value?.texture }
+        let transforms = inputImages.map { $0?.textureTransform ?? inputImage.textureTransform }
+        self.inputTextureTransformBuffer.update(data: transforms)
+        self.postMaterial.set(self.inputTextureTransformBuffer, index: FragmentBufferIndex.Custom10)
+        outImage.textureTransform = matrix_identity_float4x4
 
         self.postProcessor.mesh.preDraw = { renderEncoder in
             for (index, texture) in textures.enumerated() {
@@ -698,7 +708,7 @@ open class BaseImageNode: Node, NodeFileLoadingProtocol
             }
         }
 
-        self.postProcessor.resize(size: (width: Float(inputTexture0.width), height: Float(inputTexture0.height)), scaleFactor: 1)
+        self.postProcessor.resize(size: (width: Float(outputWidth), height: Float(outputHeight)), scaleFactor: 1)
 
         let renderPassDesc = MTLRenderPassDescriptor()
         renderPassDesc.colorAttachments[0].texture = outImage.texture

--- a/Fabric/Nodes/Base/BaseMultiPassBlurEffectNode.swift
+++ b/Fabric/Nodes/Base/BaseMultiPassBlurEffectNode.swift
@@ -50,11 +50,9 @@ public class BaseMultiPassBlurEffectNode: BaseImageNode
 
     private func textureTransformBuffer(forStepIndex index: Int) -> StructBuffer<simd_float4x4> {
         while self.textureTransformBuffers.count <= index {
-            let buffer = StructBuffer<simd_float4x4>(
-                device: self.context.device,
-                count: 1,
-                label: "Multi-Pass Blur Texture Transform \(self.textureTransformBuffers.count)"
-            )
+            let buffer = StructBuffer<simd_float4x4>(device: self.context.device,
+                                                      count: 1,
+                                                      label: "Multi-Pass Blur Texture Transform \(self.textureTransformBuffers.count)")
             self.textureTransformBuffers.append(buffer)
         }
 

--- a/Fabric/Nodes/Base/BaseMultiPassBlurEffectNode.swift
+++ b/Fabric/Nodes/Base/BaseMultiPassBlurEffectNode.swift
@@ -26,6 +26,7 @@ public class BaseMultiPassBlurEffectNode: BaseImageNode
 
     public static let lowAmountThreshold: Float = 0.0
     private var hasLoggedInputCountMismatch = false
+    private var textureTransformBuffers: [StructBuffer<simd_float4x4>] = []
 
 
     public func floatParameterValue(named name: String, default defaultValue: Float = 0.0) -> Float
@@ -33,7 +34,7 @@ public class BaseMultiPassBlurEffectNode: BaseImageNode
         self.postMaterial.parameters.get(name, as: FloatParameter.self)?.value ?? defaultValue
     }
 
-    public func validatedSingleInputTexture() -> MTLTexture? {
+    public func validatedSingleInputImage() -> FabricImage? {
         let inputs = self.imageInputPorts()
         if inputs.count != 1 {
             if self.hasLoggedInputCountMismatch == false {
@@ -44,7 +45,20 @@ public class BaseMultiPassBlurEffectNode: BaseImageNode
         }
 
         self.hasLoggedInputCountMismatch = false
-        return inputs[0].value?.texture
+        return inputs[0].value
+    }
+
+    private func textureTransformBuffer(forStepIndex index: Int) -> StructBuffer<simd_float4x4> {
+        while self.textureTransformBuffers.count <= index {
+            let buffer = StructBuffer<simd_float4x4>(
+                device: self.context.device,
+                count: 1,
+                label: "Multi-Pass Blur Texture Transform \(self.textureTransformBuffers.count)"
+            )
+            self.textureTransformBuffers.append(buffer)
+        }
+
+        return self.textureTransformBuffers[index]
     }
 
     public func scaledPassSize(baseWidth: Int, baseHeight: Int, amount: Float, passRatio: Float) -> (width: Int, height: Int)
@@ -61,7 +75,7 @@ public class BaseMultiPassBlurEffectNode: BaseImageNode
     public func runPassChain(renderer:GraphRenderer,
                              executionInfo: GraphExecutionInfo,
                              commandBuffer: MTLCommandBuffer,
-                             inputTexture: MTLTexture,
+                             inputImage: FabricImage,
                              steps: [MultiPassStep],
                              prepareStep: (Int, MultiPassStep) -> Void ) -> FabricImage? {
 
@@ -69,7 +83,7 @@ public class BaseMultiPassBlurEffectNode: BaseImageNode
             return nil
         }
 
-        var currentTexture: MTLTexture = inputTexture
+        var currentTexture = inputImage.texture
         var currentImage: FabricImage? = nil
 
         for (index, step) in steps.enumerated() {
@@ -81,6 +95,13 @@ public class BaseMultiPassBlurEffectNode: BaseImageNode
             commandBuffer.pushDebugGroup("\(self.debugDescription) - pass \(index)")
 
             prepareStep(index, step)
+
+            let textureTransform = index == 0
+                ? inputImage.textureTransform
+                : matrix_identity_float4x4
+            let textureTransformBuffer = self.textureTransformBuffer(forStepIndex: index)
+            textureTransformBuffer.update(data: [textureTransform])
+            self.postMaterial.set(textureTransformBuffer, index: FragmentBufferIndex.Custom10)
 
             self.postProcessor.mesh.preDraw = { renderEncoder in
                 renderEncoder.setFragmentTexture(currentTexture, index: FragmentTextureIndex.Custom0.rawValue)

--- a/Fabric/Nodes/Base/BaseMultiPassBlurEffectTwoChannelNode.swift
+++ b/Fabric/Nodes/Base/BaseMultiPassBlurEffectTwoChannelNode.swift
@@ -24,6 +24,7 @@ public class BaseMultiPassBlurEffectTwoChannelNode: BaseImageNode
 
     public static let lowAmountThreshold: Float = 0.0
     private var hasLoggedInputCountMismatch = false
+    private var textureTransformBuffers: [StructBuffer<simd_float4x4>] = []
 
 
     public func floatParameterValue(named name: String, default defaultValue: Float = 0.0) -> Float
@@ -31,7 +32,7 @@ public class BaseMultiPassBlurEffectTwoChannelNode: BaseImageNode
         self.postMaterial.parameters.get(name, as: FloatParameter.self)?.value ?? defaultValue
     }
 
-    public func validatedTwoInputTextures() -> (MTLTexture, MTLTexture)? {
+    public func validatedTwoInputImages() -> (FabricImage, FabricImage)? {
         let inputs = self.imageInputPorts()
         if inputs.count != 2 {
             if self.hasLoggedInputCountMismatch == false {
@@ -41,13 +42,28 @@ public class BaseMultiPassBlurEffectTwoChannelNode: BaseImageNode
             return nil
         }
 
-        guard let first = inputs[0].value?.texture,
-              let second = inputs[1].value?.texture else {
+        guard let first = inputs[0].value,
+              let second = inputs[1].value else {
             return nil
         }
 
         self.hasLoggedInputCountMismatch = false
         return (first, second)
+    }
+
+    public func setTextureTransforms(_ textureTransforms: [simd_float4x4], forStepIndex index: Int) {
+        while self.textureTransformBuffers.count <= index {
+            let buffer = StructBuffer<simd_float4x4>(
+                device: self.context.device,
+                count: 2,
+                label: "Two-Channel Multi-Pass Blur Texture Transforms \(self.textureTransformBuffers.count)"
+            )
+            self.textureTransformBuffers.append(buffer)
+        }
+
+        let textureTransformBuffer = self.textureTransformBuffers[index]
+        textureTransformBuffer.update(data: textureTransforms)
+        self.postMaterial.set(textureTransformBuffer, index: FragmentBufferIndex.Custom10)
     }
 
     public func scaledPassSize(baseWidth: Int, baseHeight: Int, amount: Float, passRatio: Float) -> (width: Int, height: Int) {
@@ -63,8 +79,8 @@ public class BaseMultiPassBlurEffectTwoChannelNode: BaseImageNode
     public func runPassChain(renderer:GraphRenderer,
                              executionInfo: GraphExecutionInfo,
                              commandBuffer: MTLCommandBuffer,
-                             inputATexture: MTLTexture,
-                             inputBTexture: MTLTexture,
+                             inputAImage: FabricImage,
+                             inputBImage: FabricImage,
                              steps: [MultiPassStep],
                              prepareStep: (Int, MultiPassStep) -> Void) -> FabricImage?
     {
@@ -73,7 +89,7 @@ public class BaseMultiPassBlurEffectTwoChannelNode: BaseImageNode
             return nil
         }
 
-        var currentTexture: MTLTexture = inputATexture
+        var currentTexture = inputAImage.texture
         var currentImage: FabricImage? = nil
 
         for (index, step) in steps.enumerated() {
@@ -84,9 +100,17 @@ public class BaseMultiPassBlurEffectTwoChannelNode: BaseImageNode
 
             prepareStep(index, step)
 
+            self.setTextureTransforms(
+                [
+                    index == 0 ? inputAImage.textureTransform : matrix_identity_float4x4,
+                    inputBImage.textureTransform,
+                ],
+                forStepIndex: index
+            )
+
             self.postProcessor.mesh.preDraw = { renderEncoder in
                 renderEncoder.setFragmentTexture(currentTexture, index: FragmentTextureIndex.Custom0.rawValue)
-                renderEncoder.setFragmentTexture(inputBTexture, index: FragmentTextureIndex.Custom1.rawValue)
+                renderEncoder.setFragmentTexture(inputBImage.texture, index: FragmentTextureIndex.Custom1.rawValue)
             }
 
             self.postProcessor.resize(size: (width: Float(step.width), height: Float(step.height)), scaleFactor: 1)

--- a/Fabric/Nodes/Base/BaseMultiPassBlurEffectTwoChannelNode.swift
+++ b/Fabric/Nodes/Base/BaseMultiPassBlurEffectTwoChannelNode.swift
@@ -53,11 +53,9 @@ public class BaseMultiPassBlurEffectTwoChannelNode: BaseImageNode
 
     public func setTextureTransforms(_ textureTransforms: [simd_float4x4], forStepIndex index: Int) {
         while self.textureTransformBuffers.count <= index {
-            let buffer = StructBuffer<simd_float4x4>(
-                device: self.context.device,
-                count: 2,
-                label: "Two-Channel Multi-Pass Blur Texture Transforms \(self.textureTransformBuffers.count)"
-            )
+            let buffer = StructBuffer<simd_float4x4>(device: self.context.device,
+                                                      count: 2,
+                                                      label: "Two-Channel Multi-Pass Blur Texture Transforms \(self.textureTransformBuffers.count)")
             self.textureTransformBuffers.append(buffer)
         }
 
@@ -100,13 +98,9 @@ public class BaseMultiPassBlurEffectTwoChannelNode: BaseImageNode
 
             prepareStep(index, step)
 
-            self.setTextureTransforms(
-                [
-                    index == 0 ? inputAImage.textureTransform : matrix_identity_float4x4,
-                    inputBImage.textureTransform,
-                ],
-                forStepIndex: index
-            )
+            self.setTextureTransforms([index == 0 ? inputAImage.textureTransform : matrix_identity_float4x4,
+                                       inputBImage.textureTransform],
+                                      forStepIndex: index)
 
             self.postProcessor.mesh.preDraw = { renderEncoder in
                 renderEncoder.setFragmentTexture(currentTexture, index: FragmentTextureIndex.Custom0.rawValue)

--- a/Fabric/Nodes/Base/BaseTextureComputeProcessorNode.swift
+++ b/Fabric/Nodes/Base/BaseTextureComputeProcessorNode.swift
@@ -128,8 +128,9 @@ public class BaseTextureComputeProcessorNode: Node, NodeFileLoadingProtocol
     public override func execute(renderer:GraphRenderer, executionInfo:GraphExecutionInfo, renderPassDescriptor: MTLRenderPassDescriptor, commandBuffer: MTLCommandBuffer) throws
     {
         guard self.inputImage.valueDidChange,
-              let inTex = self.inputImage.value?.texture
+              let inputImage = self.inputImage.value
         else { return }
+        let inTex = inputImage.texture
 
         guard self.compute != nil else
         {
@@ -139,6 +140,7 @@ public class BaseTextureComputeProcessorNode: Node, NodeFileLoadingProtocol
         }
 
         let outImage = try renderer.newImage(withWidth: inTex.width, height: inTex.height)
+        outImage.textureTransform = inputImage.textureTransform
 
         guard let computeEncoder = commandBuffer.makeComputeCommandEncoder() else
         {

--- a/Fabric/Nodes/Image/Analysis/ContourPathNode.swift
+++ b/Fabric/Nodes/Image/Analysis/ContourPathNode.swift
@@ -88,12 +88,13 @@ public final class ContourPathNode: Node {
         guard
             inputMask.valueDidChange,
             let proc = processor,
-            let inTex = inputMask.value?.texture
+            let inputMaskImage = inputMask.value
         else {
             outputContour.send(nil)
 //            print("not outputting contour")
             return
         }
+        let inTex = inputMaskImage.texture
         
         let device = renderer.context.device
 
@@ -129,8 +130,7 @@ public final class ContourPathNode: Node {
         let epsilon = inputJoinEpsilon.value ?? 1.0
         /*let points = */readAndBuildContour(device: device,
                                          commandBuffer: commandBuffer,
-                                         width: inTex.width,
-                                         height: inTex.height,
+                                         image: inputMaskImage,
                                          epsilon: epsilon)
 
         // Emit
@@ -182,7 +182,7 @@ public final class ContourPathNode: Node {
     // MARK: - Readback & Stitching
     private func readAndBuildContour(device: MTLDevice,
                                      commandBuffer: MTLCommandBuffer,
-                                     width: Int, height: Int,
+                                     image: FabricImage,
                                      epsilon: Float)
     {
         guard
@@ -200,8 +200,23 @@ public final class ContourPathNode: Node {
         let segPtr = segBuf.contents().bindMemory(to: simd_float4.self, capacity: segCount)
         var segments: [simd_float4] = []
         segments.reserveCapacity(segCount)
+        let storageSize = simd_float2(Float(image.texture.width), Float(image.texture.height))
+        let presentationSize = simd_float2(
+            Float(image.presentationSize.width),
+            Float(image.presentationSize.height)
+        )
+
+        func presentationPoint(fromStoredPoint point: simd_float2) -> simd_float2
+        {
+            image.canonicalTextureCoordinate(fromStoredTextureCoordinate: point / storageSize)
+                * presentationSize
+        }
+
         for i in 0..<segCount {
-            segments.append(segPtr[i])
+            let segment = segPtr[i]
+            let start = presentationPoint(fromStoredPoint: simd_float2(segment.x, segment.y))
+            let end = presentationPoint(fromStoredPoint: simd_float2(segment.z, segment.w))
+            segments.append(simd_float4(start.x, start.y, end.x, end.y))
         }
         
         self.outputContour.send( self.stitchSegmentsToPath(segments: segments) )

--- a/Fabric/Nodes/Image/Analysis/ContourPathNode.swift
+++ b/Fabric/Nodes/Image/Analysis/ContourPathNode.swift
@@ -201,10 +201,8 @@ public final class ContourPathNode: Node {
         var segments: [simd_float4] = []
         segments.reserveCapacity(segCount)
         let storageSize = simd_float2(Float(image.texture.width), Float(image.texture.height))
-        let presentationSize = simd_float2(
-            Float(image.presentationSize.width),
-            Float(image.presentationSize.height)
-        )
+        let presentationSize = simd_float2(Float(image.presentationSize.width),
+                                           Float(image.presentationSize.height))
 
         func presentationPoint(fromStoredPoint point: simd_float2) -> simd_float2
         {

--- a/Fabric/Nodes/Image/Analysis/FacePoseAnalysisNode.swift
+++ b/Fabric/Nodes/Image/Analysis/FacePoseAnalysisNode.swift
@@ -277,7 +277,7 @@ public class FacePoseAnalysisNode: Node
         
         let x = remap(Float(imagePoint.x), 0.0, Float(size.width), -1.0, 1.0)
         let y:Float
-        if flipped
+        if !flipped
         {
             y = remap(Float(imagePoint.y), Float(size.height), 0.0, -Float(aspect), Float(aspect))
         }

--- a/Fabric/Nodes/Image/Analysis/FacePoseAnalysisNode.swift
+++ b/Fabric/Nodes/Image/Analysis/FacePoseAnalysisNode.swift
@@ -272,10 +272,8 @@ public class FacePoseAnalysisNode: Node
         
         let imagePoint = VNImagePointForFaceLandmarkPoint( simd_float2(x:Float(point.x), y:Float(point.y)), boundingBox,  Int(size.width), Int(size.height))
 
-        return simd_float2(
-            remap(Float(imagePoint.x / size.width), 0.0, 1.0, -1.0, 1.0),
-            remap(Float(imagePoint.y / size.height), 0.0, 1.0, -Float(aspect), Float(aspect))
-        )
+        return simd_float2(remap(Float(imagePoint.x / size.width), 0.0, 1.0, -1.0, 1.0),
+                           remap(Float(imagePoint.y / size.height), 0.0, 1.0, -Float(aspect), Float(aspect)))
     }
         
     private func faceLandmarksForRequest(_ request: VNDetectFaceLandmarksRequest, from image: FabricImage) ->  VNFaceObservation?

--- a/Fabric/Nodes/Image/Analysis/FacePoseAnalysisNode.swift
+++ b/Fabric/Nodes/Image/Analysis/FacePoseAnalysisNode.swift
@@ -101,17 +101,13 @@ public class FacePoseAnalysisNode: Node
             
             
             if let inImage = self.inputImage.value,
-               let observation =  self.faceLandmarksForRequest(request, from: inImage.texture)
+               let observation = self.faceLandmarksForRequest(request, from: inImage)
             {
-                let inTex = inImage.texture
-                
-                let imageSize = CGSize(width: inTex.width, height: inTex.height)
-
                 if let faceContour = observation.landmarks?.faceContour
                 {
                     let points = faceContour.normalizedPoints.map {
                             
-                        return self.normalizedPointToUnits($0, imageSize: imageSize, boundingBox: observation.boundingBox, flipped:inImage.isFlipped)
+                        return self.normalizedPointToUnits($0, image: inImage, boundingBox: observation.boundingBox)
                     }
                     
                     self.outputFaceContour.send( ContiguousArray(points) )
@@ -121,7 +117,7 @@ public class FacePoseAnalysisNode: Node
                 {
                     let points = leftEye.normalizedPoints.map {
                             
-                        return self.normalizedPointToUnits($0, imageSize: imageSize, boundingBox: observation.boundingBox, flipped:inImage.isFlipped)
+                        return self.normalizedPointToUnits($0, image: inImage, boundingBox: observation.boundingBox)
                     }
                     
                     self.outputLeftEye.send( ContiguousArray(points) )
@@ -131,7 +127,7 @@ public class FacePoseAnalysisNode: Node
                 {
                     let points = rightEye.normalizedPoints.map {
                             
-                        return self.normalizedPointToUnits($0, imageSize: imageSize, boundingBox: observation.boundingBox, flipped:inImage.isFlipped)
+                        return self.normalizedPointToUnits($0, image: inImage, boundingBox: observation.boundingBox)
                     }
                     
                     self.outputRightEye.send( ContiguousArray(points) )
@@ -141,7 +137,7 @@ public class FacePoseAnalysisNode: Node
                 {
                     let points = leftPupil.normalizedPoints.map {
                             
-                        return self.normalizedPointToUnits($0, imageSize: imageSize, boundingBox: observation.boundingBox, flipped:inImage.isFlipped)
+                        return self.normalizedPointToUnits($0, image: inImage, boundingBox: observation.boundingBox)
                     }
                     
                     self.outputLeftPupil.send( ContiguousArray(points) )
@@ -151,7 +147,7 @@ public class FacePoseAnalysisNode: Node
                 {
                     let points = rightPupil.normalizedPoints.map {
                             
-                        return self.normalizedPointToUnits($0, imageSize: imageSize, boundingBox: observation.boundingBox, flipped:inImage.isFlipped)
+                        return self.normalizedPointToUnits($0, image: inImage, boundingBox: observation.boundingBox)
                     }
                     
                     self.outputRightPupil.send( ContiguousArray(points) )
@@ -161,7 +157,7 @@ public class FacePoseAnalysisNode: Node
                 {
                     let points = leftEyebrow.normalizedPoints.map {
                             
-                        return self.normalizedPointToUnits($0, imageSize: imageSize, boundingBox: observation.boundingBox, flipped:inImage.isFlipped)
+                        return self.normalizedPointToUnits($0, image: inImage, boundingBox: observation.boundingBox)
                     }
                     
                     self.outputLeftEyebrow.send( ContiguousArray(points) )
@@ -171,7 +167,7 @@ public class FacePoseAnalysisNode: Node
                 {
                     let points = rightEyebrow.normalizedPoints.map {
                             
-                        return self.normalizedPointToUnits($0, imageSize: imageSize, boundingBox: observation.boundingBox, flipped:inImage.isFlipped)
+                        return self.normalizedPointToUnits($0, image: inImage, boundingBox: observation.boundingBox)
                     }
                     
                     self.outputRightEyebrow.send( ContiguousArray(points) )
@@ -181,7 +177,7 @@ public class FacePoseAnalysisNode: Node
                 {
                     let points = nose.normalizedPoints.map {
                             
-                        return self.normalizedPointToUnits($0, imageSize: imageSize, boundingBox: observation.boundingBox, flipped:inImage.isFlipped)
+                        return self.normalizedPointToUnits($0, image: inImage, boundingBox: observation.boundingBox)
                     }
                     
                     self.outputNose.send( ContiguousArray(points) )
@@ -191,7 +187,7 @@ public class FacePoseAnalysisNode: Node
                 {
                     let points = noseCrest.normalizedPoints.map {
                             
-                        return self.normalizedPointToUnits($0, imageSize: imageSize, boundingBox: observation.boundingBox, flipped:inImage.isFlipped)
+                        return self.normalizedPointToUnits($0, image: inImage, boundingBox: observation.boundingBox)
                     }
                     
                     self.outputNoseCrest.send( ContiguousArray(points) )
@@ -201,7 +197,7 @@ public class FacePoseAnalysisNode: Node
                 {
                     let points = medianLine.normalizedPoints.map {
                             
-                        return self.normalizedPointToUnits($0, imageSize: imageSize, boundingBox: observation.boundingBox, flipped:inImage.isFlipped)
+                        return self.normalizedPointToUnits($0, image: inImage, boundingBox: observation.boundingBox)
                     }
                     
                     self.outputMedianLine.send( ContiguousArray(points) )
@@ -211,7 +207,7 @@ public class FacePoseAnalysisNode: Node
                 {
                     let points = innerLips.normalizedPoints.map {
                             
-                        return self.normalizedPointToUnits($0, imageSize: imageSize, boundingBox: observation.boundingBox, flipped:inImage.isFlipped)
+                        return self.normalizedPointToUnits($0, image: inImage, boundingBox: observation.boundingBox)
                     }
                     
                     self.outputInnerLips.send( ContiguousArray(points) )
@@ -221,7 +217,7 @@ public class FacePoseAnalysisNode: Node
                 {
                     let points = outerLips.normalizedPoints.map {
                             
-                        return self.normalizedPointToUnits($0, imageSize: imageSize, boundingBox: observation.boundingBox, flipped:inImage.isFlipped)
+                        return self.normalizedPointToUnits($0, image: inImage, boundingBox: observation.boundingBox)
                     }
                     
                     self.outputOuterLips.send( ContiguousArray(points) )
@@ -269,29 +265,22 @@ public class FacePoseAnalysisNode: Node
         }
     }
     
-    private func normalizedPointToUnits(_ point:CGPoint, imageSize size:CGSize, boundingBox:CGRect, flipped:Bool) -> simd_float2
+    private func normalizedPointToUnits(_ point: CGPoint, image: FabricImage, boundingBox: CGRect) -> simd_float2
     {
+        let size = image.presentationSize
         let aspect = size.height / size.width
         
         let imagePoint = VNImagePointForFaceLandmarkPoint( simd_float2(x:Float(point.x), y:Float(point.y)), boundingBox,  Int(size.width), Int(size.height))
-        
-        let x = remap(Float(imagePoint.x), 0.0, Float(size.width), -1.0, 1.0)
-        let y:Float
-        if !flipped
-        {
-            y = remap(Float(imagePoint.y), Float(size.height), 0.0, -Float(aspect), Float(aspect))
-        }
-        else
-        {
-            y = remap(Float(imagePoint.y), 0.0, Float(size.height), -Float(aspect), Float(aspect))
-        }
 
-        return simd_float2(x: x, y: y)
+        return simd_float2(
+            remap(Float(imagePoint.x / size.width), 0.0, 1.0, -1.0, 1.0),
+            remap(Float(imagePoint.y / size.height), 0.0, 1.0, -Float(aspect), Float(aspect))
+        )
     }
         
-    private func faceLandmarksForRequest(_ request: VNDetectFaceLandmarksRequest, from texture:MTLTexture) ->  VNFaceObservation?
+    private func faceLandmarksForRequest(_ request: VNDetectFaceLandmarksRequest, from image: FabricImage) ->  VNFaceObservation?
     {
-        if let inputImage = CIImage(mtlTexture: texture)
+        if let inputImage = image.presentationCIImage
         {
 //            for computeDevice in MLComputeDevice.allComputeDevices
 //            {

--- a/Fabric/Nodes/Image/Analysis/HandPoseAnalysisNode.swift
+++ b/Fabric/Nodes/Image/Analysis/HandPoseAnalysisNode.swift
@@ -139,10 +139,8 @@ public class HandPoseAnalysisNode: Node
 
     private func unitPoint(from recognizedPoint: VNRecognizedPoint, aspect: Float) -> simd_float2
     {
-        return simd_float2(
-            remap(Float(recognizedPoint.x), 0.0, 1.0, -1.0, 1.0),
-            remap(Float(recognizedPoint.y), 0.0, 1.0, -aspect, aspect)
-        )
+        return simd_float2(remap(Float(recognizedPoint.x), 0.0, 1.0, -1.0, 1.0),
+                           remap(Float(recognizedPoint.y), 0.0, 1.0, -aspect, aspect))
     }
         
     private func handPointsForRequest(_ request: VNDetectHumanHandPoseRequest, from image: FabricImage) ->  [VNRecognizedPointKey : VNRecognizedPoint]?

--- a/Fabric/Nodes/Image/Analysis/HandPoseAnalysisNode.swift
+++ b/Fabric/Nodes/Image/Analysis/HandPoseAnalysisNode.swift
@@ -81,32 +81,31 @@ public class HandPoseAnalysisNode: Node
             request.maximumHandCount = 1
             
             if let inImage = self.inputImage.value,
-               let allPoints =  self.handPointsForRequest(request, from: inImage.texture)
+               let allPoints = self.handPointsForRequest(request, from: inImage)
             {
-                let inTex = inImage.texture
-                let aspect = Float(inTex.height)/Float(inTex.width)
+                let aspect = Float(inImage.presentationSize.height / inImage.presentationSize.width)
 
-                if let thumbPoints = self.unitPoints(for: Self.thumbJoints, from: allPoints, aspect: aspect, flipped:inImage.isFlipped )
+                if let thumbPoints = self.unitPoints(for: Self.thumbJoints, from: allPoints, aspect: aspect)
                 {
                     self.outputThumb.send(thumbPoints)
                 }
 
-                if let indexPoints = self.unitPoints(for: Self.indexJoints, from: allPoints, aspect: aspect, flipped:inImage.isFlipped)
+                if let indexPoints = self.unitPoints(for: Self.indexJoints, from: allPoints, aspect: aspect)
                 {
                     self.outputIndex.send(indexPoints)
                 }
 
-                if let middlePoints = self.unitPoints(for: Self.middleJoints, from: allPoints, aspect: aspect, flipped:inImage.isFlipped)
+                if let middlePoints = self.unitPoints(for: Self.middleJoints, from: allPoints, aspect: aspect)
                 {
                     self.outputMiddle.send(middlePoints)
                 }
 
-                if let ringPoints = self.unitPoints(for: Self.ringJoints, from: allPoints, aspect: aspect, flipped:inImage.isFlipped)
+                if let ringPoints = self.unitPoints(for: Self.ringJoints, from: allPoints, aspect: aspect)
                 {
                     self.outputRing.send(ringPoints)
                 }
 
-                if let littlePoints = self.unitPoints(for: Self.littleJoints, from: allPoints, aspect: aspect, flipped:inImage.isFlipped)
+                if let littlePoints = self.unitPoints(for: Self.littleJoints, from: allPoints, aspect: aspect)
                 {
                     self.outputLittle.send(littlePoints)
                 }
@@ -121,8 +120,7 @@ public class HandPoseAnalysisNode: Node
 
     private func unitPoints(for joints: [VNHumanHandPoseObservation.JointName],
                             from recognizedPoints: [VNRecognizedPointKey: VNRecognizedPoint],
-                            aspect: Float,
-                            flipped:Bool
+                            aspect: Float
     ) -> ContiguousArray<simd_float2>?
     {
         var points = ContiguousArray<simd_float2>()
@@ -131,7 +129,7 @@ public class HandPoseAnalysisNode: Node
         for joint in joints
         {
             guard let recognizedPoint = recognizedPoints[joint.rawValue] else { return nil }
-            points.append(self.unitPoint(from: recognizedPoint, aspect: aspect, flipped: !flipped))
+            points.append(self.unitPoint(from: recognizedPoint, aspect: aspect))
         }
 
         return points
@@ -139,25 +137,17 @@ public class HandPoseAnalysisNode: Node
     
     
 
-    private func unitPoint(from recognizedPoint: VNRecognizedPoint, aspect: Float, flipped:Bool = false) -> simd_float2
+    private func unitPoint(from recognizedPoint: VNRecognizedPoint, aspect: Float) -> simd_float2
     {
-        let x = remap(Float(recognizedPoint.x), 0.0, 1.0, -1.0, 1.0)
-        let y:Float
-        if flipped
-        {
-            y = remap(Float(recognizedPoint.y), 1.0, 0.0, -aspect, aspect)
-
-        }
-        else
-        {
-            y = remap(Float(recognizedPoint.y), 0.0, 1.0, -aspect, aspect)
-        }
-        return simd_float2(x, y)
+        return simd_float2(
+            remap(Float(recognizedPoint.x), 0.0, 1.0, -1.0, 1.0),
+            remap(Float(recognizedPoint.y), 0.0, 1.0, -aspect, aspect)
+        )
     }
         
-    private func handPointsForRequest(_ request: VNDetectHumanHandPoseRequest, from texture:MTLTexture) ->  [VNRecognizedPointKey : VNRecognizedPoint]?
+    private func handPointsForRequest(_ request: VNDetectHumanHandPoseRequest, from image: FabricImage) ->  [VNRecognizedPointKey : VNRecognizedPoint]?
     {
-        if let inputImage = CIImage(mtlTexture: texture)
+        if let inputImage = image.presentationCIImage
         {
 //            for computeDevice in MLComputeDevice.allComputeDevices
 //            {

--- a/Fabric/Nodes/Image/Analysis/HandPoseAnalysisNode.swift
+++ b/Fabric/Nodes/Image/Analysis/HandPoseAnalysisNode.swift
@@ -131,7 +131,7 @@ public class HandPoseAnalysisNode: Node
         for joint in joints
         {
             guard let recognizedPoint = recognizedPoints[joint.rawValue] else { return nil }
-            points.append(self.unitPoint(from: recognizedPoint, aspect: aspect, flipped: flipped))
+            points.append(self.unitPoint(from: recognizedPoint, aspect: aspect, flipped: !flipped))
         }
 
         return points

--- a/Fabric/Nodes/Image/Analysis/LucasKanadeOpticalFlowNode.swift
+++ b/Fabric/Nodes/Image/Analysis/LucasKanadeOpticalFlowNode.swift
@@ -133,11 +133,13 @@ public class LucasKanadeOpticalFlowNode: Node
                 || self.inputTemporalSmoothing.valueDidChange
         else { return }
 
-        guard let inTex = self.inputImage.value?.texture else
+        guard let inputImage = self.inputImage.value else
         {
             outputFlow.send(nil)
             return
         }
+
+        let inTex = inputImage.texture
 
         guard
             let preProc = preprocessPipeline,
@@ -333,6 +335,7 @@ public class LucasKanadeOpticalFlowNode: Node
             outputImage = temporallySmoothedFlow
         }
 
+        outputImage.textureTransform = inputImage.textureTransform
         outputFlow.send(outputImage)
     }
 

--- a/Fabric/Nodes/Image/Analysis/MetalFXSpatialUpsample2xNode.swift
+++ b/Fabric/Nodes/Image/Analysis/MetalFXSpatialUpsample2xNode.swift
@@ -70,7 +70,7 @@ final class MetalFXSpatialUpsample2xNode: BaseImageNode
             height: inputHeight * 2,
             format: inputFormat
         )
-
+        outImage.textureTransform = inImage.textureTransform
         // Validate usage (best-effort). MetalFX requires the texture usage be a superset of these.
         // (Some upstream nodes may create textures with too-restrictive usage flags.)
         if !inTex.usage.contains(scaler.colorTextureUsage) {

--- a/Fabric/Nodes/Image/Analysis/VLM/LocalVLMNode.swift
+++ b/Fabric/Nodes/Image/Analysis/VLM/LocalVLMNode.swift
@@ -218,7 +218,7 @@ struct LocalVLMNodeSettingsView: View {
                 self.vlmEvaluator.prompt = prompt
             }
 
-            let image = self.inputTexturePort.value.map { CIImage(mtlTexture: $0.texture) }.flatMap { $0 }
+            let image = self.inputTexturePort.value?.presentationCIImage
             self.vlmEvaluator.generate(image: image)
 
             if self.inputGenerate.connections.isEmpty {

--- a/Fabric/Nodes/Image/Blur/DepthOfFieldNode.swift
+++ b/Fabric/Nodes/Image/Blur/DepthOfFieldNode.swift
@@ -65,14 +65,14 @@ public final class DepthOfFieldNode: Node
                                  commandBuffer: MTLCommandBuffer)
     throws
     {
-        guard
-              let colorTexture = self.inputImage.value?.texture,
-              let depthTexture = self.inputDepthImage.value?.texture
+        guard let colorImage = self.inputImage.value,
+              let depthImage = self.inputDepthImage.value
         else
         {
             self.outputImage.send(nil)
             return
         }
+        let colorTexture = colorImage.texture
 
         if renderer.currentCamera == nil
         {
@@ -80,7 +80,7 @@ public final class DepthOfFieldNode: Node
         }
 
         self.postProcessor.colorTexture = colorTexture
-        self.postProcessor.depthTexture = depthTexture
+        self.postProcessor.depthTexture = depthImage.texture
         self.postProcessor.sceneCamera = renderer.currentCamera ?? self.fallbackCamera
         self.postProcessor.focusDistance = self.inputFocusDistance.value ?? 4.0
         self.postProcessor.focusRange = self.inputFocusRange.value ?? 1.5
@@ -99,7 +99,7 @@ public final class DepthOfFieldNode: Node
         let outputImage = try renderer.newImage(withWidth: processedTexture.width,
                                                 height: processedTexture.height,
                                                 format: processedTexture.pixelFormat)
-
+        outputImage.textureTransform = colorImage.textureTransform
         try self.copyTexture(processedTexture, to: outputImage.texture, using: commandBuffer)
         self.outputImage.send(outputImage)
     }

--- a/Fabric/Nodes/Image/Blur/GaussianBlurChannelsNode.swift
+++ b/Fabric/Nodes/Image/Blur/GaussianBlurChannelsNode.swift
@@ -144,13 +144,9 @@ public final class GaussianBlurChannelsNode: BaseMultiPassBlurEffectTwoChannelNo
             let passBuffer = self.passUniformsBuffer(forStepIndex: index)
             passBuffer.update(data: [passUniforms])
             self.postMaterial.set(passBuffer, index: FragmentBufferIndex.Custom0)
-            self.setTextureTransforms(
-                [
-                    index == 0 ? inputImage.textureTransform : matrix_identity_float4x4,
-                    originalImage.textureTransform,
-                ],
-                forStepIndex: index
-            )
+            self.setTextureTransforms([index == 0 ? inputImage.textureTransform : matrix_identity_float4x4,
+                                       originalImage.textureTransform],
+                                      forStepIndex: index)
 
             self.postProcessor.mesh.preDraw = { renderEncoder in
                 renderEncoder.setFragmentTexture(currentTexture, index: FragmentTextureIndex.Custom0.rawValue)

--- a/Fabric/Nodes/Image/Blur/GaussianBlurChannelsNode.swift
+++ b/Fabric/Nodes/Image/Blur/GaussianBlurChannelsNode.swift
@@ -59,11 +59,13 @@ public final class GaussianBlurChannelsNode: BaseMultiPassBlurEffectTwoChannelNo
     {
         let inputs = self.imageInputPorts()
         guard inputs.count >= 1,
-              let inputTexture = inputs[0].value?.texture else {
+              let inputImage = inputs[0].value else {
             self.outputTexturePort.send(nil)
             return
         }
-        let originalTexture = inputs.indices.contains(1) ? (inputs[1].value?.texture ?? inputTexture) : inputTexture
+        let originalImage = inputs.indices.contains(1) ? (inputs[1].value ?? inputImage) : inputImage
+        let outputWidth = Int(inputImage.presentationSize.width.rounded())
+        let outputHeight = Int(inputImage.presentationSize.height.rounded())
 
         let redAmount = self.floatParameterValue(named: "Red Amount")
         let greenAmount = self.floatParameterValue(named: "Green Amount")
@@ -72,8 +74,8 @@ public final class GaussianBlurChannelsNode: BaseMultiPassBlurEffectTwoChannelNo
 
         var steps: [MultiPassStep] = []
         if amount <= Self.lowAmountThreshold {
-            steps.append(MultiPassStep(width: inputTexture.width, height: inputTexture.height, amountScale: 0.0, vector: simd_float2(1.0, 0.0)))
-            steps.append(MultiPassStep(width: inputTexture.width, height: inputTexture.height, amountScale: 0.0, vector: simd_float2(0.0, 1.0)))
+            steps.append(MultiPassStep(width: outputWidth, height: outputHeight, amountScale: 0.0, vector: simd_float2(1.0, 0.0)))
+            steps.append(MultiPassStep(width: outputWidth, height: outputHeight, amountScale: 0.0, vector: simd_float2(0.0, 1.0)))
         } else {
             let stageRatios: [(ratio: Float, multiplier: Float)] = [
                 (0.1, 0.111),
@@ -84,8 +86,8 @@ public final class GaussianBlurChannelsNode: BaseMultiPassBlurEffectTwoChannelNo
             ]
 
             for stage in stageRatios {
-                let stageSize = self.scaledPassSize(baseWidth: inputTexture.width,
-                                                    baseHeight: inputTexture.height,
+                let stageSize = self.scaledPassSize(baseWidth: outputWidth,
+                                                    baseHeight: outputHeight,
                                                     amount: amount,
                                                     passRatio: stage.ratio)
 
@@ -99,14 +101,14 @@ public final class GaussianBlurChannelsNode: BaseMultiPassBlurEffectTwoChannelNo
                                            vector: simd_float2(0.0, 1.0)))
             }
 
-            steps.append(MultiPassStep(width: inputTexture.width, height: inputTexture.height, amountScale: 0.333, vector: simd_float2(1.0, 0.0)))
-            steps.append(MultiPassStep(width: inputTexture.width, height: inputTexture.height, amountScale: 0.333, vector: simd_float2(0.0, 1.0)))
+            steps.append(MultiPassStep(width: outputWidth, height: outputHeight, amountScale: 0.333, vector: simd_float2(1.0, 0.0)))
+            steps.append(MultiPassStep(width: outputWidth, height: outputHeight, amountScale: 0.333, vector: simd_float2(0.0, 1.0)))
         }
 
         let outputImage = self.runChannelPassChain(renderer: renderer,
                                                    commandBuffer: commandBuffer,
-                                                   inputTexture: inputTexture,
-                                                   originalTexture: originalTexture,
+                                                   inputImage: inputImage,
+                                                   originalImage: originalImage,
                                                    steps: steps)
 
         if let outputImage {
@@ -118,14 +120,14 @@ public final class GaussianBlurChannelsNode: BaseMultiPassBlurEffectTwoChannelNo
 
     private func runChannelPassChain(renderer: GraphRenderer,
                                      commandBuffer: MTLCommandBuffer,
-                                     inputTexture: MTLTexture,
-                                     originalTexture: MTLTexture,
+                                     inputImage: FabricImage,
+                                     originalImage: FabricImage,
                                      steps: [MultiPassStep]) -> FabricImage? {
         guard !steps.isEmpty else {
             return nil
         }
 
-        var currentTexture: MTLTexture = inputTexture
+        var currentTexture = inputImage.texture
         var currentImage: FabricImage? = nil
 
         for (index, step) in steps.enumerated() {
@@ -142,10 +144,17 @@ public final class GaussianBlurChannelsNode: BaseMultiPassBlurEffectTwoChannelNo
             let passBuffer = self.passUniformsBuffer(forStepIndex: index)
             passBuffer.update(data: [passUniforms])
             self.postMaterial.set(passBuffer, index: FragmentBufferIndex.Custom0)
+            self.setTextureTransforms(
+                [
+                    index == 0 ? inputImage.textureTransform : matrix_identity_float4x4,
+                    originalImage.textureTransform,
+                ],
+                forStepIndex: index
+            )
 
             self.postProcessor.mesh.preDraw = { renderEncoder in
                 renderEncoder.setFragmentTexture(currentTexture, index: FragmentTextureIndex.Custom0.rawValue)
-                renderEncoder.setFragmentTexture(originalTexture, index: FragmentTextureIndex.Custom1.rawValue)
+                renderEncoder.setFragmentTexture(originalImage.texture, index: FragmentTextureIndex.Custom1.rawValue)
             }
 
             self.postProcessor.resize(size: (width: Float(step.width), height: Float(step.height)), scaleFactor: 1)

--- a/Fabric/Nodes/Image/Blur/GaussianBlurMaskNode.swift
+++ b/Fabric/Nodes/Image/Blur/GaussianBlurMaskNode.swift
@@ -48,18 +48,21 @@ public final class GaussianBlurMaskNode: BaseMultiPassBlurEffectTwoChannelNode {
                                  commandBuffer: MTLCommandBuffer)
     throws
     {
-        guard let (inputTexture, inputMask) = self.validatedTwoInputTextures() else {
+        guard let (inputImage, inputMaskImage) = self.validatedTwoInputImages() else {
             self.outputTexturePort.send(nil)
             return
         }
+
+        let outputWidth = Int(inputImage.presentationSize.width.rounded())
+        let outputHeight = Int(inputImage.presentationSize.height.rounded())
 
         let amount = self.floatParameterValue(named: "Amount")
 
         var steps: [MultiPassStep] = []
 
         if amount <= Self.lowAmountThreshold {
-            steps.append(MultiPassStep(width: inputTexture.width, height: inputTexture.height, amountScale: 1.0, vector: simd_float2(1.0, 0.0)))
-            steps.append(MultiPassStep(width: inputTexture.width, height: inputTexture.height, amountScale: 1.0, vector: simd_float2(0.0, 1.0)))
+            steps.append(MultiPassStep(width: outputWidth, height: outputHeight, amountScale: 1.0, vector: simd_float2(1.0, 0.0)))
+            steps.append(MultiPassStep(width: outputWidth, height: outputHeight, amountScale: 1.0, vector: simd_float2(0.0, 1.0)))
         } else {
             let stageRatios: [(ratio: Float, multiplier: Float)] = [
                 (0.2, 1.0),
@@ -69,8 +72,8 @@ public final class GaussianBlurMaskNode: BaseMultiPassBlurEffectTwoChannelNode {
             ]
 
             for stage in stageRatios {
-                let stageSize = self.scaledPassSize(baseWidth: inputTexture.width,
-                                                    baseHeight: inputTexture.height,
+                let stageSize = self.scaledPassSize(baseWidth: outputWidth,
+                                                    baseHeight: outputHeight,
                                                     amount: amount,
                                                     passRatio: stage.ratio)
 
@@ -85,15 +88,15 @@ public final class GaussianBlurMaskNode: BaseMultiPassBlurEffectTwoChannelNode {
                                            vector: simd_float2(0.0, 1.0)))
             }
 
-            steps.append(MultiPassStep(width: inputTexture.width, height: inputTexture.height, amountScale: 1.0, vector: simd_float2(1.0, 0.0)))
-            steps.append(MultiPassStep(width: inputTexture.width, height: inputTexture.height, amountScale: 1.0, vector: simd_float2(0.0, 1.0)))
+            steps.append(MultiPassStep(width: outputWidth, height: outputHeight, amountScale: 1.0, vector: simd_float2(1.0, 0.0)))
+            steps.append(MultiPassStep(width: outputWidth, height: outputHeight, amountScale: 1.0, vector: simd_float2(0.0, 1.0)))
         }
 
         if let outputImage = self.runPassChain(renderer: renderer,
                                                executionInfo: executionInfo,
                                                commandBuffer: commandBuffer,
-                                               inputATexture: inputTexture,
-                                               inputBTexture: inputMask,
+                                               inputAImage: inputImage,
+                                               inputBImage: inputMaskImage,
                                                steps: steps,
                                                prepareStep: { [weak self] stepIndex, step in
             guard let self else { return }

--- a/Fabric/Nodes/Image/Blur/GaussianBlurNode.swift
+++ b/Fabric/Nodes/Image/Blur/GaussianBlurNode.swift
@@ -48,10 +48,13 @@ public final class GaussianBlurNode: BaseMultiPassBlurEffectNode {
                                  commandBuffer: MTLCommandBuffer)
     throws
     {
-        guard let inputTexture = self.validatedSingleInputTexture() else {
+        guard let inputImage = self.validatedSingleInputImage() else {
             self.outputTexturePort.send(nil)
             return
         }
+
+        let outputWidth = Int(inputImage.presentationSize.width.rounded())
+        let outputHeight = Int(inputImage.presentationSize.height.rounded())
 
         let amount = self.floatParameterValue(named: "Amount")
 
@@ -78,8 +81,8 @@ public final class GaussianBlurNode: BaseMultiPassBlurEffectNode {
 
             for stage in stageRatios
             {
-                let stageSize = self.scaledPassSize(baseWidth: inputTexture.width,
-                                                    baseHeight: inputTexture.height,
+                let stageSize = self.scaledPassSize(baseWidth: outputWidth,
+                                                    baseHeight: outputHeight,
                                                     amount: amount,
                                                     passRatio: stage.ratio)
 
@@ -94,14 +97,14 @@ public final class GaussianBlurNode: BaseMultiPassBlurEffectNode {
                                            vector: simd_float2(0.0, 1.0)))
             }
 
-        steps.append(MultiPassStep(width: inputTexture.width, height: inputTexture.height, amountScale: 0.333, vector: simd_float2(1.0, 0.0)))
-        steps.append(MultiPassStep(width: inputTexture.width, height: inputTexture.height, amountScale: 0.333, vector: simd_float2(0.0, 1.0)))
+        steps.append(MultiPassStep(width: outputWidth, height: outputHeight, amountScale: 0.333, vector: simd_float2(1.0, 0.0)))
+        steps.append(MultiPassStep(width: outputWidth, height: outputHeight, amountScale: 0.333, vector: simd_float2(0.0, 1.0)))
 //        }
         
         let outputImage = self.runPassChain(renderer: renderer,
                                             executionInfo: executionInfo,
                                             commandBuffer: commandBuffer,
-                                            inputTexture: inputTexture,
+                                            inputImage: inputImage,
                                             steps: steps,
                                             prepareStep: { [weak self] stepIndex, step in
             guard let self else { return }

--- a/Fabric/Nodes/Image/Blur/MotionBlurNode.swift
+++ b/Fabric/Nodes/Image/Blur/MotionBlurNode.swift
@@ -46,17 +46,20 @@ public final class MotionBlurNode: BaseMultiPassBlurEffectNode {
     throws
     {
 
-        guard let inputTexture = self.validatedSingleInputTexture() else {
+        guard let inputImage = self.validatedSingleInputImage() else {
             self.outputTexturePort.send(nil)
             return
         }
+
+        let outputWidth = Int(inputImage.presentationSize.width.rounded())
+        let outputHeight = Int(inputImage.presentationSize.height.rounded())
 
         let amount = self.floatParameterValue(named: "Amount")
 
         var steps: [MultiPassStep] = []
 
         if amount <= Self.lowAmountThreshold {
-            steps.append(MultiPassStep(width: inputTexture.width, height: inputTexture.height, amountScale: 1.0))
+            steps.append(MultiPassStep(width: outputWidth, height: outputHeight, amountScale: 1.0))
         } else {
             let stageRatios: [(ratio: Float, multiplier: Float)] = [
                 
@@ -67,8 +70,8 @@ public final class MotionBlurNode: BaseMultiPassBlurEffectNode {
             ]
 
             for stage in stageRatios {
-                let stageSize = self.scaledPassSize(baseWidth: inputTexture.width,
-                                                    baseHeight: inputTexture.height,
+                let stageSize = self.scaledPassSize(baseWidth: outputWidth,
+                                                    baseHeight: outputHeight,
                                                     amount: amount,
                                                     passRatio: stage.ratio)
 
@@ -77,13 +80,13 @@ public final class MotionBlurNode: BaseMultiPassBlurEffectNode {
                                            amountScale: stage.multiplier))
             }
 
-            steps.append(MultiPassStep(width: inputTexture.width, height: inputTexture.height, amountScale: 1.0))
+            steps.append(MultiPassStep(width: outputWidth, height: outputHeight, amountScale: 1.0))
         }
 
         if let outputImage = self.runPassChain(renderer: renderer,
                                                executionInfo: executionInfo,
                                                commandBuffer: commandBuffer,
-                                               inputTexture: inputTexture,
+                                               inputImage: inputImage,
                                                steps: steps,
                                                prepareStep: { [weak self] stepIndex, step in
             guard let self else { return }

--- a/Fabric/Nodes/Image/Blur/PostProcessMotionBlurNode.swift
+++ b/Fabric/Nodes/Image/Blur/PostProcessMotionBlurNode.swift
@@ -55,17 +55,17 @@ public final class PostProcessMotionBlurNode: Node
                                  commandBuffer: MTLCommandBuffer)
     throws
     {
-        guard
-              let colorTexture = self.inputImage.value?.texture,
-              let velocityTexture = self.inputVelocityImage.value?.texture
+        guard let colorImage = self.inputImage.value,
+              let velocityImage = self.inputVelocityImage.value
         else
         {
             self.outputImage.send(nil)
             return
         }
+        let colorTexture = colorImage.texture
 
         self.postProcessor.colorTexture = colorTexture
-        self.postProcessor.velocityTexture = velocityTexture
+        self.postProcessor.velocityTexture = velocityImage.texture
         self.postProcessor.depthTexture = self.inputDepthImage.value?.texture
         self.postProcessor.motionBlurMaterial.shutterAngle = self.inputShutterAngle.value ?? 180.0
         self.postProcessor.motionBlurMaterial.samples = Int32(self.inputSamples.value ?? 16)
@@ -82,7 +82,7 @@ public final class PostProcessMotionBlurNode: Node
         let outputImage = try renderer.newImage(withWidth: processedTexture.width,
                                                 height: processedTexture.height,
                                                 format: processedTexture.pixelFormat)
-
+        outputImage.textureTransform = colorImage.textureTransform
         try self.copyTexture(processedTexture, to: outputImage.texture, using: commandBuffer)
         self.outputImage.send(outputImage)
     }

--- a/Fabric/Nodes/Image/Blur/ZoomBlurNode.swift
+++ b/Fabric/Nodes/Image/Blur/ZoomBlurNode.swift
@@ -46,10 +46,13 @@ public final class ZoomBlurNode: BaseMultiPassBlurEffectNode {
     throws
     {
 
-        guard let inputTexture = self.validatedSingleInputTexture() else {
+        guard let inputImage = self.validatedSingleInputImage() else {
             self.outputTexturePort.send(nil)
             return
         }
+
+        let outputWidth = Int(inputImage.presentationSize.width.rounded())
+        let outputHeight = Int(inputImage.presentationSize.height.rounded())
 
         let amount = self.floatParameterValue(named: "Amount")
 
@@ -91,8 +94,8 @@ public final class ZoomBlurNode: BaseMultiPassBlurEffectNode {
             ]
 
             for stage in stageRatios {
-                let stageSize = self.scaledPassSize(baseWidth: inputTexture.width,
-                                                    baseHeight: inputTexture.height,
+                let stageSize = self.scaledPassSize(baseWidth: outputWidth,
+                                                    baseHeight: outputHeight,
                                                     amount: amount,
                                                     passRatio: stage.ratio)
 
@@ -101,13 +104,13 @@ public final class ZoomBlurNode: BaseMultiPassBlurEffectNode {
                                            amountScale: stage.multiplier))
             }
 
-        steps.append(MultiPassStep(width: inputTexture.width, height: inputTexture.height, amountScale: 1.0))
+        steps.append(MultiPassStep(width: outputWidth, height: outputHeight, amountScale: 1.0))
 //        }
 
         if let outputImage = self.runPassChain(renderer: renderer,
                                                executionInfo: executionInfo,
                                                commandBuffer: commandBuffer,
-                                               inputTexture: inputTexture,
+                                               inputImage: inputImage,
                                                steps: steps,
                                                prepareStep: { [weak self] stepIndex, step in
             guard let self else { return }

--- a/Fabric/Nodes/Image/ColorAdjust/LUTProcessorNode.swift
+++ b/Fabric/Nodes/Image/ColorAdjust/LUTProcessorNode.swift
@@ -75,27 +75,16 @@ public class LUTProcessorNode : BaseImageNode
             try self.loadLUTFromInputValue()
         }
 
-        if self.imageInputPorts().first?.valueDidChange == true
-        {
-            if let inImage = self.inputImage(at: 0),
-               let inTex2 = self.texture
-            {
-                let inTex = inImage.texture
-                let outImage = try renderer.newImage(withWidth: inTex.width, height: inTex.height)
+        guard let lutTexture = self.texture else {
+            self.outputTexturePort.send(nil)
+            return
+        }
 
-                self.postMaterial.set(inTex, index: FragmentTextureIndex.Custom0)
-                self.postMaterial.set(inTex2, index: FragmentTextureIndex.Custom1)
-                
-                self.postProcessor.resize(size: (width: Float(inTex.width), height: Float(inTex.height)), scaleFactor: 1)
-                
-                let renderPassDesc = MTLRenderPassDescriptor()
-                renderPassDesc.colorAttachments[0].texture = outImage.texture
-                
-                self.postProcessor.draw(renderPassDescriptor:renderPassDesc , commandBuffer: commandBuffer)
-
-                self.outputTexturePort.send( outImage )
-            }
-        }        
+        self.postMaterial.set(lutTexture, index: FragmentTextureIndex.Custom1)
+        try super.execute(renderer: renderer,
+                          executionInfo: executionInfo,
+                          renderPassDescriptor: renderPassDescriptor,
+                          commandBuffer: commandBuffer)
      }
     
     private func loadLUTFromInputValue() throws

--- a/Fabric/Nodes/Image/Distort/KeypointDistortNode.swift
+++ b/Fabric/Nodes/Image/Distort/KeypointDistortNode.swift
@@ -104,39 +104,15 @@ public class KeypointDistortNode: BaseImageNode {
             self.disKeyPointStructBuffer.update(data: inputDisplacedKeyPoints)
         }
         
-        if self.imageInputPorts().first?.valueDidChange == true
-        {
-            if let inImage = self.inputImage(at: 0)
-            {
-                let inTex = inImage.texture
-                
-                let outImage = try renderer.newImage(withWidth: inTex.width, height: inTex.height)
+        let minimumCount = min(self.refKeyPointStructBuffer.count, self.disKeyPointStructBuffer.count)
+        self.countBuffer.update(data: [UInt32(minimumCount)])
+        self.postMaterial.set(self.refKeyPointStructBuffer, index: FragmentBufferIndex.Custom0)
+        self.postMaterial.set(self.disKeyPointStructBuffer, index: FragmentBufferIndex.Custom1)
+        self.postMaterial.set(self.countBuffer, index: FragmentBufferIndex.Custom2)
 
-                let minCount = min (self.refKeyPointStructBuffer.count, self.disKeyPointStructBuffer.count)
-                self.countBuffer.update(data: [UInt32(minCount)] )
-                
-                self.postMaterial.set(self.refKeyPointStructBuffer, index: FragmentBufferIndex.Custom0)
-                self.postMaterial.set(self.disKeyPointStructBuffer, index: FragmentBufferIndex.Custom1)
-                self.postMaterial.set(self.countBuffer, index: FragmentBufferIndex.Custom2)
-                
-                self.postMaterial.set(inTex, index: FragmentTextureIndex.Custom0)
-
-                    
-                self.postProcessor.resize(size: (width: Float(inTex.width), height: Float(inTex.height)), scaleFactor: 1)
-                
-                let renderPassDesc = MTLRenderPassDescriptor()
-                renderPassDesc.colorAttachments[0].texture = outImage.texture
-                
-                self.postProcessor.draw(renderPassDescriptor:renderPassDesc , commandBuffer: commandBuffer)
-
-                self.outputTexturePort.send( outImage )
-            }
-            else
-            {
-                self.outputTexturePort.send( nil )
-            }
-        }
-
-        
+        try super.execute(renderer: renderer,
+                          executionInfo: executionInfo,
+                          renderPassDescriptor: renderPassDescriptor,
+                          commandBuffer: commandBuffer)
     }
 }

--- a/Fabric/Nodes/Image/ImageDimensions.swift
+++ b/Fabric/Nodes/Image/ImageDimensions.swift
@@ -104,8 +104,8 @@ public final class ImageDimensions: Node
             return
         }
 
-        let width = Float(image.texture.width)
-        let height = Float(image.texture.height)
+        let width = Float(image.presentationSize.width)
+        let height = Float(image.presentationSize.height)
 
         self.outputWidth.send(width)
         self.outputHeight.send(height)

--- a/Fabric/Nodes/Image/ImageResampleNode.swift
+++ b/Fabric/Nodes/Image/ImageResampleNode.swift
@@ -185,18 +185,12 @@ public final class ImageResampleNode: Node
         }
 
         let sourceTexture = sourceImage.texture
-        let presentationWidth = resolvedDimension(
-            inputWidth.value,
-            fallback: Int(sourceImage.presentationSize.width.rounded())
-        )
-        let presentationHeight = resolvedDimension(
-            inputHeight.value,
-            fallback: Int(sourceImage.presentationSize.height.rounded())
-        )
-        let storageSize = simd_abs(
-            sourceImage.textureTransform.inverse
-                * simd_float4(Float(presentationWidth), Float(presentationHeight), 0, 0)
-        )
+        let presentationWidth = resolvedDimension(inputWidth.value,
+                                                  fallback: Int(sourceImage.presentationSize.width.rounded()))
+        let presentationHeight = resolvedDimension(inputHeight.value,
+                                                   fallback: Int(sourceImage.presentationSize.height.rounded()))
+        let storageSize = simd_abs(sourceImage.textureTransform.inverse
+            * simd_float4(Float(presentationWidth), Float(presentationHeight), 0, 0))
         let outputWidth = max(1, Int(storageSize.x.rounded()))
         let outputHeight = max(1, Int(storageSize.y.rounded()))
         let method = ResamplingMethod(rawValue: inputMethod.value ?? "") ?? .bilinear

--- a/Fabric/Nodes/Image/ImageResampleNode.swift
+++ b/Fabric/Nodes/Image/ImageResampleNode.swift
@@ -185,8 +185,20 @@ public final class ImageResampleNode: Node
         }
 
         let sourceTexture = sourceImage.texture
-        let outputWidth = resolvedDimension(inputWidth.value, fallback: sourceTexture.width)
-        let outputHeight = resolvedDimension(inputHeight.value, fallback: sourceTexture.height)
+        let presentationWidth = resolvedDimension(
+            inputWidth.value,
+            fallback: Int(sourceImage.presentationSize.width.rounded())
+        )
+        let presentationHeight = resolvedDimension(
+            inputHeight.value,
+            fallback: Int(sourceImage.presentationSize.height.rounded())
+        )
+        let storageSize = simd_abs(
+            sourceImage.textureTransform.inverse
+                * simd_float4(Float(presentationWidth), Float(presentationHeight), 0, 0)
+        )
+        let outputWidth = max(1, Int(storageSize.x.rounded()))
+        let outputHeight = max(1, Int(storageSize.y.rounded()))
         let method = ResamplingMethod(rawValue: inputMethod.value ?? "") ?? .bilinear
 
         guard outputWidth != sourceTexture.width || outputHeight != sourceTexture.height else {
@@ -199,6 +211,7 @@ public final class ImageResampleNode: Node
             height: outputHeight,
             format: sourceTexture.pixelFormat
         )
+        destinationImage.textureTransform = sourceImage.textureTransform
 
         guard let computeEncoder = commandBuffer.makeComputeCommandEncoder() else
         {
@@ -232,7 +245,6 @@ public final class ImageResampleNode: Node
             )
         }
 
-        destinationImage.isFlipped = sourceImage.isFlipped
         outputImage.send(destinationImage)
     }
 

--- a/Fabric/Nodes/Image/LiveCode/LiveImageNode.swift
+++ b/Fabric/Nodes/Image/LiveCode/LiveImageNode.swift
@@ -290,9 +290,11 @@ public class LiveImageNode: BaseImageNode
 
         fragment half4 postFragment(VertexData in [[stage_in]],
                                     constant PostUniforms &uniforms [[buffer(FragmentBufferMaterialUniforms)]],
+                                    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
                                     texture2d<half, access::sample> inputTexture [[texture(FragmentTextureCustom0)]]) {
             constexpr sampler s(address::clamp_to_edge, filter::linear);
-            half4 color = inputTexture.sample(s, in.texcoord);
+            float2 textureCoordinate = (imageTransforms[0] * float4(in.texcoord, 0.0, 1.0)).xy;
+            half4 color = inputTexture.sample(s, textureCoordinate);
             return mix(half4(0.0), color, half(uniforms.amount));
         }
         """

--- a/Fabric/Nodes/Image/Mask/ForegroundMaskNode.swift
+++ b/Fabric/Nodes/Image/Mask/ForegroundMaskNode.swift
@@ -24,19 +24,12 @@ public class ForegroundMaskNode: Node
     let inputTexturePort:NodePort<FabricImage>
     let outputTexturePort:NodePort<FabricImage>
     override public var ports: [Port] { [inputTexturePort, outputTexturePort] + super.ports}
-    
-    private var textureCache:CVMetalTextureCache?
-    
+        
     required init(context:Context)
     {
         self.inputTexturePort = NodePort<FabricImage>(name: "Image", kind: .Inlet, description: "Input image to analyze")
         self.outputTexturePort = NodePort<FabricImage>(name: "Image", kind: .Outlet, description: "Foreground object mask")
         
-        let _ = CVMetalTextureCacheCreate(kCFAllocatorDefault,
-                                          nil,
-                                          context.device,
-                                          nil,
-                                          &self.textureCache)
         super.init(context: context)
     }
     
@@ -69,12 +62,6 @@ public class ForegroundMaskNode: Node
         self.inputTexturePort = try container.decode(NodePort<FabricImage>.self, forKey: .inputTexturePort)
         self.outputTexturePort = try container.decode(NodePort<FabricImage>.self, forKey: .outputTexturePort)
         
-        let _ = CVMetalTextureCacheCreate(kCFAllocatorDefault,
-                                          nil,
-                                          decodeContext.documentContext.device,
-                                          nil,
-                                          &self.textureCache)
-        
         try super.init(from:decoder)
     }
     
@@ -87,22 +74,18 @@ public class ForegroundMaskNode: Node
         
         if self.inputTexturePort.valueDidChange
         {
-            if let inTex = self.inputTexturePort.value?.texture,
-               let (maskTex, flipped) =  self.maskForRequest(VNGenerateForegroundInstanceMaskRequest(), from: inTex)
+            if  let inImage = self.inputTexturePort.value,
+                let mask =  self.maskForRequest(VNGenerateForegroundInstanceMaskRequest(), from: inImage.texture)
             {
+                let outputImage = try renderer.newImage(fromPixelBuffer: mask)
+                outputImage.isFlipped = CVImageBufferIsFlipped(mask)
              
-                let image = FabricImage.unmanaged(texture: maskTex)
-                image.isFlipped = flipped
-                self.outputTexturePort.send( image )
-            }
-            else
-            {
-                self.outputTexturePort.send( nil )
+                self.outputTexturePort.send( outputImage )
             }
         }
     }
     
-    private func maskForRequest(_ request: VNGenerateForegroundInstanceMaskRequest, from texture:MTLTexture,) -> (texture:MTLTexture, flipped:Bool)?
+    private func maskForRequest(_ request: VNGenerateForegroundInstanceMaskRequest, from texture:MTLTexture,) -> CVPixelBuffer?
     {
         if let inputImage = CIImage(mtlTexture: texture)
         {
@@ -133,27 +116,7 @@ public class ForegroundMaskNode: Node
                 {
                     let mask = try observation.generateMask(forInstances: observation.allInstances)
   
-                    // Doesnt always work?
-//                    let mask = observation.instanceMask
-
-                    CVMetalTextureCacheFlush(self.textureCache!, 0)
-                    
-                    var cvMask:CVMetalTexture? = nil
-                    let success = CVMetalTextureCacheCreateTextureFromImage(kCFAllocatorDefault,
-                                                                            self.textureCache!,
-                                                                            mask,
-                                                                            nil,
-                                                                            .bgra8Unorm,
-                                                                            CVPixelBufferGetWidth(mask),
-                                                                            CVPixelBufferGetHeight(mask),
-                                                                            0,
-                                                                            &cvMask)
-                    
-                    if success == kCVReturnSuccess, let cvMask,
-                       let texture = CVMetalTextureGetTexture(cvMask)
-                    {
-                        return ( texture:texture, flipped: CVMetalTextureIsFlipped(cvMask) )
-                    }
+                    return mask
                 }
             }
             catch

--- a/Fabric/Nodes/Image/Mask/ForegroundMaskNode.swift
+++ b/Fabric/Nodes/Image/Mask/ForegroundMaskNode.swift
@@ -75,19 +75,16 @@ public class ForegroundMaskNode: Node
         if self.inputTexturePort.valueDidChange
         {
             if  let inImage = self.inputTexturePort.value,
-                let mask =  self.maskForRequest(VNGenerateForegroundInstanceMaskRequest(), from: inImage.texture)
+                let mask = self.maskForRequest(VNGenerateForegroundInstanceMaskRequest(), from: inImage)
             {
-                let outputImage = try renderer.newImage(fromPixelBuffer: mask)
-                outputImage.isFlipped = CVImageBufferIsFlipped(mask)
-             
-                self.outputTexturePort.send( outputImage )
+                self.outputTexturePort.send(try renderer.newImage(fromPixelBuffer: mask))
             }
         }
     }
     
-    private func maskForRequest(_ request: VNGenerateForegroundInstanceMaskRequest, from texture:MTLTexture,) -> CVPixelBuffer?
+    private func maskForRequest(_ request: VNGenerateForegroundInstanceMaskRequest, from image: FabricImage) -> CVPixelBuffer?
     {
-        if let inputImage = CIImage(mtlTexture: texture)
+        if let inputImage = image.presentationCIImage
         {
             for computeDevice in MLComputeDevice.allComputeDevices
             {

--- a/Fabric/Nodes/Image/Mask/ForegroundMaskNode.swift
+++ b/Fabric/Nodes/Image/Mask/ForegroundMaskNode.swift
@@ -24,7 +24,7 @@ public class ForegroundMaskNode: Node
     let inputTexturePort:NodePort<FabricImage>
     let outputTexturePort:NodePort<FabricImage>
     override public var ports: [Port] { [inputTexturePort, outputTexturePort] + super.ports}
-        
+
     required init(context:Context)
     {
         self.inputTexturePort = NodePort<FabricImage>(name: "Image", kind: .Inlet, description: "Input image to analyze")

--- a/Fabric/Nodes/Image/Mask/PersonSegmentationMaskNode.swift
+++ b/Fabric/Nodes/Image/Mask/PersonSegmentationMaskNode.swift
@@ -24,7 +24,7 @@ public class PersonSegmentationMaskNode: Node
     let inputTexturePort:NodePort<FabricImage>
     let outputTexturePort:NodePort<FabricImage>
     override public var ports: [Port] { [inputTexturePort, outputTexturePort] + super.ports}
-        
+
     required init(context:Context)
     {
         self.inputTexturePort = NodePort<FabricImage>(name: "Image", kind: .Inlet, description: "Input image to analyze")
@@ -61,7 +61,7 @@ public class PersonSegmentationMaskNode: Node
         
         self.inputTexturePort = try container.decode(NodePort<FabricImage>.self, forKey: .inputTexturePort)
         self.outputTexturePort = try container.decode(NodePort<FabricImage>.self, forKey: .outputTexturePort)
-                
+
         try super.init(from:decoder)
     }
     

--- a/Fabric/Nodes/Image/Mask/PersonSegmentationMaskNode.swift
+++ b/Fabric/Nodes/Image/Mask/PersonSegmentationMaskNode.swift
@@ -24,19 +24,12 @@ public class PersonSegmentationMaskNode: Node
     let inputTexturePort:NodePort<FabricImage>
     let outputTexturePort:NodePort<FabricImage>
     override public var ports: [Port] { [inputTexturePort, outputTexturePort] + super.ports}
-    
-    private var textureCache:CVMetalTextureCache?
-    
+        
     required init(context:Context)
     {
         self.inputTexturePort = NodePort<FabricImage>(name: "Image", kind: .Inlet, description: "Input image to analyze")
         self.outputTexturePort = NodePort<FabricImage>(name: "Image", kind: .Outlet, description: "Person segmentation mask")
         
-        let _ = CVMetalTextureCacheCreate(kCFAllocatorDefault,
-                                          nil,
-                                          context.device,
-                                          nil,
-                                          &self.textureCache)
         super.init(context: context)
     }
     
@@ -68,13 +61,7 @@ public class PersonSegmentationMaskNode: Node
         
         self.inputTexturePort = try container.decode(NodePort<FabricImage>.self, forKey: .inputTexturePort)
         self.outputTexturePort = try container.decode(NodePort<FabricImage>.self, forKey: .outputTexturePort)
-        
-        let _ = CVMetalTextureCacheCreate(kCFAllocatorDefault,
-                                          nil,
-                                          decodeContext.documentContext.device,
-                                          nil,
-                                          &self.textureCache)
-        
+                
         try super.init(from:decoder)
     }
     
@@ -91,19 +78,21 @@ public class PersonSegmentationMaskNode: Node
 //            request.qualityLevel = .fast
 //            request.outputPixelFormat = kCVPixelFormatType_OneComponent16Half
             
-            if let inTex = self.inputTexturePort.value?.texture,
-               let maskTex =  self.maskForRequest(request, from: inTex)
+            if self.inputTexturePort.valueDidChange
             {
-                self.outputTexturePort.send( FabricImage.unmanaged(texture: maskTex) )
-            }
-            else
-            {
-                self.outputTexturePort.send( nil )
+                if  let inImage = self.inputTexturePort.value,
+                    let mask =  self.maskForRequest(request, from: inImage.texture)
+                {
+                    let outputImage = try renderer.newImage(fromPixelBuffer: mask)
+                    outputImage.isFlipped = CVImageBufferIsFlipped(mask)
+                 
+                    self.outputTexturePort.send( outputImage )
+                }
             }
         }
     }
     
-    private func maskForRequest(_ request: VNGeneratePersonInstanceMaskRequest, from texture:MTLTexture,) -> MTLTexture?
+    private func maskForRequest(_ request: VNGeneratePersonInstanceMaskRequest, from texture:MTLTexture,) -> CVPixelBuffer?
     {
         if let inputImage = CIImage(mtlTexture: texture)
         {
@@ -132,28 +121,9 @@ public class PersonSegmentationMaskNode: Node
                                 
                 if let observation = request.results?.first
                 {
-//                    let mask = observation.pixelBuffer
-  
-                    // Doesnt always work?
                     let mask = try observation.generateMask(forInstances: IndexSet(integer: 1) )
-
-                    CVMetalTextureCacheFlush(self.textureCache!, 0)
                     
-                    var cvMask:CVMetalTexture? = nil
-                    let success = CVMetalTextureCacheCreateTextureFromImage(kCFAllocatorDefault,
-                                                                            self.textureCache!,
-                                                                            mask,
-                                                                            nil,
-                                                                            .bgra8Unorm,
-                                                                            CVPixelBufferGetWidth(mask),
-                                                                            CVPixelBufferGetHeight(mask),
-                                                                            0,
-                                                                            &cvMask)
-                    
-                    if success == kCVReturnSuccess, let cvMask
-                    {
-                        return CVMetalTextureGetTexture(cvMask)
-                    }
+                    return mask
                 }
             }
             catch

--- a/Fabric/Nodes/Image/Mask/PersonSegmentationMaskNode.swift
+++ b/Fabric/Nodes/Image/Mask/PersonSegmentationMaskNode.swift
@@ -81,20 +81,17 @@ public class PersonSegmentationMaskNode: Node
             if self.inputTexturePort.valueDidChange
             {
                 if  let inImage = self.inputTexturePort.value,
-                    let mask =  self.maskForRequest(request, from: inImage.texture)
+                    let mask = self.maskForRequest(request, from: inImage)
                 {
-                    let outputImage = try renderer.newImage(fromPixelBuffer: mask)
-                    outputImage.isFlipped = CVImageBufferIsFlipped(mask)
-                 
-                    self.outputTexturePort.send( outputImage )
+                    self.outputTexturePort.send(try renderer.newImage(fromPixelBuffer: mask))
                 }
             }
         }
     }
     
-    private func maskForRequest(_ request: VNGeneratePersonInstanceMaskRequest, from texture:MTLTexture,) -> CVPixelBuffer?
+    private func maskForRequest(_ request: VNGeneratePersonInstanceMaskRequest, from image: FabricImage) -> CVPixelBuffer?
     {
-        if let inputImage = CIImage(mtlTexture: texture)
+        if let inputImage = image.presentationCIImage
         {
             for computeDevice in MLComputeDevice.allComputeDevices
             {

--- a/Fabric/Nodes/Image/MovieProviderNode.swift
+++ b/Fabric/Nodes/Image/MovieProviderNode.swift
@@ -421,7 +421,7 @@ public class MovieProviderNode : Node, NodeFileLoadingProtocol
             performSeek(to: pending)
         }
 
-        let time = executionInfo.timing.time
+        let time = executionInfo.timing.hostMediaTime
 
 #if FABRIC_HAP_ENABLED
         if try self.executeHapPath(renderer: renderer, hostTime: time) {
@@ -586,7 +586,7 @@ public class MovieProviderNode : Node, NodeFileLoadingProtocol
 
 
                 let playerItem = AVPlayerItem(asset: self.asset!, automaticallyLoadedAssetKeys: ["tracks", "metadata", "duration"])
-
+                
                 playerItem.preferredForwardBufferDuration = 0.5
 #if FABRIC_HAP_ENABLED
                 if !self.attachHapOutput(to: playerItem, url: inputURL)

--- a/Fabric/Nodes/Image/MovieProviderNode.swift
+++ b/Fabric/Nodes/Image/MovieProviderNode.swift
@@ -110,6 +110,8 @@ public class MovieProviderNode : Node, NodeFileLoadingProtocol
     private var didPlayToEndPendingPulse: Bool = false
     public private(set) var duration: TimeInterval = 0
     public private(set) var currentTime: TimeInterval = 0
+    private var sourceToPresentationTransform: CGAffineTransform = .identity
+    private var sourceNaturalSize: CGSize = .zero
 
 #if FABRIC_HAP_ENABLED
     /// Hap decoder output, present only while the loaded asset is a
@@ -440,6 +442,7 @@ public class MovieProviderNode : Node, NodeFileLoadingProtocol
             {
                 self.updateCurrentTime(from: displayTime, fallback: itemTime)
                 let image = try renderer.newImage(fromPixelBuffer: pixelBuffer)
+                image.textureTransform = self.videoTextureTransform(for: pixelBuffer)
 
                 self.outputTexturePort.send( image )
             }
@@ -458,6 +461,7 @@ public class MovieProviderNode : Node, NodeFileLoadingProtocol
             {
                 self.updateCurrentTime(from: displayTime, fallback: pausedTime)
                 let image = try renderer.newImage(fromPixelBuffer: pixelBuffer)
+                image.textureTransform = self.videoTextureTransform(for: pixelBuffer)
 
                 self.outputTexturePort.send( image )
             }
@@ -530,6 +534,8 @@ public class MovieProviderNode : Node, NodeFileLoadingProtocol
         self.player.replaceCurrentItem(with: nil)
         self.asset = nil
         self.url = nil
+        self.sourceToPresentationTransform = .identity
+        self.sourceNaturalSize = .zero
         self.outputTexturePort.send(nil)
         self.resetPlaybackInfo()
 
@@ -581,6 +587,11 @@ public class MovieProviderNode : Node, NodeFileLoadingProtocol
 #endif
 
                 self.asset = AVURLAsset(url: inputURL, options: [AVURLAssetPreferPreciseDurationAndTimingKey: true])
+                if let videoTrack = self.asset?.tracks(withMediaType: .video).first
+                {
+                    self.sourceToPresentationTransform = videoTrack.preferredTransform
+                    self.sourceNaturalSize = videoTrack.naturalSize
+                }
                 self.cacheDuration(from: self.asset)
                 self.currentTime = 0
 
@@ -623,6 +634,18 @@ public class MovieProviderNode : Node, NodeFileLoadingProtocol
                                   message: "Movie file not found: \(inputURL.path)")
             }
         }
+    }
+
+    private func videoTextureTransform(for pixelBuffer: CVPixelBuffer) -> simd_float4x4
+    {
+        let sourceSize = self.sourceNaturalSize == .zero
+            ? CGSize(width: CVPixelBufferGetWidth(pixelBuffer), height: CVPixelBufferGetHeight(pixelBuffer))
+            : self.sourceNaturalSize
+        return FabricImageTextureTransform.video(
+            pixelBuffer: pixelBuffer,
+            sourceToPresentationTransform: self.sourceToPresentationTransform,
+            sourceSize: sourceSize
+        )
     }
 
 #if FABRIC_HAP_ENABLED
@@ -689,6 +712,7 @@ public class MovieProviderNode : Node, NodeFileLoadingProtocol
         else if let pixelBuffer = Self.makePixelBuffer(fromHapFrame: frame)
         {
             let image = try renderer.newImage(fromPixelBuffer: pixelBuffer)
+            image.textureTransform = self.videoTextureTransform(for: pixelBuffer)
 
             self.outputTexturePort.send( image )
             emitted = true
@@ -900,6 +924,12 @@ public class MovieProviderNode : Node, NodeFileLoadingProtocol
 
         let region = MTLRegionMake2D(0, 0, texWidth, texHeight)
         image.texture.replace(region: region, mipmapLevel: 0, withBytes: dxtData!, bytesPerRow: bytesPerRow)
+        image.textureTransform = FabricImageTextureTransform.sourceToPresentation(
+            self.sourceToPresentationTransform,
+            sourceSize: self.sourceNaturalSize == .zero
+                ? CGSize(width: trueWidth, height: trueHeight)
+                : self.sourceNaturalSize
+        )
 
         return image
     }

--- a/Fabric/Nodes/Image/MovieProviderNode.swift
+++ b/Fabric/Nodes/Image/MovieProviderNode.swift
@@ -597,7 +597,7 @@ public class MovieProviderNode : Node, NodeFileLoadingProtocol
 
 
                 let playerItem = AVPlayerItem(asset: self.asset!, automaticallyLoadedAssetKeys: ["tracks", "metadata", "duration"])
-                
+
                 playerItem.preferredForwardBufferDuration = 0.5
 #if FABRIC_HAP_ENABLED
                 if !self.attachHapOutput(to: playerItem, url: inputURL)
@@ -641,11 +641,9 @@ public class MovieProviderNode : Node, NodeFileLoadingProtocol
         let sourceSize = self.sourceNaturalSize == .zero
             ? CGSize(width: CVPixelBufferGetWidth(pixelBuffer), height: CVPixelBufferGetHeight(pixelBuffer))
             : self.sourceNaturalSize
-        return FabricImageTextureTransform.video(
-            pixelBuffer: pixelBuffer,
-            sourceToPresentationTransform: self.sourceToPresentationTransform,
-            sourceSize: sourceSize
-        )
+        return FabricImageTextureTransform.video(pixelBuffer: pixelBuffer,
+                                                 sourceToPresentationTransform: self.sourceToPresentationTransform,
+                                                 sourceSize: sourceSize)
     }
 
 #if FABRIC_HAP_ENABLED
@@ -924,12 +922,10 @@ public class MovieProviderNode : Node, NodeFileLoadingProtocol
 
         let region = MTLRegionMake2D(0, 0, texWidth, texHeight)
         image.texture.replace(region: region, mipmapLevel: 0, withBytes: dxtData!, bytesPerRow: bytesPerRow)
-        image.textureTransform = FabricImageTextureTransform.sourceToPresentation(
-            self.sourceToPresentationTransform,
-            sourceSize: self.sourceNaturalSize == .zero
-                ? CGSize(width: trueWidth, height: trueHeight)
-                : self.sourceNaturalSize
-        )
+        image.textureTransform = FabricImageTextureTransform.sourceToPresentation(self.sourceToPresentationTransform,
+                                                                                  sourceSize: self.sourceNaturalSize == .zero
+                                                                                      ? CGSize(width: trueWidth, height: trueHeight)
+                                                                                      : self.sourceNaturalSize)
 
         return image
     }

--- a/Fabric/Nodes/Image/SyphonServerNode.swift
+++ b/Fabric/Nodes/Image/SyphonServerNode.swift
@@ -70,12 +70,18 @@ public class SyphonServerNode : Node
         }
             
         if self.inputTexture.valueDidChange,
-           let texture = self.inputTexture.value
+           let inputImage = self.inputTexture.value
         {
-            let region = NSRect(origin: .zero, size: .init(width: texture.texture.width, height: texture.texture.height))
+            let region = NSRect(
+                origin: .zero,
+                size: CGSize(width: inputImage.texture.width, height: inputImage.texture.height)
+            )
 
-            // Somethings up with flippedness?
-            self.syphonServer.publishFrameTexture(texture.texture, on: commandBuffer, imageRegion: region, flipped: !texture.isFlipped)
+            let syphonRequiresVerticalFlip = inputImage.textureTransform == .textureVerticalFlip
+            self.syphonServer.publishFrameTexture(inputImage.texture,
+                                                  on: commandBuffer,
+                                                  imageRegion: region,
+                                                  flipped: syphonRequiresVerticalFlip)
         }
      }
 }

--- a/Fabric/Nodes/Image/SyphonServerNode.swift
+++ b/Fabric/Nodes/Image/SyphonServerNode.swift
@@ -72,10 +72,8 @@ public class SyphonServerNode : Node
         if self.inputTexture.valueDidChange,
            let inputImage = self.inputTexture.value
         {
-            let region = NSRect(
-                origin: .zero,
-                size: CGSize(width: inputImage.texture.width, height: inputImage.texture.height)
-            )
+            let region = NSRect(origin: .zero,
+                                size: CGSize(width: inputImage.texture.width, height: inputImage.texture.height))
 
             let syphonRequiresVerticalFlip = inputImage.textureTransform == .textureVerticalFlip
             self.syphonServer.publishFrameTexture(inputImage.texture,

--- a/Fabric/Nodes/Image/TextureCropNode.swift
+++ b/Fabric/Nodes/Image/TextureCropNode.swift
@@ -43,25 +43,21 @@ public class TextureCropNode: Node
 
     private let cropMaterial: PostMaterial
     private let cropProcessor: PostProcessEncoder
-    private lazy var cropUniformsBuffer = StructBuffer<CropUniforms>(
-        device: self.context.device,
-        count: 1,
-        label: "Texture Crop Uniforms"
-    )
+    private lazy var cropUniformsBuffer = StructBuffer<CropUniforms>(device: self.context.device,
+                                                                     count: 1,
+                                                                     label: "Texture Crop Uniforms")
 
     public required init(context: Context)
     {
         let material = PostMaterial(context: context, pipelineURL: Self.shaderURL())
         self.cropMaterial = material
-        self.cropProcessor = PostProcessEncoder(
-            context: context,
-            material: material,
-            depthPixelFormat: .invalid,
-            stencilPixelFormat: .invalid,
-            depthStoreAction: .dontCare,
-            stencilStoreAction: .dontCare,
-            frameBufferOnly: false
-        )
+        self.cropProcessor = PostProcessEncoder(context: context,
+                                                material: material,
+                                                depthPixelFormat: .invalid,
+                                                stencilPixelFormat: .invalid,
+                                                depthStoreAction: .dontCare,
+                                                stencilStoreAction: .dontCare,
+                                                frameBufferOnly: false)
         super.init(context: context)
     }
 
@@ -73,15 +69,13 @@ public class TextureCropNode: Node
 
         let material = PostMaterial(context: context, pipelineURL: Self.shaderURL())
         self.cropMaterial = material
-        self.cropProcessor = PostProcessEncoder(
-            context: context,
-            material: material,
-            depthPixelFormat: .invalid,
-            stencilPixelFormat: .invalid,
-            depthStoreAction: .dontCare,
-            stencilStoreAction: .dontCare,
-            frameBufferOnly: false
-        )
+        self.cropProcessor = PostProcessEncoder(context: context,
+                                                material: material,
+                                                depthPixelFormat: .invalid,
+                                                stencilPixelFormat: .invalid,
+                                                depthStoreAction: .dontCare,
+                                                stencilStoreAction: .dontCare,
+                                                frameBufferOnly: false)
         try super.init(from: decoder)
     }
 
@@ -101,42 +95,30 @@ public class TextureCropNode: Node
         let cropHeight = max(1, min(inputCropHeight.value ?? 1080, presentationHeight - cropY))
 
         let outImage = try renderer.newImage(withWidth: cropWidth, height: cropHeight)
-        let cropUniforms = CropUniforms(
-            origin: simd_float2(
-                Float(cropX) / Float(presentationWidth),
-                Float(cropY) / Float(presentationHeight)
-            ),
-            size: simd_float2(
-                Float(cropWidth) / Float(presentationWidth),
-                Float(cropHeight) / Float(presentationHeight)
-            ),
-            textureTransform: sourceImage.textureTransform
-        )
+        let cropUniforms = CropUniforms(origin: simd_float2(Float(cropX) / Float(presentationWidth),
+                                                            Float(cropY) / Float(presentationHeight)),
+                                        size: simd_float2(Float(cropWidth) / Float(presentationWidth),
+                                                          Float(cropHeight) / Float(presentationHeight)),
+                                        textureTransform: sourceImage.textureTransform)
         self.cropUniformsBuffer.update(data: [cropUniforms])
         self.cropMaterial.set(self.cropUniformsBuffer, index: FragmentBufferIndex.Custom0)
         self.cropMaterial.set(sourceImage.texture, index: FragmentTextureIndex.Custom0)
-        self.cropProcessor.resize(
-            size: (width: Float(cropWidth), height: Float(cropHeight)),
-            scaleFactor: 1
-        )
+        self.cropProcessor.resize(size: (width: Float(cropWidth), height: Float(cropHeight)),
+                                  scaleFactor: 1)
 
         let cropRenderPassDescriptor = MTLRenderPassDescriptor()
         cropRenderPassDescriptor.colorAttachments[0].texture = outImage.texture
-        self.cropProcessor.draw(
-            renderPassDescriptor: cropRenderPassDescriptor,
-            commandBuffer: commandBuffer
-        )
+        self.cropProcessor.draw(renderPassDescriptor: cropRenderPassDescriptor,
+                                commandBuffer: commandBuffer)
 
         outputTexture.send(outImage)
     }
 
     private static func shaderURL() -> URL
     {
-        guard let shaderURL = Bundle.module.url(
-            forResource: "TextureCropShader",
-            withExtension: "metal",
-            subdirectory: "Shaders"
-        ) else {
+        guard let shaderURL = Bundle.module.url(forResource: "TextureCropShader",
+                                                withExtension: "metal",
+                                                subdirectory: "Shaders") else {
             fatalError("TextureCropShader.metal is missing from the Fabric resource bundle")
         }
 

--- a/Fabric/Nodes/Image/TextureCropNode.swift
+++ b/Fabric/Nodes/Image/TextureCropNode.swift
@@ -3,9 +3,11 @@ import Satin
 import simd
 import Metal
 
-/// Crops a rectangular sub-region from an input texture using a blit encoder.
+/// Crops a presentation-space rectangle and returns an identity-oriented image.
 public class TextureCropNode: Node
 {
+    private final class PostMaterial: SourceMaterial {}
+
     public override class var name: String { "Texture Crop" }
     public override class var nodeType: Node.NodeType { .Image(imageType: .BaseEffect) }
     override public class var nodeExecutionMode: Node.ExecutionMode { .Processor }
@@ -32,6 +34,57 @@ public class TextureCropNode: Node
     public var inputCropHeight: ParameterPort<Int> { port(named: "inputCropHeight") }
     public var outputTexture: NodePort<FabricImage> { port(named: "outputTexture") }
 
+    private struct CropUniforms
+    {
+        var origin: simd_float2
+        var size: simd_float2
+        var textureTransform: simd_float4x4
+    }
+
+    private let cropMaterial: PostMaterial
+    private let cropProcessor: PostProcessEncoder
+    private lazy var cropUniformsBuffer = StructBuffer<CropUniforms>(
+        device: self.context.device,
+        count: 1,
+        label: "Texture Crop Uniforms"
+    )
+
+    public required init(context: Context)
+    {
+        let material = PostMaterial(context: context, pipelineURL: Self.shaderURL())
+        self.cropMaterial = material
+        self.cropProcessor = PostProcessEncoder(
+            context: context,
+            material: material,
+            depthPixelFormat: .invalid,
+            stencilPixelFormat: .invalid,
+            depthStoreAction: .dontCare,
+            stencilStoreAction: .dontCare,
+            frameBufferOnly: false
+        )
+        super.init(context: context)
+    }
+
+    public required init(from decoder: any Decoder) throws
+    {
+        guard let context = decoder.context?.documentContext as? Context else {
+            fatalError("Required Decode Context Not set")
+        }
+
+        let material = PostMaterial(context: context, pipelineURL: Self.shaderURL())
+        self.cropMaterial = material
+        self.cropProcessor = PostProcessEncoder(
+            context: context,
+            material: material,
+            depthPixelFormat: .invalid,
+            stencilPixelFormat: .invalid,
+            depthStoreAction: .dontCare,
+            stencilStoreAction: .dontCare,
+            frameBufferOnly: false
+        )
+        try super.init(from: decoder)
+    }
+
     override public func execute(renderer:GraphRenderer,
                                  executionInfo:GraphExecutionInfo,
                                  renderPassDescriptor: MTLRenderPassDescriptor,
@@ -40,41 +93,53 @@ public class TextureCropNode: Node
     {
         guard let sourceImage = inputTexture.value else { return }
 
-        let srcTex = sourceImage.texture
-        let x = max(0, min(inputCropX.value ?? 0, srcTex.width - 1))
-        var y = max(0, min(inputCropY.value ?? 0, srcTex.height - 1))
-        let w = max(1, min(inputCropWidth.value ?? 1920, srcTex.width - x))
-        let h = max(1, min(inputCropHeight.value ?? 1080, srcTex.height - y))
+        let presentationWidth = max(1, Int(sourceImage.presentationSize.width.rounded()))
+        let presentationHeight = max(1, Int(sourceImage.presentationSize.height.rounded()))
+        let cropX = max(0, min(inputCropX.value ?? 0, presentationWidth - 1))
+        let cropY = max(0, min(inputCropY.value ?? 0, presentationHeight - 1))
+        let cropWidth = max(1, min(inputCropWidth.value ?? 1920, presentationWidth - cropX))
+        let cropHeight = max(1, min(inputCropHeight.value ?? 1080, presentationHeight - cropY))
 
-        let outImage = try renderer.newImage(withWidth: w, height: h, format: sourceImage.texture.pixelFormat)
-        // For flipped sources (e.g. Syphon/OpenGL with bottom-left origin),
-        // the visual top of the image is stored at the bottom of texture
-        // memory. Invert the Y coordinate so crop regions specified in
-        // visual space select the correct memory rows.
-        if sourceImage.isFlipped {
-            y = max(0, srcTex.height - y - h)
-        }
-
-        guard let encoder = commandBuffer.makeBlitCommandEncoder() else
-        {
-            throw FabricError(.execution(.gpu),
-                              severity: .recoverable,
-                              message: "Could not create Texture Crop blit encoder")
-        }
-        encoder.copy(
-            from: srcTex,
-            sourceSlice: 0, sourceLevel: 0,
-            sourceOrigin: MTLOrigin(x: x, y: y, z: 0),
-            sourceSize: MTLSize(width: w, height: h, depth: 1),
-            to: outImage.texture,
-            destinationSlice: 0, destinationLevel: 0,
-            destinationOrigin: MTLOrigin(x: 0, y: 0, z: 0)
+        let outImage = try renderer.newImage(withWidth: cropWidth, height: cropHeight)
+        let cropUniforms = CropUniforms(
+            origin: simd_float2(
+                Float(cropX) / Float(presentationWidth),
+                Float(cropY) / Float(presentationHeight)
+            ),
+            size: simd_float2(
+                Float(cropWidth) / Float(presentationWidth),
+                Float(cropHeight) / Float(presentationHeight)
+            ),
+            textureTransform: sourceImage.textureTransform
         )
-        encoder.endEncoding()
+        self.cropUniformsBuffer.update(data: [cropUniforms])
+        self.cropMaterial.set(self.cropUniformsBuffer, index: FragmentBufferIndex.Custom0)
+        self.cropMaterial.set(sourceImage.texture, index: FragmentTextureIndex.Custom0)
+        self.cropProcessor.resize(
+            size: (width: Float(cropWidth), height: Float(cropHeight)),
+            scaleFactor: 1
+        )
 
-        // Preserve the source's flip flag so downstream material nodes
-        // apply the correct UV orientation.
-        outImage.isFlipped = sourceImage.isFlipped
+        let cropRenderPassDescriptor = MTLRenderPassDescriptor()
+        cropRenderPassDescriptor.colorAttachments[0].texture = outImage.texture
+        self.cropProcessor.draw(
+            renderPassDescriptor: cropRenderPassDescriptor,
+            commandBuffer: commandBuffer
+        )
+
         outputTexture.send(outImage)
+    }
+
+    private static func shaderURL() -> URL
+    {
+        guard let shaderURL = Bundle.module.url(
+            forResource: "TextureCropShader",
+            withExtension: "metal",
+            subdirectory: "Shaders"
+        ) else {
+            fatalError("TextureCropShader.metal is missing from the Fabric resource bundle")
+        }
+
+        return shaderURL
     }
 }

--- a/Fabric/Nodes/Material/BasicTextureMaterialNode.swift
+++ b/Fabric/Nodes/Material/BasicTextureMaterialNode.swift
@@ -39,7 +39,7 @@ public class BasicTextureMaterialNode : BasicColorMaterialNode
         if self.inputTexture.valueDidChange
         {
             self.material.texture =  self.inputTexture.value?.texture
-            self.material.flipped =  (self.inputTexture.value?.isFlipped ?? false)
+            self.material.textureTransform = self.inputTexture.value?.textureTransform ?? matrix_identity_float4x4
             shouldOutput = true
         }
         

--- a/Fabric/Nodes/Material/DisplacementMaterialNode.swift
+++ b/Fabric/Nodes/Material/DisplacementMaterialNode.swift
@@ -122,10 +122,8 @@ public class DisplacementMaterialNode: BaseMaterialNode
         {
             let displacementImage = self.inputDisplacementTexture.value ?? self.inputTexture.value
             self.material.set(displacementImage?.texture, index: VertexTextureIndex.Custom0)
-            self.material.set(
-                "displacementTextureTransform",
-                displacementImage?.textureTransform ?? matrix_identity_float4x4
-            )
+            self.material.set("displacementTextureTransform",
+                              displacementImage?.textureTransform ?? matrix_identity_float4x4)
             shouldOutput = true
         }
         
@@ -133,10 +131,8 @@ public class DisplacementMaterialNode: BaseMaterialNode
         {
             let image = self.inputTexture.value
             self.material.set(image?.texture, index: FragmentTextureIndex.Custom0)
-            self.material.set(
-                "colorTextureTransform",
-                image?.textureTransform ?? matrix_identity_float4x4
-            )
+            self.material.set("colorTextureTransform",
+                              image?.textureTransform ?? matrix_identity_float4x4)
             shouldOutput = true
         }
         
@@ -144,10 +140,8 @@ public class DisplacementMaterialNode: BaseMaterialNode
         {
             let image = self.inputPointSpriteTexture.value
             self.material.set(image?.texture, index: FragmentTextureIndex.Custom1)
-            self.material.set(
-                "pointSpriteTextureTransform",
-                image?.textureTransform ?? matrix_identity_float4x4
-            )
+            self.material.set("pointSpriteTextureTransform",
+                              image?.textureTransform ?? matrix_identity_float4x4)
             shouldOutput = true
         }
         

--- a/Fabric/Nodes/Material/DisplacementMaterialNode.swift
+++ b/Fabric/Nodes/Material/DisplacementMaterialNode.swift
@@ -118,31 +118,37 @@ public class DisplacementMaterialNode: BaseMaterialNode
     {
         var shouldOutput = super.evaluate(material: material, atTime: atTime)
         
-        if self.inputDisplacementTexture.valueDidChange
+        if self.inputDisplacementTexture.valueDidChange || self.inputTexture.valueDidChange
         {
-            if let texture = self.inputDisplacementTexture.value?.texture ?? self.inputTexture.value?.texture
-            {
-                self.material.set(texture, index: VertexTextureIndex.Custom0)
-                shouldOutput = true
-            }
+            let displacementImage = self.inputDisplacementTexture.value ?? self.inputTexture.value
+            self.material.set(displacementImage?.texture, index: VertexTextureIndex.Custom0)
+            self.material.set(
+                "displacementTextureTransform",
+                displacementImage?.textureTransform ?? matrix_identity_float4x4
+            )
+            shouldOutput = true
         }
         
         if self.inputTexture.valueDidChange
         {
-            if let texture = self.inputTexture.value?.texture
-            {
-                self.material.set(texture, index: FragmentTextureIndex.Custom0)
-                shouldOutput = true
-            }
+            let image = self.inputTexture.value
+            self.material.set(image?.texture, index: FragmentTextureIndex.Custom0)
+            self.material.set(
+                "colorTextureTransform",
+                image?.textureTransform ?? matrix_identity_float4x4
+            )
+            shouldOutput = true
         }
         
         if self.inputPointSpriteTexture.valueDidChange
         {
-            if let texture = self.inputPointSpriteTexture.value?.texture
-            {
-                self.material.set(texture, index: FragmentTextureIndex.Custom1)
-                shouldOutput = true
-            }
+            let image = self.inputPointSpriteTexture.value
+            self.material.set(image?.texture, index: FragmentTextureIndex.Custom1)
+            self.material.set(
+                "pointSpriteTextureTransform",
+                image?.textureTransform ?? matrix_identity_float4x4
+            )
+            shouldOutput = true
         }
         
         if self.inputAmount.valueDidChange,

--- a/Fabric/Nodes/Material/PBRMaterialNode.swift
+++ b/Fabric/Nodes/Material/PBRMaterialNode.swift
@@ -204,10 +204,8 @@ public class PBRMaterialNode : StandardMaterialNode
         if self.inputClearcoatRoughTexture.valueDidChange || self.inputClearcoatGlossTexture.valueDidChange
         {
             let clearcoatSurfaceImage = self.inputClearcoatRoughTexture.value ?? self.inputClearcoatGlossTexture.value
-            self.material.setTextureTransform(
-                clearcoatSurfaceImage?.textureTransform ?? matrix_identity_float4x4,
-                type: .clearcoatRoughness
-            )
+            self.material.setTextureTransform(clearcoatSurfaceImage?.textureTransform ?? matrix_identity_float4x4,
+                                              type: .clearcoatRoughness)
         }
         
         if self.inputTransmissionTexture.valueDidChange

--- a/Fabric/Nodes/Material/PBRMaterialNode.swift
+++ b/Fabric/Nodes/Material/PBRMaterialNode.swift
@@ -161,31 +161,31 @@ public class PBRMaterialNode : StandardMaterialNode
         
         if self.inputBumpTexture.valueDidChange
         {
-            self.material.setTexture(self.inputBumpTexture.value?.texture, type: .bump)
+            self.setImage(self.inputBumpTexture.value, for: .bump)
             shouldOutput = true
         }
         
         if self.inputDisplacementTexture.valueDidChange
         {
-            self.material.setTexture(self.inputDisplacementTexture.value?.texture, type: .displacement)
+            self.setImage(self.inputDisplacementTexture.value, for: .displacement)
             shouldOutput = true
         }
         
         if self.inputOcclusionTexture.valueDidChange
         {
-            self.material.setTexture(self.inputOcclusionTexture.value?.texture, type: .occlusion)
+            self.setImage(self.inputOcclusionTexture.value, for: .occlusion)
             shouldOutput = true
         }
         
         if self.inputSubsurfaceTexture.valueDidChange
         {
-            self.material.setTexture(self.inputSubsurfaceTexture.value?.texture, type: .subsurface)
+            self.setImage(self.inputSubsurfaceTexture.value, for: .subsurface)
             shouldOutput = true
         }
         
         if self.inputClearcoatTexture.valueDidChange
         {
-            self.material.setTexture(self.inputClearcoatTexture.value?.texture, type: .clearcoat)
+            self.setImage(self.inputClearcoatTexture.value, for: .clearcoat)
             shouldOutput = true
         }
         
@@ -200,10 +200,19 @@ public class PBRMaterialNode : StandardMaterialNode
             self.material.setTexture(self.inputClearcoatGlossTexture.value?.texture, type: .clearcoatGloss)
             shouldOutput = true
         }
+
+        if self.inputClearcoatRoughTexture.valueDidChange || self.inputClearcoatGlossTexture.valueDidChange
+        {
+            let clearcoatSurfaceImage = self.inputClearcoatRoughTexture.value ?? self.inputClearcoatGlossTexture.value
+            self.material.setTextureTransform(
+                clearcoatSurfaceImage?.textureTransform ?? matrix_identity_float4x4,
+                type: .clearcoatRoughness
+            )
+        }
         
         if self.inputTransmissionTexture.valueDidChange
         {
-            self.material.setTexture(self.inputTransmissionTexture.value?.texture, type: .transmission)
+            self.setImage(self.inputTransmissionTexture.value, for: .transmission)
             shouldOutput = true
         }
         

--- a/Fabric/Nodes/Material/StandardMaterialNode.swift
+++ b/Fabric/Nodes/Material/StandardMaterialNode.swift
@@ -62,6 +62,15 @@ public class StandardMaterialNode : BaseMaterialNode
     }
     
     private lazy var _material = StandardMaterial(context:self.context)
+
+    func setImage(_ image: FabricImage?, for textureType: PBRTextureType)
+    {
+        self.material.setTexture(image?.texture, type: textureType)
+        self.material.setTextureTransform(
+            image?.textureTransform ?? matrix_identity_float4x4,
+            type: textureType
+        )
+    }
     
     public override func evaluate(material: Material, atTime: TimeInterval) -> Bool
     {
@@ -125,37 +134,37 @@ public class StandardMaterialNode : BaseMaterialNode
 
         if self.inputDiffuseTexture.valueDidChange
         {
-            self.material.setTexture(self.inputDiffuseTexture.value?.texture, type: .baseColor)
+            self.setImage(self.inputDiffuseTexture.value, for: .baseColor)
             shouldOutput = true
         }
         
         if self.inputNormalTexture.valueDidChange
         {
-            self.material.setTexture(self.inputNormalTexture.value?.texture, type: .normal)
+            self.setImage(self.inputNormalTexture.value, for: .normal)
             shouldOutput = true
         }
 
         if self.inputEmissiveTexture.valueDidChange
         {
-            self.material.setTexture(self.inputEmissiveTexture.value?.texture, type: .emissive)
+            self.setImage(self.inputEmissiveTexture.value, for: .emissive)
             shouldOutput = true
         }
 
         if self.inputSpecularTexture.valueDidChange
         {
-            self.material.setTexture(self.inputSpecularTexture.value?.texture, type: .specular)
+            self.setImage(self.inputSpecularTexture.value, for: .specular)
             shouldOutput = true
         }
 
         if self.inputRoughnessTexture.valueDidChange
         {
-            self.material.setTexture(self.inputRoughnessTexture.value?.texture, type: .roughness)
+            self.setImage(self.inputRoughnessTexture.value, for: .roughness)
             shouldOutput = true
         }
         
         if self.inputMetallicTexture.valueDidChange
         {
-            self.material.setTexture(self.inputMetallicTexture.value?.texture, type: .metallic)
+            self.setImage(self.inputMetallicTexture.value, for: .metallic)
             shouldOutput = true
         }
 //        self.material.setTexture(self.inputBumpTexture.value?.texture, type: .displacement)

--- a/Fabric/Nodes/Material/StandardMaterialNode.swift
+++ b/Fabric/Nodes/Material/StandardMaterialNode.swift
@@ -66,10 +66,8 @@ public class StandardMaterialNode : BaseMaterialNode
     func setImage(_ image: FabricImage?, for textureType: PBRTextureType)
     {
         self.material.setTexture(image?.texture, type: textureType)
-        self.material.setTextureTransform(
-            image?.textureTransform ?? matrix_identity_float4x4,
-            type: textureType
-        )
+        self.material.setTextureTransform(image?.textureTransform ?? matrix_identity_float4x4,
+                                          type: textureType)
     }
     
     public override func evaluate(material: Material, atTime: TimeInterval) -> Bool

--- a/Fabric/Nodes/Object/Lights/SpotLightNode.swift
+++ b/Fabric/Nodes/Object/Lights/SpotLightNode.swift
@@ -19,12 +19,6 @@ public class SpotLightNode : ObjectNode<SpotLight>
     override public class var nodeDescription: String { "Adds a Spot Light to the scene with optional cookie or projector image support."}
 
     private static let projectionModeOptions = ["Mask", "Color"]
-    private static let verticalFlipProjectionTransform = simd_float3x3(
-        simd_float3(1.0, 0.0, 0.0),
-        simd_float3(0.0, -1.0, 0.0),
-        simd_float3(0.0, 1.0, 1.0)
-    )
-
     override public class func registerPorts(context: Context) -> [(name: String, port: Port)] {
         let ports = super.registerPorts(context: context)
 
@@ -169,9 +163,14 @@ public class SpotLightNode : ObjectNode<SpotLight>
     {
         let image = self.inputProjectionImage.value
         self.light.projectionTexture = image?.texture
-        self.light.projectionTransform = image?.isFlipped == true
-            ? Self.verticalFlipProjectionTransform
-            : matrix_identity_float3x3
+        self.light.projectionTransform = image.map {
+            let transform = $0.textureTransform
+            return simd_float3x3(
+                simd_float3(transform.columns.0.x, transform.columns.0.y, 0),
+                simd_float3(transform.columns.1.x, transform.columns.1.y, 0),
+                simd_float3(transform.columns.3.x, transform.columns.3.y, 1)
+            )
+        } ?? matrix_identity_float3x3
     }
 
     private func resolvedProjectionMode() -> SpotLightProjectionMode

--- a/Fabric/Nodes/Object/Lights/SpotLightNode.swift
+++ b/Fabric/Nodes/Object/Lights/SpotLightNode.swift
@@ -165,11 +165,9 @@ public class SpotLightNode : ObjectNode<SpotLight>
         self.light.projectionTexture = image?.texture
         self.light.projectionTransform = image.map {
             let transform = $0.textureTransform
-            return simd_float3x3(
-                simd_float3(transform.columns.0.x, transform.columns.0.y, 0),
-                simd_float3(transform.columns.1.x, transform.columns.1.y, 0),
-                simd_float3(transform.columns.3.x, transform.columns.3.y, 1)
-            )
+            return simd_float3x3(simd_float3(transform.columns.0.x, transform.columns.0.y, 0),
+                                 simd_float3(transform.columns.1.x, transform.columns.1.y, 0),
+                                 simd_float3(transform.columns.3.x, transform.columns.3.y, 1))
         } ?? matrix_identity_float3x3
     }
 

--- a/Fabric/Nodes/Object/Renderables/ImageMeshNode.swift
+++ b/Fabric/Nodes/Object/Renderables/ImageMeshNode.swift
@@ -85,7 +85,7 @@ class ImageMeshNode: BaseRenderableNode<Mesh>
         if self.inputImage.valueDidChange
         {
             self.material.texture = self.inputImage.value?.texture
-            self.material.flipped = (self.inputImage.value?.isFlipped ?? false)
+            self.material.textureTransform = self.inputImage.value?.textureTransform ?? matrix_identity_float4x4
         }
 
         if self.inputColor.valueDidChange,
@@ -102,9 +102,9 @@ class ImageMeshNode: BaseRenderableNode<Mesh>
             let size = self.inputSize.value ?? 1.0
             let aspect: Float
 
-            if let texture = self.inputImage.value?.texture
+            if let image = self.inputImage.value
             {
-                aspect = Float(texture.width) / Float(texture.height)
+                aspect = Float(image.presentationSize.width / image.presentationSize.height)
             }
             else
             {
@@ -113,13 +113,13 @@ class ImageMeshNode: BaseRenderableNode<Mesh>
 
             if self.inputSizingDimension.value == "Height"
             {
-                self.mesh.scale.y = size
-                self.mesh.scale.x = size * aspect
+                self.geometry.height = size
+                self.geometry.width = size * aspect
             }
             else
             {
-                self.mesh.scale.x = size
-                self.mesh.scale.y = size / aspect
+                self.geometry.width = size
+                self.geometry.height = size / aspect
             }
         }
 

--- a/Fabric/Nodes/Object/Renderables/ImageMeshNode.swift
+++ b/Fabric/Nodes/Object/Renderables/ImageMeshNode.swift
@@ -49,6 +49,7 @@ class ImageMeshNode: BaseRenderableNode<Mesh>
     public required init(context: Context)
     {
         self.geometry = PlaneGeometry(context:context,width: 1, height: 1, orientation: .xy)
+//        self.geometry = QuadGeometry(context: context)
         self.material = BasicTextureMaterial(context:context)
         self.mesh = Mesh(context:context, geometry: self.geometry, material: self.material)
 
@@ -65,6 +66,7 @@ class ImageMeshNode: BaseRenderableNode<Mesh>
         }
         
         self.geometry = PlaneGeometry(context:context,width: 1, height: 1, orientation: .xy)
+//        self.geometry = QuadGeometry(context: context)// PlaneGeometry(context:context,width: 1, height: 1, orientation: .xy)
         self.material = BasicTextureMaterial(context:context)
         self.mesh = Mesh(context:context, geometry: self.geometry, material: self.material)
 
@@ -111,13 +113,13 @@ class ImageMeshNode: BaseRenderableNode<Mesh>
 
             if self.inputSizingDimension.value == "Height"
             {
-                self.geometry.height = size
-                self.geometry.width = size * aspect
+                self.mesh.scale.y = size
+                self.mesh.scale.x = size * aspect
             }
             else
             {
-                self.geometry.width = size
-                self.geometry.height = size / aspect
+                self.mesh.scale.x = size
+                self.mesh.scale.y = size / aspect
             }
         }
 

--- a/Fabric/Nodes/Parameters/Orientation/ComposeOrientationNode.swift
+++ b/Fabric/Nodes/Parameters/Orientation/ComposeOrientationNode.swift
@@ -116,7 +116,7 @@ public class ComposeOrientationNode: StrategyNode
             let up = simd_quatf.upDirection(from: inputUpOrientation.value ?? simd_float4(0, 0, 0, 1))
             let offset = simd_quatf(safeVector: inputAimOffset.value ?? simd_float4(0, 0, 0, 1))
 
-            let look = simd_quatf(lookingAlong: position - target , up: up)
+            let look = simd_quatf(lookingAlong: target - position, up: up)
             outputOrientation.send((look * offset).vector)
 
         default:

--- a/Fabric/Nodes/Parameters/Orientation/ComposeOrientationNode.swift
+++ b/Fabric/Nodes/Parameters/Orientation/ComposeOrientationNode.swift
@@ -116,7 +116,7 @@ public class ComposeOrientationNode: StrategyNode
             let up = simd_quatf.upDirection(from: inputUpOrientation.value ?? simd_float4(0, 0, 0, 1))
             let offset = simd_quatf(safeVector: inputAimOffset.value ?? simd_float4(0, 0, 0, 1))
 
-            let look = simd_quatf(lookingAlong: target - position, up: up)
+            let look = simd_quatf(lookingAlong: position - target , up: up)
             outputOrientation.send((look * offset).vector)
 
         default:

--- a/Fabric/Nodes/Utility/JavaScriptNode.swift
+++ b/Fabric/Nodes/Utility/JavaScriptNode.swift
@@ -105,9 +105,9 @@ private protocol JavaScriptOpaqueValueBoxing
 {
     var type: String { get }
     var handleID: String { get }
-    var width: Int { get }
-    var height: Int { get }
-    var isFlipped: Bool { get }
+    var width: Double { get }
+    var height: Double { get }
+    var textureTransform: [Double] { get }
     var pixelFormat: String { get }
 }
 
@@ -122,9 +122,17 @@ private protocol JavaScriptOpaqueValueBoxing
 
     var type: String { "Image" }
     var handleID: String { image.id.uuidString }
-    var width: Int { image.texture.width }
-    var height: Int { image.texture.height }
-    var isFlipped: Bool { image.isFlipped }
+    var width: Double { image.presentationSize.width }
+    var height: Double { image.presentationSize.height }
+    var textureTransform: [Double] {
+        let matrix = image.textureTransform
+        return [
+            Double(matrix.columns.0.x), Double(matrix.columns.0.y), Double(matrix.columns.0.z), Double(matrix.columns.0.w),
+            Double(matrix.columns.1.x), Double(matrix.columns.1.y), Double(matrix.columns.1.z), Double(matrix.columns.1.w),
+            Double(matrix.columns.2.x), Double(matrix.columns.2.y), Double(matrix.columns.2.z), Double(matrix.columns.2.w),
+            Double(matrix.columns.3.x), Double(matrix.columns.3.y), Double(matrix.columns.3.z), Double(matrix.columns.3.w),
+        ]
+    }
     var pixelFormat: String { String(describing: image.texture.pixelFormat) }
     var boxedPortValue: PortValue { .Image(image) }
 }

--- a/Fabric/Shaders/FabricImageTextureTransform.metal
+++ b/Fabric/Shaders/FabricImageTextureTransform.metal
@@ -1,0 +1,17 @@
+#ifndef FABRIC_IMAGE_TEXTURE_TRANSFORM_METAL
+#define FABRIC_IMAGE_TEXTURE_TRANSFORM_METAL
+
+#include <metal_stdlib>
+using namespace metal;
+
+inline float2 fabricTextureCoordinate(float4x4 textureTransform, float2 coordinate)
+{
+    return (textureTransform * float4(coordinate, 0.0, 1.0)).xy;
+}
+
+inline float2 fabricPresentationSize(float4x4 textureTransform, float2 textureSize)
+{
+    return abs((textureTransform * float4(textureSize, 0.0, 0.0)).xy);
+}
+
+#endif

--- a/Fabric/Shaders/GaussianBlurChannelsShader.metal
+++ b/Fabric/Shaders/GaussianBlurChannelsShader.metal
@@ -1,6 +1,7 @@
 using namespace metal;
 
 #include <metal_stdlib>
+#include "FabricImageTextureTransform.metal"
 
 typedef struct {
     float redAmount; // slider, 0.0, 50.0, 0.0, Red Amount
@@ -16,14 +17,15 @@ struct GaussianPassUniforms {
 
 static inline half4 weightedSamples(texture2d<half, access::sample> renderTex,
                                     sampler linearSampler,
+                                    float4x4 textureTransform,
                                     float2 uv,
                                     float2 blurStep)
 {
-    half4 sample0 = renderTex.sample(linearSampler, uv);
-    half4 sample1 = renderTex.sample(linearSampler, uv - blurStep * 0.5f);
-    half4 sample2 = renderTex.sample(linearSampler, uv + blurStep * 0.5f);
-    half4 sample3 = renderTex.sample(linearSampler, uv - blurStep);
-    half4 sample4 = renderTex.sample(linearSampler, uv + blurStep);
+    half4 sample0 = renderTex.sample(linearSampler, fabricTextureCoordinate(textureTransform, uv));
+    half4 sample1 = renderTex.sample(linearSampler, fabricTextureCoordinate(textureTransform, uv - blurStep * 0.5f));
+    half4 sample2 = renderTex.sample(linearSampler, fabricTextureCoordinate(textureTransform, uv + blurStep * 0.5f));
+    half4 sample3 = renderTex.sample(linearSampler, fabricTextureCoordinate(textureTransform, uv - blurStep));
+    half4 sample4 = renderTex.sample(linearSampler, fabricTextureCoordinate(textureTransform, uv + blurStep));
 
     return sample0 * 0.40262h +
            sample1 * 0.24420h +
@@ -36,27 +38,29 @@ fragment half4 postFragment(VertexData in [[stage_in]],
                             constant PostUniforms &uniforms [[buffer(FragmentBufferMaterialUniforms)]],
                             texture2d<half, access::sample> renderTex [[texture(FragmentTextureCustom0)]],
                             texture2d<half, access::sample> originalTex [[texture(FragmentTextureCustom1)]],
-                            constant GaussianPassUniforms &passUniforms [[buffer(FragmentBufferCustom0)]])
+                            constant GaussianPassUniforms &passUniforms [[buffer(FragmentBufferCustom0)]],
+                            constant float4x4 *textureTransforms [[buffer(FragmentBufferCustom10)]])
 {
     constexpr sampler linearSampler(coord::normalized,
                                     address::clamp_to_edge,
                                     min_filter::linear,
                                     mag_filter::linear);
 
-    const float2 texelSize = 1.0f / float2(renderTex.get_width(), renderTex.get_height());
+    const float2 textureSize = float2(renderTex.get_width(), renderTex.get_height());
+    const float2 texelSize = 1.0f / fabricPresentationSize(textureTransforms[0], textureSize);
     const float2 scaledDirection = texelSize * passUniforms.direction * passUniforms.amountScale;
     const float2 uv = in.texcoord;
-    half4 original = originalTex.sample(linearSampler, uv);
+    half4 original = originalTex.sample(linearSampler, fabricTextureCoordinate(textureTransforms[1], uv));
 
     half red = uniforms.redAmount <= 0.0001f
         ? original.r
-        : weightedSamples(renderTex, linearSampler, uv, scaledDirection * uniforms.redAmount).r;
+        : weightedSamples(renderTex, linearSampler, textureTransforms[0], uv, scaledDirection * uniforms.redAmount).r;
     half green = uniforms.greenAmount <= 0.0001f
         ? original.g
-        : weightedSamples(renderTex, linearSampler, uv, scaledDirection * uniforms.greenAmount).g;
+        : weightedSamples(renderTex, linearSampler, textureTransforms[0], uv, scaledDirection * uniforms.greenAmount).g;
     half blue = uniforms.blueAmount <= 0.0001f
         ? original.b
-        : weightedSamples(renderTex, linearSampler, uv, scaledDirection * uniforms.blueAmount).b;
+        : weightedSamples(renderTex, linearSampler, textureTransforms[0], uv, scaledDirection * uniforms.blueAmount).b;
 
     return half4(red, green, blue, original.a);
 }

--- a/Fabric/Shaders/GaussianBlurMaskShader.metal
+++ b/Fabric/Shaders/GaussianBlurMaskShader.metal
@@ -1,6 +1,7 @@
 using namespace metal;
 
 #include <metal_stdlib>
+#include "FabricImageTextureTransform.metal"
 
 typedef struct {
     float amount; // slider, 0.0, 5.0, 0.0, Amount
@@ -16,7 +17,8 @@ fragment half4 postFragment(VertexData in [[stage_in]],
                             constant PostUniforms &uniforms [[buffer(FragmentBufferMaterialUniforms)]],
                             texture2d<half, access::sample> renderTex [[texture(FragmentTextureCustom0)]],
                             texture2d<half, access::sample> renderTex2 [[texture(FragmentTextureCustom1)]],
-                            constant GaussianPassUniforms &passUniforms [[buffer(FragmentBufferCustom0)]])
+                            constant GaussianPassUniforms &passUniforms [[buffer(FragmentBufferCustom0)]],
+                            constant float4x4 *textureTransforms [[buffer(FragmentBufferCustom10)]])
 {
     constexpr sampler linearSampler(coord::normalized,
                                     address::clamp_to_edge,
@@ -25,16 +27,17 @@ fragment half4 postFragment(VertexData in [[stage_in]],
 
 
     
-    const float2 texelSize = 1.0 / float2(renderTex.get_width(), renderTex.get_height());
+    const float2 textureSize = float2(renderTex.get_width(), renderTex.get_height());
+    const float2 texelSize = 1.0 / fabricPresentationSize(textureTransforms[0], textureSize);
     const float2 blurStep = texelSize * passUniforms.direction * (uniforms.amount * passUniforms.amountScale);
 
     const float2 uv = in.texcoord;
 
-    half4 mask = renderTex2.sample(linearSampler, in.texcoord);
+    half4 mask = renderTex2.sample(linearSampler, fabricTextureCoordinate(textureTransforms[1], in.texcoord));
 
-    half4 sample0 = renderTex.sample(linearSampler, uv);
-    half4 sample1 = renderTex.sample(linearSampler, uv - blurStep * mask.r);
-    half4 sample2 = renderTex.sample(linearSampler, uv + blurStep * mask.r);
+    half4 sample0 = renderTex.sample(linearSampler, fabricTextureCoordinate(textureTransforms[0], uv));
+    half4 sample1 = renderTex.sample(linearSampler, fabricTextureCoordinate(textureTransforms[0], uv - blurStep * mask.r));
+    half4 sample2 = renderTex.sample(linearSampler, fabricTextureCoordinate(textureTransforms[0], uv + blurStep * mask.r));
 
     return (sample0 + sample1 + sample2) / 3.0h;
 }

--- a/Fabric/Shaders/GaussianBlurShader.metal
+++ b/Fabric/Shaders/GaussianBlurShader.metal
@@ -1,6 +1,7 @@
 using namespace metal;
 
 #include <metal_stdlib>
+#include "FabricImageTextureTransform.metal"
 
 typedef struct {
     float amount; // slider, 0.0, 50.0, 0.0, Amount
@@ -15,24 +16,26 @@ struct GaussianPassUniforms {
 fragment half4 postFragment(VertexData in [[stage_in]],
                             constant PostUniforms &uniforms [[buffer(FragmentBufferMaterialUniforms)]],
                             texture2d<half, access::sample> renderTex [[texture(FragmentTextureCustom0)]],
-                            constant GaussianPassUniforms &passUniforms [[buffer(FragmentBufferCustom0)]])
+                            constant GaussianPassUniforms &passUniforms [[buffer(FragmentBufferCustom0)]],
+                            constant float4x4 *textureTransforms [[buffer(FragmentBufferCustom10)]])
 {
     constexpr sampler linearSampler(coord::normalized,
                                     address::clamp_to_edge,
                                     min_filter::linear,
                                     mag_filter::linear);
 
-    const float2 texelSize = 1.0 / float2(renderTex.get_width(), renderTex.get_height());
+    const float2 textureSize = float2(renderTex.get_width(), renderTex.get_height());
+    const float2 texelSize = 1.0 / fabricPresentationSize(textureTransforms[0], textureSize);
     const float2 blurStep = texelSize * passUniforms.direction * (uniforms.amount * passUniforms.amountScale);
 
     const float2 uv = in.texcoord;
 
     // 5 tap
-    half4 sample0 = renderTex.sample(linearSampler, uv);
-    half4 sample1 = renderTex.sample(linearSampler, uv - blurStep * 0.5);
-    half4 sample2 = renderTex.sample(linearSampler, uv + blurStep * 0.5);
-    half4 sample3 = renderTex.sample(linearSampler, uv - blurStep);
-    half4 sample4 = renderTex.sample(linearSampler, uv + blurStep);
+    half4 sample0 = renderTex.sample(linearSampler, fabricTextureCoordinate(textureTransforms[0], uv));
+    half4 sample1 = renderTex.sample(linearSampler, fabricTextureCoordinate(textureTransforms[0], uv - blurStep * 0.5));
+    half4 sample2 = renderTex.sample(linearSampler, fabricTextureCoordinate(textureTransforms[0], uv + blurStep * 0.5));
+    half4 sample3 = renderTex.sample(linearSampler, fabricTextureCoordinate(textureTransforms[0], uv - blurStep));
+    half4 sample4 = renderTex.sample(linearSampler, fabricTextureCoordinate(textureTransforms[0], uv + blurStep));
     return (sample0 * 0.40262 + sample1 * 0.24420 + sample2 * 0.24420 + sample3 * 0.05449 + sample4 * 0.05449);
 
     // 3 tap

--- a/Fabric/Shaders/KeypointDistortShader.metal
+++ b/Fabric/Shaders/KeypointDistortShader.metal
@@ -11,6 +11,7 @@ using namespace metal;
 #define SAMPLER_TYPE texture2d<half>
 
 #include "../lygia/sampler.msl"
+#include "FabricImageTextureTransform.metal"
 
 // Input Uniform Buffer Struct type for our 2 Keypoint Buffers
 struct KeypointUV {
@@ -27,7 +28,8 @@ fragment half4 postFragment( VertexData in [[stage_in]],
                             texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]],
                             constant KeypointUV* origKP   [[ buffer( FragmentBufferCustom0 )]],
                             constant KeypointUV* newKP    [[ buffer( FragmentBufferCustom1 )]],
-                            constant uint* count           [[ buffer( FragmentBufferCustom2 ) ]]
+                            constant uint* count           [[ buffer( FragmentBufferCustom2 ) ]],
+                            constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]]
 )
 {
     float2 uv = in.texcoord;
@@ -72,7 +74,5 @@ fragment half4 postFragment( VertexData in [[stage_in]],
     
     float2 finalUV =  mix(uv, uv + disp, uniforms.amount);
     
-    return half4(finalUV.x, finalUV.y, length(disp), 1.0);
-    
-    return SAMPLER_FNC( renderTex, finalUV );
+    return SAMPLER_FNC(renderTex, fabricTextureCoordinate(imageTransforms[0], finalUV));
 }

--- a/Fabric/Shaders/LUTShader.metal
+++ b/Fabric/Shaders/LUTShader.metal
@@ -9,6 +9,7 @@
 #define SAMPLER_TYPE texture2d<half>
 
 #include "../lygia/sampler.msl"
+#include "FabricImageTextureTransform.metal"
 
 typedef struct {
     float amount; // slider, 0.0, 2.0, 1.0, Amount
@@ -16,13 +17,14 @@ typedef struct {
 
 fragment half4 postFragment( VertexData in [[stage_in]],
     constant PostUniforms &uniforms [[buffer( FragmentBufferMaterialUniforms )]],
+    constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
     texture2d<half, access::sample> renderTex [[texture( FragmentTextureCustom0 )]],
     texture3d<half, access::sample> lutTex [[texture( FragmentTextureCustom1 )]]
     )
 {
     constexpr sampler s = sampler( min_filter::linear, mag_filter::linear );
 
-    half4 rgba = SAMPLER_FNC(renderTex, in.texcoord);
+    half4 rgba = SAMPLER_FNC(renderTex, fabricTextureCoordinate(imageTransforms[0], in.texcoord));
 
     // Sample the 3D LUT
     half4 lutColor = lutTex.sample(s, float3(rgba.rgb) );

--- a/Fabric/Shaders/LiveEffectDefaultShader.metal
+++ b/Fabric/Shaders/LiveEffectDefaultShader.metal
@@ -14,8 +14,10 @@ typedef struct {
 
 fragment half4 postFragment(VertexData in [[stage_in]],
                             constant PostUniforms &uniforms [[buffer(FragmentBufferMaterialUniforms)]],
+                            constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
                             texture2d<half, access::sample> inputTexture [[texture(FragmentTextureCustom0)]]) {
     constexpr sampler s(address::clamp_to_edge, filter::linear);
-    half4 color = inputTexture.sample(s, in.texcoord);
+    float2 textureCoordinate = (imageTransforms[0] * float4(in.texcoord, 0.0, 1.0)).xy;
+    half4 color = inputTexture.sample(s, textureCoordinate);
     return mix(half4(0.0), color, half(uniforms.amount));
 }

--- a/Fabric/Shaders/MotionBlurShader.metal
+++ b/Fabric/Shaders/MotionBlurShader.metal
@@ -1,7 +1,7 @@
 using namespace metal;
 
 #include <metal_stdlib>
-#include "../lygia/math/radians.msl"
+#include "FabricImageTextureTransform.metal"
 
 typedef struct {
     float amount; // slider, 0.0, 50.0, 0.0, Amount
@@ -15,16 +15,18 @@ struct MotionPassUniforms {
 fragment half4 postFragment(VertexData in [[stage_in]],
                             constant PostUniforms &uniforms [[buffer(FragmentBufferMaterialUniforms)]],
                             texture2d<half, access::sample> renderTex [[texture(FragmentTextureCustom0)]],
-                            constant MotionPassUniforms &passUniforms [[buffer(FragmentBufferCustom0)]])
+                            constant MotionPassUniforms &passUniforms [[buffer(FragmentBufferCustom0)]],
+                            constant float4x4 *textureTransforms [[buffer(FragmentBufferCustom10)]])
 {
     constexpr sampler linearSampler(coord::normalized,
                                     address::clamp_to_edge,
                                     min_filter::linear,
                                     mag_filter::linear);
 
-    const float2 texelSize = 1.0 / float2(renderTex.get_width(), renderTex.get_height());
+    const float2 textureSize = float2(renderTex.get_width(), renderTex.get_height());
+    const float2 texelSize = 1.0 / fabricPresentationSize(textureTransforms[0], textureSize);
 
-    const float theta = radians(uniforms.angle);
+    const float theta = uniforms.angle * 0.017453292519943295f;
     const float2 direction = float2(cos(theta), sin(theta));
 
     const float scaledAmount = uniforms.amount * passUniforms.amountScale;
@@ -36,15 +38,15 @@ fragment half4 postFragment(VertexData in [[stage_in]],
 
     const float2 uv = in.texcoord;
 
-    half4 sample0 = renderTex.sample(linearSampler, uv);
-    half4 sample1 = renderTex.sample(linearSampler, uv + step1);
-    half4 sample2 = renderTex.sample(linearSampler, uv + step2);
-    half4 sample3 = renderTex.sample(linearSampler, uv + step3);
-    half4 sample4 = renderTex.sample(linearSampler, uv + step4);
-    half4 sample5 = renderTex.sample(linearSampler, uv - step1);
-    half4 sample6 = renderTex.sample(linearSampler, uv - step2);
-    half4 sample7 = renderTex.sample(linearSampler, uv - step3);
-    half4 sample8 = renderTex.sample(linearSampler, uv - step4);
+    half4 sample0 = renderTex.sample(linearSampler, fabricTextureCoordinate(textureTransforms[0], uv));
+    half4 sample1 = renderTex.sample(linearSampler, fabricTextureCoordinate(textureTransforms[0], uv + step1));
+    half4 sample2 = renderTex.sample(linearSampler, fabricTextureCoordinate(textureTransforms[0], uv + step2));
+    half4 sample3 = renderTex.sample(linearSampler, fabricTextureCoordinate(textureTransforms[0], uv + step3));
+    half4 sample4 = renderTex.sample(linearSampler, fabricTextureCoordinate(textureTransforms[0], uv + step4));
+    half4 sample5 = renderTex.sample(linearSampler, fabricTextureCoordinate(textureTransforms[0], uv - step1));
+    half4 sample6 = renderTex.sample(linearSampler, fabricTextureCoordinate(textureTransforms[0], uv - step2));
+    half4 sample7 = renderTex.sample(linearSampler, fabricTextureCoordinate(textureTransforms[0], uv - step3));
+    half4 sample8 = renderTex.sample(linearSampler, fabricTextureCoordinate(textureTransforms[0], uv - step4));
 
 //    return (sample0 + sample1 + sample2 + sample3 + sample4 + sample5 + sample6 + sample7 + sample8) / 9.0h;
     return (sample0 * 0.39894 + sample1 * 0.24197 + sample2 * 0.24197 + sample3 * 0.05399 + sample4 * 0.05399 + sample5 * 0.00443 + sample6 * 0.00443 + sample7 * 0.00013+ sample8 * 0.00013);

--- a/Fabric/Shaders/TextureCropShader.metal
+++ b/Fabric/Shaders/TextureCropShader.metal
@@ -1,0 +1,34 @@
+#include <metal_stdlib>
+#include "FabricImageTextureTransform.metal"
+
+using namespace metal;
+
+struct PostUniforms {
+    float unused;
+};
+
+struct CropUniforms {
+    float2 origin;
+    float2 size;
+    float4x4 textureTransform;
+};
+
+fragment half4 postFragment(
+    VertexData in [[stage_in]],
+    constant PostUniforms &uniforms [[buffer(FragmentBufferMaterialUniforms)]],
+    constant CropUniforms &crop [[buffer(FragmentBufferCustom0)]],
+    texture2d<half, access::sample> sourceTexture [[texture(FragmentTextureCustom0)]])
+{
+    constexpr sampler sourceSampler(
+        coord::normalized,
+        address::clamp_to_edge,
+        min_filter::linear,
+        mag_filter::linear
+    );
+    const float2 presentationCoordinate = crop.origin + in.texcoord * crop.size;
+    const float2 storedCoordinate = fabricTextureCoordinate(
+        crop.textureTransform,
+        presentationCoordinate
+    );
+    return sourceTexture.sample(sourceSampler, storedCoordinate);
+}

--- a/Fabric/Shaders/ZoomBlurShader.metal
+++ b/Fabric/Shaders/ZoomBlurShader.metal
@@ -1,6 +1,7 @@
 using namespace metal;
 
 #include <metal_stdlib>
+#include "FabricImageTextureTransform.metal"
 
 typedef struct {
     float amount; // slider, 0.0, 50.0, 0.0, Amount
@@ -14,7 +15,8 @@ struct ZoomPassUniforms {
 fragment half4 postFragment(VertexData in [[stage_in]],
                             constant PostUniforms &uniforms [[buffer(FragmentBufferMaterialUniforms)]],
                             texture2d<half, access::sample> renderTex [[texture(FragmentTextureCustom0)]],
-                            constant ZoomPassUniforms &passUniforms [[buffer(FragmentBufferCustom0)]])
+                            constant ZoomPassUniforms &passUniforms [[buffer(FragmentBufferCustom0)]],
+                            constant float4x4 *textureTransforms [[buffer(FragmentBufferCustom10)]])
 {
     constexpr sampler linearSampler(coord::normalized,
                                     address::clamp_to_edge,
@@ -27,7 +29,8 @@ fragment half4 postFragment(VertexData in [[stage_in]],
 
     const float2 destination = uv - origin;
 
-    const float2 texelSize = 1.0 / float2(renderTex.get_width(), renderTex.get_height());
+    const float2 textureSize = float2(renderTex.get_width(), renderTex.get_height());
+    const float2 texelSize = 1.0 / fabricPresentationSize(textureTransforms[0], textureSize);
 //    const float2 off = (destination * (amount + 1.0)) / (texSize * (amount + 1.0) );//    const float2 off = 1.0;//' / texSize;
 
     const float scaledAmount = uniforms.amount * passUniforms.amountScale * length(texelSize);
@@ -37,15 +40,15 @@ fragment half4 postFragment(VertexData in [[stage_in]],
     const float2 step3 = destination * (scaledAmount / 2.0) ;
     const float2 step4 = destination * (scaledAmount / 1.0) ;
 
-    half4 sample0 = renderTex.sample(linearSampler, uv);
-    half4 sample1 = renderTex.sample(linearSampler, destination + step1 + origin);
-    half4 sample2 = renderTex.sample(linearSampler, destination - step1 + origin);
-    half4 sample3 = renderTex.sample(linearSampler, destination + step2 + origin);
-    half4 sample4 = renderTex.sample(linearSampler, destination - step2 + origin);
-    half4 sample5 = renderTex.sample(linearSampler, destination + step3 + origin);
-    half4 sample6 = renderTex.sample(linearSampler, destination - step3 + origin);
-    half4 sample7 = renderTex.sample(linearSampler, destination + step4 + origin);
-    half4 sample8 = renderTex.sample(linearSampler, destination - step4 + origin);
+    half4 sample0 = renderTex.sample(linearSampler, fabricTextureCoordinate(textureTransforms[0], uv));
+    half4 sample1 = renderTex.sample(linearSampler, fabricTextureCoordinate(textureTransforms[0], destination + step1 + origin));
+    half4 sample2 = renderTex.sample(linearSampler, fabricTextureCoordinate(textureTransforms[0], destination - step1 + origin));
+    half4 sample3 = renderTex.sample(linearSampler, fabricTextureCoordinate(textureTransforms[0], destination + step2 + origin));
+    half4 sample4 = renderTex.sample(linearSampler, fabricTextureCoordinate(textureTransforms[0], destination - step2 + origin));
+    half4 sample5 = renderTex.sample(linearSampler, fabricTextureCoordinate(textureTransforms[0], destination + step3 + origin));
+    half4 sample6 = renderTex.sample(linearSampler, fabricTextureCoordinate(textureTransforms[0], destination - step3 + origin));
+    half4 sample7 = renderTex.sample(linearSampler, fabricTextureCoordinate(textureTransforms[0], destination + step4 + origin));
+    half4 sample8 = renderTex.sample(linearSampler, fabricTextureCoordinate(textureTransforms[0], destination - step4 + origin));
 
     
 //    half4 sample0 = renderTex.sample(linearSampler, destination + off + origin);

--- a/Fabric/Views/Nodes/LiveCode/JavaScriptLanguageService.swift
+++ b/Fabric/Views/Nodes/LiveCode/JavaScriptLanguageService.swift
@@ -169,7 +169,7 @@ final class JavaScriptLanguageService: LanguageService
         .init(label: "handleID", insertText: "handleID", documentation: "Stable handle identity for the current image.", kind: .property, priority: 500),
         .init(label: "width", insertText: "width", documentation: "Image width in pixels.", kind: .property, priority: 500),
         .init(label: "height", insertText: "height", documentation: "Image height in pixels.", kind: .property, priority: 500),
-        .init(label: "isFlipped", insertText: "isFlipped", documentation: "Whether the image is vertically flipped.", kind: .property, priority: 500),
+        .init(label: "textureTransform", insertText: "textureTransform", documentation: "Column-major texture-coordinate transform matrix.", kind: .property, priority: 500),
         .init(label: "pixelFormat", insertText: "pixelFormat", documentation: "Metal pixel format name.", kind: .property, priority: 500),
     ]
 

--- a/Tests/GraphExecutionTestSupport.swift
+++ b/Tests/GraphExecutionTestSupport.swift
@@ -67,6 +67,7 @@ struct GraphExecutionTestHarness
                 deltaTime: deltaTime,
                 displayTime: time,
                 systemTime: systemTime ?? time,
+                hostMediaTime: systemTime ?? time,
                 frameNumber: frameNumber
             ),
             iterationInfo: nil,

--- a/Tests/GraphExecutionTests.swift
+++ b/Tests/GraphExecutionTests.swift
@@ -116,31 +116,23 @@ struct GraphExecutionTests {
         let sourceSize = CGSize(width: 1920, height: 1080)
         let verticalFlip = CGAffineTransform(a: 1, b: 0, c: 0, d: -1, tx: 0, ty: sourceSize.height)
 
-        let textureTransform = FabricImageTextureTransform.sourceToPresentation(
-            verticalFlip,
-            sourceSize: sourceSize
-        )
+        let textureTransform = FabricImageTextureTransform.sourceToPresentation(verticalFlip,
+                                                                                sourceSize: sourceSize)
 
         expectEqual(textureTransform, .textureVerticalFlip)
 
-        let clockwiseQuarterTurn = CGAffineTransform(
-            a: 0,
-            b: 1,
-            c: -1,
-            d: 0,
-            tx: sourceSize.height,
-            ty: 0
-        )
-        let rotatedTextureTransform = FabricImageTextureTransform.sourceToPresentation(
-            clockwiseQuarterTurn,
-            sourceSize: sourceSize
-        )
-        let expectedRotatedTextureTransform = simd_float4x4(
-            simd_float4(0, -1, 0, 0),
-            simd_float4(1, 0, 0, 0),
-            simd_float4(0, 0, 1, 0),
-            simd_float4(0, 1, 0, 1)
-        )
+        let clockwiseQuarterTurn = CGAffineTransform(a: 0,
+                                                     b: 1,
+                                                     c: -1,
+                                                     d: 0,
+                                                     tx: sourceSize.height,
+                                                     ty: 0)
+        let rotatedTextureTransform = FabricImageTextureTransform.sourceToPresentation(clockwiseQuarterTurn,
+                                                                                       sourceSize: sourceSize)
+        let expectedRotatedTextureTransform = simd_float4x4(simd_float4(0, -1, 0, 0),
+                                                            simd_float4(1, 0, 0, 0),
+                                                            simd_float4(0, 0, 1, 0),
+                                                            simd_float4(0, 1, 0, 1))
         expectEqual(rotatedTextureTransform, expectedRotatedTextureTransform)
     }
 
@@ -148,12 +140,10 @@ struct GraphExecutionTests {
     func presentationCIImageUsesTextureTransform() throws {
         guard let harness = GraphExecutionTestHarness(renderWidth: 4, renderHeight: 2) else { return }
         let rotatedImage = try harness.makeImage(width: 4, height: 2)
-        rotatedImage.textureTransform = simd_float4x4(
-            simd_float4(0, -1, 0, 0),
-            simd_float4(1, 0, 0, 0),
-            simd_float4(0, 0, 1, 0),
-            simd_float4(0, 1, 0, 1)
-        )
+        rotatedImage.textureTransform = simd_float4x4(simd_float4(0, -1, 0, 0),
+                                                      simd_float4(1, 0, 0, 0),
+                                                      simd_float4(0, 0, 1, 0),
+                                                      simd_float4(0, 1, 0, 1))
         #expect(rotatedImage.presentationCIImage?.extent == CGRect(x: 0, y: 0, width: 2, height: 4))
     }
 
@@ -195,12 +185,10 @@ struct GraphExecutionTests {
         }
         let sourcePixels = red + blue
         sourcePixels.withUnsafeBytes { bytes in
-            image.texture.replace(
-                region: MTLRegionMake2D(0, 0, 4, 4),
-                mipmapLevel: 0,
-                withBytes: bytes.baseAddress!,
-                bytesPerRow: 4 * 4
-            )
+            image.texture.replace(region: MTLRegionMake2D(0, 0, 4, 4),
+                                  mipmapLevel: 0,
+                                  withBytes: bytes.baseAddress!,
+                                  bytesPerRow: 4 * 4)
         }
         image.textureTransform = .textureVerticalFlip
 
@@ -212,67 +200,55 @@ struct GraphExecutionTests {
         input.send(image, force: true)
 
         try harness.renderer.startExecution(graph: graph)
-        try harness.render(
-            graph: graph,
-            executionInfo: harness.makeExecutionInfo(),
-            drawScene: false
-        )
+        try harness.render(graph: graph,
+                           executionInfo: harness.makeExecutionInfo(),
+                           drawScene: false)
 
         let outputImage = try #require(output.value)
         expectEqual(outputImage.textureTransform, matrix_identity_float4x4)
         #expect(outputImage.texture.width == 4)
         #expect(outputImage.texture.height == 4)
 
-        let readbackDescriptor = MTLTextureDescriptor.texture2DDescriptor(
-            pixelFormat: .bgra8Unorm,
-            width: 4,
-            height: 4,
-            mipmapped: false
-        )
+        let readbackDescriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .bgra8Unorm,
+                                                                          width: 4,
+                                                                          height: 4,
+                                                                          mipmapped: false)
         readbackDescriptor.storageMode = .shared
         let readbackTexture = try #require(harness.context.device.makeTexture(descriptor: readbackDescriptor))
         let readbackCommandBuffer = try #require(harness.renderer.commandQueue.makeCommandBuffer())
         let blitEncoder = try #require(readbackCommandBuffer.makeBlitCommandEncoder())
-        blitEncoder.copy(
-            from: outputImage.texture,
-            sourceSlice: 0,
-            sourceLevel: 0,
-            sourceOrigin: .init(x: 0, y: 0, z: 0),
-            sourceSize: .init(width: 4, height: 4, depth: 1),
-            to: readbackTexture,
-            destinationSlice: 0,
-            destinationLevel: 0,
-            destinationOrigin: .init(x: 0, y: 0, z: 0)
-        )
+        blitEncoder.copy(from: outputImage.texture,
+                         sourceSlice: 0,
+                         sourceLevel: 0,
+                         sourceOrigin: .init(x: 0, y: 0, z: 0),
+                         sourceSize: .init(width: 4, height: 4, depth: 1),
+                         to: readbackTexture,
+                         destinationSlice: 0,
+                         destinationLevel: 0,
+                         destinationOrigin: .init(x: 0, y: 0, z: 0))
         blitEncoder.endEncoding()
         readbackCommandBuffer.commit()
         readbackCommandBuffer.waitUntilCompleted()
 
         var outputPixels = [UInt8](repeating: 0, count: 4 * 4 * 4)
         outputPixels.withUnsafeMutableBytes { bytes in
-            readbackTexture.getBytes(
-                bytes.baseAddress!,
-                bytesPerRow: 4 * 4,
-                from: MTLRegionMake2D(0, 0, 4, 4),
-                mipmapLevel: 0
-            )
+            readbackTexture.getBytes(bytes.baseAddress!,
+                                     bytesPerRow: 4 * 4,
+                                     from: MTLRegionMake2D(0, 0, 4, 4),
+                                     mipmapLevel: 0)
         }
         #expect(Array(outputPixels[0..<4]) == [255, 0, 0, 255])
         #expect(Array(outputPixels[(3 * 4 * 4)..<(3 * 4 * 4 + 4)]) == [0, 0, 255, 255])
 
         let rotatedImage = try harness.makeImage(width: 4, height: 2)
-        rotatedImage.textureTransform = simd_float4x4(
-            simd_float4(0, -1, 0, 0),
-            simd_float4(1, 0, 0, 0),
-            simd_float4(0, 0, 1, 0),
-            simd_float4(0, 1, 0, 1)
-        )
+        rotatedImage.textureTransform = simd_float4x4(simd_float4(0, -1, 0, 0),
+                                                      simd_float4(1, 0, 0, 0),
+                                                      simd_float4(0, 0, 1, 0),
+                                                      simd_float4(0, 1, 0, 1))
         input.send(rotatedImage, force: true)
-        try harness.render(
-            graph: graph,
-            executionInfo: harness.makeExecutionInfo(frameNumber: 1),
-            drawScene: false
-        )
+        try harness.render(graph: graph,
+                           executionInfo: harness.makeExecutionInfo(frameNumber: 1),
+                           drawScene: false)
 
         let rotatedOutputImage = try #require(output.value)
         expectEqual(rotatedOutputImage.textureTransform, matrix_identity_float4x4)
@@ -287,12 +263,10 @@ struct GraphExecutionTests {
         guard let harness = GraphExecutionTestHarness(renderWidth: 2, renderHeight: 4) else { return }
 
         let image = try harness.makeImage(width: 4, height: 2)
-        image.textureTransform = simd_float4x4(
-            simd_float4(0, -1, 0, 0),
-            simd_float4(1, 0, 0, 0),
-            simd_float4(0, 0, 1, 0),
-            simd_float4(0, 1, 0, 1)
-        )
+        image.textureTransform = simd_float4x4(simd_float4(0, -1, 0, 0),
+                                               simd_float4(1, 0, 0, 0),
+                                               simd_float4(0, 0, 1, 0),
+                                               simd_float4(0, 1, 0, 1))
 
         let blurNodes: [BaseImageNode] = [
             GaussianBlurNode(context: harness.context),
@@ -315,11 +289,9 @@ struct GraphExecutionTests {
             }
 
             try harness.renderer.startExecution(graph: graph)
-            try harness.render(
-                graph: graph,
-                executionInfo: harness.makeExecutionInfo(),
-                drawScene: false
-            )
+            try harness.render(graph: graph,
+                               executionInfo: harness.makeExecutionInfo(),
+                               drawScene: false)
 
             let outputImage = try #require(output.value)
             #expect(outputImage.texture.width == 2)
@@ -341,19 +313,15 @@ struct GraphExecutionTests {
             + Array(repeating: redPixel, count: 4).flatMap { $0 }
         sourcePixels.withUnsafeBytes { bytes in
             guard let baseAddress = bytes.baseAddress else { return }
-            image.texture.replace(
-                region: MTLRegionMake2D(0, 0, 4, 2),
-                mipmapLevel: 0,
-                withBytes: baseAddress,
-                bytesPerRow: 4 * 4
-            )
+            image.texture.replace(region: MTLRegionMake2D(0, 0, 4, 2),
+                                  mipmapLevel: 0,
+                                  withBytes: baseAddress,
+                                  bytesPerRow: 4 * 4)
         }
-        image.textureTransform = simd_float4x4(
-            simd_float4(0, -1, 0, 0),
-            simd_float4(1, 0, 0, 0),
-            simd_float4(0, 0, 1, 0),
-            simd_float4(0, 1, 0, 1)
-        )
+        image.textureTransform = simd_float4x4(simd_float4(0, -1, 0, 0),
+                                               simd_float4(1, 0, 0, 0),
+                                               simd_float4(0, 0, 1, 0),
+                                               simd_float4(0, 1, 0, 1))
 
         let cropNode = TextureCropNode(context: harness.context)
         cropNode.inputCropX.value = 0
@@ -376,27 +344,23 @@ struct GraphExecutionTests {
         #expect(outputImage.texture.height == 4)
         expectEqual(outputImage.textureTransform, matrix_identity_float4x4)
 
-        let readbackDescriptor = MTLTextureDescriptor.texture2DDescriptor(
-            pixelFormat: .bgra8Unorm,
-            width: 1,
-            height: 4,
-            mipmapped: false
-        )
+        let readbackDescriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .bgra8Unorm,
+                                                                          width: 1,
+                                                                          height: 4,
+                                                                          mipmapped: false)
         readbackDescriptor.storageMode = .shared
         let readbackTexture = try #require(harness.context.device.makeTexture(descriptor: readbackDescriptor))
         let readbackCommandBuffer = try #require(harness.renderer.commandQueue.makeCommandBuffer())
         let blitEncoder = try #require(readbackCommandBuffer.makeBlitCommandEncoder())
-        blitEncoder.copy(
-            from: outputImage.texture,
-            sourceSlice: 0,
-            sourceLevel: 0,
-            sourceOrigin: .init(x: 0, y: 0, z: 0),
-            sourceSize: .init(width: 1, height: 4, depth: 1),
-            to: readbackTexture,
-            destinationSlice: 0,
-            destinationLevel: 0,
-            destinationOrigin: .init(x: 0, y: 0, z: 0)
-        )
+        blitEncoder.copy(from: outputImage.texture,
+                         sourceSlice: 0,
+                         sourceLevel: 0,
+                         sourceOrigin: .init(x: 0, y: 0, z: 0),
+                         sourceSize: .init(width: 1, height: 4, depth: 1),
+                         to: readbackTexture,
+                         destinationSlice: 0,
+                         destinationLevel: 0,
+                         destinationOrigin: .init(x: 0, y: 0, z: 0))
         blitEncoder.endEncoding()
         readbackCommandBuffer.commit()
         readbackCommandBuffer.waitUntilCompleted()
@@ -404,12 +368,10 @@ struct GraphExecutionTests {
         var outputPixels = [UInt8](repeating: 0, count: 1 * 4 * 4)
         outputPixels.withUnsafeMutableBytes { bytes in
             guard let baseAddress = bytes.baseAddress else { return }
-            readbackTexture.getBytes(
-                baseAddress,
-                bytesPerRow: 4,
-                from: MTLRegionMake2D(0, 0, 1, 4),
-                mipmapLevel: 0
-            )
+            readbackTexture.getBytes(baseAddress,
+                                     bytesPerRow: 4,
+                                     from: MTLRegionMake2D(0, 0, 1, 4),
+                                     mipmapLevel: 0)
         }
         for row in 0..<4 {
             #expect(Array(outputPixels[(row * 4)..<(row * 4 + 4)]) == redPixel)
@@ -463,20 +425,16 @@ struct GraphExecutionTests {
             0, 0, 0, 255, 0, 0, 0, 255,
         ]
         image0Pixels.withUnsafeBytes { bytes in
-            image0.texture.replace(
-                region: MTLRegionMake2D(0, 0, 2, 2),
-                mipmapLevel: 0,
-                withBytes: bytes.baseAddress!,
-                bytesPerRow: 2 * 4
-            )
+            image0.texture.replace(region: MTLRegionMake2D(0, 0, 2, 2),
+                                   mipmapLevel: 0,
+                                   withBytes: bytes.baseAddress!,
+                                   bytesPerRow: 2 * 4)
         }
         image1Pixels.withUnsafeBytes { bytes in
-            image1.texture.replace(
-                region: MTLRegionMake2D(0, 0, 2, 2),
-                mipmapLevel: 0,
-                withBytes: bytes.baseAddress!,
-                bytesPerRow: 2 * 4
-            )
+            image1.texture.replace(region: MTLRegionMake2D(0, 0, 2, 2),
+                                   mipmapLevel: 0,
+                                   withBytes: bytes.baseAddress!,
+                                   bytesPerRow: 2 * 4)
         }
         image0.textureTransform = .textureVerticalFlip
 
@@ -494,39 +452,33 @@ struct GraphExecutionTests {
         let outputImage = try #require(output.value)
         expectEqual(outputImage.textureTransform, matrix_identity_float4x4)
 
-        let readbackDescriptor = MTLTextureDescriptor.texture2DDescriptor(
-            pixelFormat: .bgra8Unorm,
-            width: 2,
-            height: 2,
-            mipmapped: false
-        )
+        let readbackDescriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .bgra8Unorm,
+                                                                          width: 2,
+                                                                          height: 2,
+                                                                          mipmapped: false)
         readbackDescriptor.storageMode = .shared
         let readbackTexture = try #require(harness.context.device.makeTexture(descriptor: readbackDescriptor))
         let readbackCommandBuffer = try #require(harness.renderer.commandQueue.makeCommandBuffer())
         let blitEncoder = try #require(readbackCommandBuffer.makeBlitCommandEncoder())
-        blitEncoder.copy(
-            from: outputImage.texture,
-            sourceSlice: 0,
-            sourceLevel: 0,
-            sourceOrigin: .init(x: 0, y: 0, z: 0),
-            sourceSize: .init(width: 2, height: 2, depth: 1),
-            to: readbackTexture,
-            destinationSlice: 0,
-            destinationLevel: 0,
-            destinationOrigin: .init(x: 0, y: 0, z: 0)
-        )
+        blitEncoder.copy(from: outputImage.texture,
+                         sourceSlice: 0,
+                         sourceLevel: 0,
+                         sourceOrigin: .init(x: 0, y: 0, z: 0),
+                         sourceSize: .init(width: 2, height: 2, depth: 1),
+                         to: readbackTexture,
+                         destinationSlice: 0,
+                         destinationLevel: 0,
+                         destinationOrigin: .init(x: 0, y: 0, z: 0))
         blitEncoder.endEncoding()
         readbackCommandBuffer.commit()
         readbackCommandBuffer.waitUntilCompleted()
 
         var outputPixels = [UInt8](repeating: 0, count: 2 * 2 * 4)
         outputPixels.withUnsafeMutableBytes { bytes in
-            readbackTexture.getBytes(
-                bytes.baseAddress!,
-                bytesPerRow: 2 * 4,
-                from: MTLRegionMake2D(0, 0, 2, 2),
-                mipmapLevel: 0
-            )
+            readbackTexture.getBytes(bytes.baseAddress!,
+                                     bytesPerRow: 2 * 4,
+                                     from: MTLRegionMake2D(0, 0, 2, 2),
+                                     mipmapLevel: 0)
         }
         #expect(Array(outputPixels[0..<4]) == [0, 255, 0, 255])
         #expect(Array(outputPixels[(2 * 2 * 4 - 4)..<(2 * 2 * 4)]) == [0, 0, 255, 255])
@@ -542,12 +494,10 @@ struct GraphExecutionTests {
         let image = try harness.makeImage(width: 16, height: 8)
         #expect(image.presentationSize == CGSize(width: 16, height: 8))
 
-        let clockwiseQuarterTurn = simd_float4x4(
-            simd_float4(0, -1, 0, 0),
-            simd_float4(1, 0, 0, 0),
-            simd_float4(0, 0, 1, 0),
-            simd_float4(0, 1, 0, 1)
-        )
+        let clockwiseQuarterTurn = simd_float4x4(simd_float4(0, -1, 0, 0),
+                                                 simd_float4(1, 0, 0, 0),
+                                                 simd_float4(0, 0, 1, 0),
+                                                 simd_float4(0, 1, 0, 1))
         image.textureTransform = clockwiseQuarterTurn
         #expect(image.presentationSize == CGSize(width: 8, height: 16))
         node.inputImage.value = image
@@ -556,11 +506,9 @@ struct GraphExecutionTests {
         graph.addNode(node)
 
         try harness.renderer.startExecution(graph: graph)
-        try harness.render(
-            graph: graph,
-            executionInfo: harness.makeExecutionInfo(),
-            drawScene: false
-        )
+        try harness.render(graph: graph,
+                           executionInfo: harness.makeExecutionInfo(),
+                           drawScene: false)
         try harness.renderer.stopExecution(graph: graph)
 
         let mesh = try #require(node.getObject() as? Mesh)
@@ -575,12 +523,10 @@ struct GraphExecutionTests {
     func materialImageInputsApplyTextureTransforms() throws {
         guard let harness = GraphExecutionTestHarness() else { return }
 
-        let quarterTurn = simd_float4x4(
-            simd_float4(0, -1, 0, 0),
-            simd_float4(1, 0, 0, 0),
-            simd_float4(0, 0, 1, 0),
-            simd_float4(0, 1, 0, 1)
-        )
+        let quarterTurn = simd_float4x4(simd_float4(0, -1, 0, 0),
+                                        simd_float4(1, 0, 0, 0),
+                                        simd_float4(0, 0, 1, 0),
+                                        simd_float4(0, 1, 0, 1))
         let flippedImage = try harness.makeImage(width: 4, height: 2)
         flippedImage.textureTransform = .textureVerticalFlip
         let rotatedImage = try harness.makeImage(width: 4, height: 2)
@@ -591,18 +537,10 @@ struct GraphExecutionTests {
         standardNode.inputNormalTexture.send(rotatedImage, force: true)
         try harness.execute(standardNode)
 
-        let baseColorTransform = try #require(
-            standardNode.material.parameters.get(
-                PBRTextureType.baseColor.texcoordName.titleCase,
-                as: Float4x4Parameter.self
-            )
-        )
-        let normalTransform = try #require(
-            standardNode.material.parameters.get(
-                PBRTextureType.normal.texcoordName.titleCase,
-                as: Float4x4Parameter.self
-            )
-        )
+        let baseColorTransform = try #require(standardNode.material.parameters.get(PBRTextureType.baseColor.texcoordName.titleCase,
+                                                                                   as: Float4x4Parameter.self))
+        let normalTransform = try #require(standardNode.material.parameters.get(PBRTextureType.normal.texcoordName.titleCase,
+                                                                                as: Float4x4Parameter.self))
         expectEqual(baseColorTransform.value, .textureVerticalFlip)
         expectEqual(normalTransform.value, quarterTurn)
 
@@ -613,24 +551,12 @@ struct GraphExecutionTests {
         pbrNode.inputClearcoatGlossTexture.send(rotatedImage, force: true)
         try harness.execute(pbrNode)
 
-        let bumpTransform = try #require(
-            pbrNode.material.parameters.get(
-                PBRTextureType.bump.texcoordName.titleCase,
-                as: Float4x4Parameter.self
-            )
-        )
-        let transmissionTransform = try #require(
-            pbrNode.material.parameters.get(
-                PBRTextureType.transmission.texcoordName.titleCase,
-                as: Float4x4Parameter.self
-            )
-        )
-        let clearcoatSurfaceTransform = try #require(
-            pbrNode.material.parameters.get(
-                PBRTextureType.clearcoatRoughness.texcoordName.titleCase,
-                as: Float4x4Parameter.self
-            )
-        )
+        let bumpTransform = try #require(pbrNode.material.parameters.get(PBRTextureType.bump.texcoordName.titleCase,
+                                                                         as: Float4x4Parameter.self))
+        let transmissionTransform = try #require(pbrNode.material.parameters.get(PBRTextureType.transmission.texcoordName.titleCase,
+                                                                                 as: Float4x4Parameter.self))
+        let clearcoatSurfaceTransform = try #require(pbrNode.material.parameters.get(PBRTextureType.clearcoatRoughness.texcoordName.titleCase,
+                                                                                    as: Float4x4Parameter.self))
         expectEqual(bumpTransform.value, .textureVerticalFlip)
         expectEqual(transmissionTransform.value, quarterTurn)
         expectEqual(clearcoatSurfaceTransform.value, .textureVerticalFlip)
@@ -641,24 +567,12 @@ struct GraphExecutionTests {
         displacementNode.inputPointSpriteTexture.send(flippedImage, force: true)
         try harness.execute(displacementNode)
 
-        let displacementTransform = try #require(
-            displacementNode.material.parameters.get(
-                "displacementTextureTransform",
-                as: Float4x4Parameter.self
-            )
-        )
-        let colorTransform = try #require(
-            displacementNode.material.parameters.get(
-                "colorTextureTransform",
-                as: Float4x4Parameter.self
-            )
-        )
-        let pointSpriteTransform = try #require(
-            displacementNode.material.parameters.get(
-                "pointSpriteTextureTransform",
-                as: Float4x4Parameter.self
-            )
-        )
+        let displacementTransform = try #require(displacementNode.material.parameters.get("displacementTextureTransform",
+                                                                                           as: Float4x4Parameter.self))
+        let colorTransform = try #require(displacementNode.material.parameters.get("colorTextureTransform",
+                                                                                    as: Float4x4Parameter.self))
+        let pointSpriteTransform = try #require(displacementNode.material.parameters.get("pointSpriteTextureTransform",
+                                                                                          as: Float4x4Parameter.self))
         expectEqual(displacementTransform.value, .textureVerticalFlip)
         expectEqual(colorTransform.value, quarterTurn)
         expectEqual(pointSpriteTransform.value, .textureVerticalFlip)

--- a/Tests/GraphExecutionTests.swift
+++ b/Tests/GraphExecutionTests.swift
@@ -1,6 +1,7 @@
 import Testing
 import Foundation
 import Metal
+import CoreImage
 @testable import Fabric
 import Satin
 
@@ -82,6 +83,14 @@ private func expectEqual(_ lhs: simd_float3x3, _ rhs: simd_float3x3, tolerance: 
     expectEqual(lhs.columns.2, rhs.columns.2, tolerance: tolerance)
 }
 
+private func expectEqual(_ lhs: simd_float4x4, _ rhs: simd_float4x4, tolerance: Float = 0.0001) {
+    for column in 0..<4 {
+        for row in 0..<4 {
+            #expect(abs(lhs[column][row] - rhs[column][row]) <= tolerance)
+        }
+    }
+}
+
 private func roundTripGraphToTemporaryFile(_ graph: Graph, context: Context) throws -> Graph {
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
@@ -102,6 +111,572 @@ private func roundTripGraphToTemporaryFile(_ graph: Graph, context: Context) thr
 
 @Suite("Graph Execution")
 struct GraphExecutionTests {
+    @Test("Texture transforms convert source presentation metadata into sampling coordinates")
+    func textureTransformConvertsPresentationMetadata() {
+        let sourceSize = CGSize(width: 1920, height: 1080)
+        let verticalFlip = CGAffineTransform(a: 1, b: 0, c: 0, d: -1, tx: 0, ty: sourceSize.height)
+
+        let textureTransform = FabricImageTextureTransform.sourceToPresentation(
+            verticalFlip,
+            sourceSize: sourceSize
+        )
+
+        expectEqual(textureTransform, .textureVerticalFlip)
+
+        let clockwiseQuarterTurn = CGAffineTransform(
+            a: 0,
+            b: 1,
+            c: -1,
+            d: 0,
+            tx: sourceSize.height,
+            ty: 0
+        )
+        let rotatedTextureTransform = FabricImageTextureTransform.sourceToPresentation(
+            clockwiseQuarterTurn,
+            sourceSize: sourceSize
+        )
+        let expectedRotatedTextureTransform = simd_float4x4(
+            simd_float4(0, -1, 0, 0),
+            simd_float4(1, 0, 0, 0),
+            simd_float4(0, 0, 1, 0),
+            simd_float4(0, 1, 0, 1)
+        )
+        expectEqual(rotatedTextureTransform, expectedRotatedTextureTransform)
+    }
+
+    @Test("Presentation CI images use the Fabric image transform")
+    func presentationCIImageUsesTextureTransform() throws {
+        guard let harness = GraphExecutionTestHarness(renderWidth: 4, renderHeight: 2) else { return }
+        let rotatedImage = try harness.makeImage(width: 4, height: 2)
+        rotatedImage.textureTransform = simd_float4x4(
+            simd_float4(0, -1, 0, 0),
+            simd_float4(1, 0, 0, 0),
+            simd_float4(0, 0, 1, 0),
+            simd_float4(0, 1, 0, 1)
+        )
+        #expect(rotatedImage.presentationCIImage?.extent == CGRect(x: 0, y: 0, width: 2, height: 4))
+    }
+
+    @Test("Transform-aware Base Image effects consume transforms into identity output")
+    func transformAwareBaseImageEffectConsumesTransform() throws {
+        guard let harness = GraphExecutionTestHarness(renderWidth: 4, renderHeight: 4) else { return }
+
+        let shaderURL = FileManager.default.temporaryDirectory
+            .appending(path: "Texture Transform Validation \(UUID().uuidString).metal")
+        let shaderSource = """
+        typedef struct {
+            float unused;
+        } PostUniforms;
+
+        fragment half4 postFragment(
+            VertexData in [[stage_in]],
+            constant PostUniforms &uniforms [[buffer(FragmentBufferMaterialUniforms)]],
+            constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
+            texture2d<half, access::sample> imageTexture [[texture(FragmentTextureCustom0)]])
+        {
+            constexpr sampler imageSampler(min_filter::nearest, mag_filter::nearest);
+            const float2 imageUV = (imageTransforms[0] * float4(in.texcoord, 0.0, 1.0)).xy;
+            return imageTexture.sample(imageSampler, imageUV);
+        }
+        """
+        try shaderSource.write(to: shaderURL, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: shaderURL) }
+
+        let node = try BaseImageNode(context: harness.context, fileURL: shaderURL)
+        let input = try imagePort(named: "Image", kind: .Inlet, on: node)
+        let output = try imagePort(named: "Image", kind: .Outlet, on: node)
+
+        let image = try harness.makeImage(width: 4, height: 4)
+        let red = [UInt8](repeating: 0, count: 4 * 2 * 4).enumerated().map { index, _ in
+            [UInt8(0), 0, 255, 255][index % 4]
+        }
+        let blue = [UInt8](repeating: 0, count: 4 * 2 * 4).enumerated().map { index, _ in
+            [UInt8(255), 0, 0, 255][index % 4]
+        }
+        let sourcePixels = red + blue
+        sourcePixels.withUnsafeBytes { bytes in
+            image.texture.replace(
+                region: MTLRegionMake2D(0, 0, 4, 4),
+                mipmapLevel: 0,
+                withBytes: bytes.baseAddress!,
+                bytesPerRow: 4 * 4
+            )
+        }
+        image.textureTransform = .textureVerticalFlip
+
+        let graph = Graph(context: harness.context)
+        let imageMesh = ImageMeshNode(context: harness.context)
+        graph.addNode(node)
+        graph.addNode(imageMesh)
+        graph.connect(output, to: imageMesh.inputImage)
+        input.send(image, force: true)
+
+        try harness.renderer.startExecution(graph: graph)
+        try harness.render(
+            graph: graph,
+            executionInfo: harness.makeExecutionInfo(),
+            drawScene: false
+        )
+
+        let outputImage = try #require(output.value)
+        expectEqual(outputImage.textureTransform, matrix_identity_float4x4)
+        #expect(outputImage.texture.width == 4)
+        #expect(outputImage.texture.height == 4)
+
+        let readbackDescriptor = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .bgra8Unorm,
+            width: 4,
+            height: 4,
+            mipmapped: false
+        )
+        readbackDescriptor.storageMode = .shared
+        let readbackTexture = try #require(harness.context.device.makeTexture(descriptor: readbackDescriptor))
+        let readbackCommandBuffer = try #require(harness.renderer.commandQueue.makeCommandBuffer())
+        let blitEncoder = try #require(readbackCommandBuffer.makeBlitCommandEncoder())
+        blitEncoder.copy(
+            from: outputImage.texture,
+            sourceSlice: 0,
+            sourceLevel: 0,
+            sourceOrigin: .init(x: 0, y: 0, z: 0),
+            sourceSize: .init(width: 4, height: 4, depth: 1),
+            to: readbackTexture,
+            destinationSlice: 0,
+            destinationLevel: 0,
+            destinationOrigin: .init(x: 0, y: 0, z: 0)
+        )
+        blitEncoder.endEncoding()
+        readbackCommandBuffer.commit()
+        readbackCommandBuffer.waitUntilCompleted()
+
+        var outputPixels = [UInt8](repeating: 0, count: 4 * 4 * 4)
+        outputPixels.withUnsafeMutableBytes { bytes in
+            readbackTexture.getBytes(
+                bytes.baseAddress!,
+                bytesPerRow: 4 * 4,
+                from: MTLRegionMake2D(0, 0, 4, 4),
+                mipmapLevel: 0
+            )
+        }
+        #expect(Array(outputPixels[0..<4]) == [255, 0, 0, 255])
+        #expect(Array(outputPixels[(3 * 4 * 4)..<(3 * 4 * 4 + 4)]) == [0, 0, 255, 255])
+
+        let rotatedImage = try harness.makeImage(width: 4, height: 2)
+        rotatedImage.textureTransform = simd_float4x4(
+            simd_float4(0, -1, 0, 0),
+            simd_float4(1, 0, 0, 0),
+            simd_float4(0, 0, 1, 0),
+            simd_float4(0, 1, 0, 1)
+        )
+        input.send(rotatedImage, force: true)
+        try harness.render(
+            graph: graph,
+            executionInfo: harness.makeExecutionInfo(frameNumber: 1),
+            drawScene: false
+        )
+
+        let rotatedOutputImage = try #require(output.value)
+        expectEqual(rotatedOutputImage.textureTransform, matrix_identity_float4x4)
+        #expect(rotatedOutputImage.texture.width == 2)
+        #expect(rotatedOutputImage.texture.height == 4)
+
+        try harness.renderer.stopExecution(graph: graph)
+    }
+
+    @Test("Multi-pass blur consumes input transforms into presentation-sized identity output")
+    func multiPassBlurConsumesTransform() throws {
+        guard let harness = GraphExecutionTestHarness(renderWidth: 2, renderHeight: 4) else { return }
+
+        let image = try harness.makeImage(width: 4, height: 2)
+        image.textureTransform = simd_float4x4(
+            simd_float4(0, -1, 0, 0),
+            simd_float4(1, 0, 0, 0),
+            simd_float4(0, 0, 1, 0),
+            simd_float4(0, 1, 0, 1)
+        )
+
+        let blurNodes: [BaseImageNode] = [
+            GaussianBlurNode(context: harness.context),
+            GaussianBlurMaskNode(context: harness.context),
+            GaussianBlurChannelsNode(context: harness.context),
+            MotionBlurNode(context: harness.context),
+            ZoomBlurNode(context: harness.context),
+        ]
+
+        for blurNode in blurNodes {
+            let output = try imagePort(named: "Image", kind: .Outlet, on: blurNode)
+            let graph = Graph(context: harness.context)
+            let imageMesh = ImageMeshNode(context: harness.context)
+            graph.addNode(blurNode)
+            graph.addNode(imageMesh)
+            graph.connect(output, to: imageMesh.inputImage)
+
+            for input in blurNode.imageInputPorts() {
+                input.send(image, force: true)
+            }
+
+            try harness.renderer.startExecution(graph: graph)
+            try harness.render(
+                graph: graph,
+                executionInfo: harness.makeExecutionInfo(),
+                drawScene: false
+            )
+
+            let outputImage = try #require(output.value)
+            #expect(outputImage.texture.width == 2)
+            #expect(outputImage.texture.height == 4)
+            expectEqual(outputImage.textureTransform, matrix_identity_float4x4)
+
+            try harness.renderer.stopExecution(graph: graph)
+        }
+    }
+
+    @Test("Texture Crop uses presentation coordinates and returns identity output")
+    func textureCropUsesPresentationCoordinates() throws {
+        guard let harness = GraphExecutionTestHarness(renderWidth: 1, renderHeight: 4) else { return }
+
+        let image = try harness.makeImage(width: 4, height: 2)
+        let bluePixel: [UInt8] = [255, 0, 0, 255]
+        let redPixel: [UInt8] = [0, 0, 255, 255]
+        let sourcePixels = Array(repeating: bluePixel, count: 4).flatMap { $0 }
+            + Array(repeating: redPixel, count: 4).flatMap { $0 }
+        sourcePixels.withUnsafeBytes { bytes in
+            guard let baseAddress = bytes.baseAddress else { return }
+            image.texture.replace(
+                region: MTLRegionMake2D(0, 0, 4, 2),
+                mipmapLevel: 0,
+                withBytes: baseAddress,
+                bytesPerRow: 4 * 4
+            )
+        }
+        image.textureTransform = simd_float4x4(
+            simd_float4(0, -1, 0, 0),
+            simd_float4(1, 0, 0, 0),
+            simd_float4(0, 0, 1, 0),
+            simd_float4(0, 1, 0, 1)
+        )
+
+        let cropNode = TextureCropNode(context: harness.context)
+        cropNode.inputCropX.value = 0
+        cropNode.inputCropY.value = 0
+        cropNode.inputCropWidth.value = 1
+        cropNode.inputCropHeight.value = 4
+        cropNode.inputTexture.send(image, force: true)
+
+        let graph = Graph(context: harness.context)
+        let imageMesh = ImageMeshNode(context: harness.context)
+        graph.addNode(cropNode)
+        graph.addNode(imageMesh)
+        graph.connect(cropNode.outputTexture, to: imageMesh.inputImage)
+
+        try harness.renderer.startExecution(graph: graph)
+        try harness.render(graph: graph, executionInfo: harness.makeExecutionInfo(), drawScene: false)
+
+        let outputImage = try #require(cropNode.outputTexture.value)
+        #expect(outputImage.texture.width == 1)
+        #expect(outputImage.texture.height == 4)
+        expectEqual(outputImage.textureTransform, matrix_identity_float4x4)
+
+        let readbackDescriptor = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .bgra8Unorm,
+            width: 1,
+            height: 4,
+            mipmapped: false
+        )
+        readbackDescriptor.storageMode = .shared
+        let readbackTexture = try #require(harness.context.device.makeTexture(descriptor: readbackDescriptor))
+        let readbackCommandBuffer = try #require(harness.renderer.commandQueue.makeCommandBuffer())
+        let blitEncoder = try #require(readbackCommandBuffer.makeBlitCommandEncoder())
+        blitEncoder.copy(
+            from: outputImage.texture,
+            sourceSlice: 0,
+            sourceLevel: 0,
+            sourceOrigin: .init(x: 0, y: 0, z: 0),
+            sourceSize: .init(width: 1, height: 4, depth: 1),
+            to: readbackTexture,
+            destinationSlice: 0,
+            destinationLevel: 0,
+            destinationOrigin: .init(x: 0, y: 0, z: 0)
+        )
+        blitEncoder.endEncoding()
+        readbackCommandBuffer.commit()
+        readbackCommandBuffer.waitUntilCompleted()
+
+        var outputPixels = [UInt8](repeating: 0, count: 1 * 4 * 4)
+        outputPixels.withUnsafeMutableBytes { bytes in
+            guard let baseAddress = bytes.baseAddress else { return }
+            readbackTexture.getBytes(
+                baseAddress,
+                bytesPerRow: 4,
+                from: MTLRegionMake2D(0, 0, 1, 4),
+                mipmapLevel: 0
+            )
+        }
+        for row in 0..<4 {
+            #expect(Array(outputPixels[(row * 4)..<(row * 4 + 4)]) == redPixel)
+        }
+
+        try harness.renderer.stopExecution(graph: graph)
+    }
+
+    @Test("Each Base Image input uses its own texture transform")
+    func multiInputBaseImageEffectUsesIndependentTextureTransforms() throws {
+        guard let harness = GraphExecutionTestHarness(renderWidth: 2, renderHeight: 2) else { return }
+
+        let shaderURL = FileManager.default.temporaryDirectory
+            .appending(path: "Multi Input Texture Transform Validation \(UUID().uuidString).metal")
+        let shaderSource = """
+        typedef struct {
+            float unused;
+        } PostUniforms;
+
+        fragment half4 postFragment(
+            VertexData in [[stage_in]],
+            constant PostUniforms &uniforms [[buffer(FragmentBufferMaterialUniforms)]],
+            constant float4x4 *imageTransforms [[buffer(FragmentBufferCustom10)]],
+            texture2d<half, access::sample> imageTexture0 [[texture(FragmentTextureCustom0)]],
+            texture2d<half, access::sample> imageTexture1 [[texture(FragmentTextureCustom1)]])
+        {
+            constexpr sampler imageSampler(min_filter::nearest, mag_filter::nearest);
+            const float2 imageUV0 = (imageTransforms[0] * float4(in.texcoord, 0.0, 1.0)).xy;
+            const float2 imageUV1 = (imageTransforms[1] * float4(in.texcoord, 0.0, 1.0)).xy;
+            const half4 color0 = imageTexture0.sample(imageSampler, imageUV0);
+            const half4 color1 = imageTexture1.sample(imageSampler, imageUV1);
+            return half4(color0.r, color1.g, 0.0h, 1.0h);
+        }
+        """
+        try shaderSource.write(to: shaderURL, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: shaderURL) }
+
+        let node = try BaseImageNode(context: harness.context, fileURL: shaderURL)
+        let input0 = try imagePort(named: "Image", kind: .Inlet, on: node)
+        let input1 = try imagePort(named: "Image 2", kind: .Inlet, on: node)
+        let output = try imagePort(named: "Image", kind: .Outlet, on: node)
+
+        let image0 = try harness.makeImage(width: 2, height: 2)
+        let image1 = try harness.makeImage(width: 2, height: 2)
+        let image0Pixels: [UInt8] = [
+            0, 0, 255, 255, 0, 0, 255, 255,
+            0, 0, 0, 255, 0, 0, 0, 255,
+        ]
+        let image1Pixels: [UInt8] = [
+            0, 255, 0, 255, 0, 255, 0, 255,
+            0, 0, 0, 255, 0, 0, 0, 255,
+        ]
+        image0Pixels.withUnsafeBytes { bytes in
+            image0.texture.replace(
+                region: MTLRegionMake2D(0, 0, 2, 2),
+                mipmapLevel: 0,
+                withBytes: bytes.baseAddress!,
+                bytesPerRow: 2 * 4
+            )
+        }
+        image1Pixels.withUnsafeBytes { bytes in
+            image1.texture.replace(
+                region: MTLRegionMake2D(0, 0, 2, 2),
+                mipmapLevel: 0,
+                withBytes: bytes.baseAddress!,
+                bytesPerRow: 2 * 4
+            )
+        }
+        image0.textureTransform = .textureVerticalFlip
+
+        let graph = Graph(context: harness.context)
+        let imageMesh = ImageMeshNode(context: harness.context)
+        graph.addNode(node)
+        graph.addNode(imageMesh)
+        graph.connect(output, to: imageMesh.inputImage)
+        input0.send(image0, force: true)
+        input1.send(image1, force: true)
+
+        try harness.renderer.startExecution(graph: graph)
+        try harness.render(graph: graph, executionInfo: harness.makeExecutionInfo(), drawScene: false)
+
+        let outputImage = try #require(output.value)
+        expectEqual(outputImage.textureTransform, matrix_identity_float4x4)
+
+        let readbackDescriptor = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .bgra8Unorm,
+            width: 2,
+            height: 2,
+            mipmapped: false
+        )
+        readbackDescriptor.storageMode = .shared
+        let readbackTexture = try #require(harness.context.device.makeTexture(descriptor: readbackDescriptor))
+        let readbackCommandBuffer = try #require(harness.renderer.commandQueue.makeCommandBuffer())
+        let blitEncoder = try #require(readbackCommandBuffer.makeBlitCommandEncoder())
+        blitEncoder.copy(
+            from: outputImage.texture,
+            sourceSlice: 0,
+            sourceLevel: 0,
+            sourceOrigin: .init(x: 0, y: 0, z: 0),
+            sourceSize: .init(width: 2, height: 2, depth: 1),
+            to: readbackTexture,
+            destinationSlice: 0,
+            destinationLevel: 0,
+            destinationOrigin: .init(x: 0, y: 0, z: 0)
+        )
+        blitEncoder.endEncoding()
+        readbackCommandBuffer.commit()
+        readbackCommandBuffer.waitUntilCompleted()
+
+        var outputPixels = [UInt8](repeating: 0, count: 2 * 2 * 4)
+        outputPixels.withUnsafeMutableBytes { bytes in
+            readbackTexture.getBytes(
+                bytes.baseAddress!,
+                bytesPerRow: 2 * 4,
+                from: MTLRegionMake2D(0, 0, 2, 2),
+                mipmapLevel: 0
+            )
+        }
+        #expect(Array(outputPixels[0..<4]) == [0, 255, 0, 255])
+        #expect(Array(outputPixels[(2 * 2 * 4 - 4)..<(2 * 2 * 4)]) == [0, 0, 255, 255])
+
+        try harness.renderer.stopExecution(graph: graph)
+    }
+
+    @Test("Image Mesh uses Fabric image presentation dimensions and texture transform")
+    func imageMeshUsesTextureTransform() throws {
+        guard let harness = GraphExecutionTestHarness() else { return }
+
+        let node = ImageMeshNode(context: harness.context)
+        let image = try harness.makeImage(width: 16, height: 8)
+        #expect(image.presentationSize == CGSize(width: 16, height: 8))
+
+        let clockwiseQuarterTurn = simd_float4x4(
+            simd_float4(0, -1, 0, 0),
+            simd_float4(1, 0, 0, 0),
+            simd_float4(0, 0, 1, 0),
+            simd_float4(0, 1, 0, 1)
+        )
+        image.textureTransform = clockwiseQuarterTurn
+        #expect(image.presentationSize == CGSize(width: 8, height: 16))
+        node.inputImage.value = image
+
+        let graph = Graph(context: harness.context)
+        graph.addNode(node)
+
+        try harness.renderer.startExecution(graph: graph)
+        try harness.render(
+            graph: graph,
+            executionInfo: harness.makeExecutionInfo(),
+            drawScene: false
+        )
+        try harness.renderer.stopExecution(graph: graph)
+
+        let mesh = try #require(node.getObject() as? Mesh)
+        let material = try #require(mesh.material as? BasicTextureMaterial)
+        let geometry = try #require(mesh.geometry as? PlaneGeometry)
+        expectEqual(material.textureTransform, clockwiseQuarterTurn)
+        #expect(abs(geometry.width - 1) <= 0.0001)
+        #expect(abs(geometry.height - 2) <= 0.0001)
+    }
+
+    @Test("Material image inputs apply their Fabric image texture transforms")
+    func materialImageInputsApplyTextureTransforms() throws {
+        guard let harness = GraphExecutionTestHarness() else { return }
+
+        let quarterTurn = simd_float4x4(
+            simd_float4(0, -1, 0, 0),
+            simd_float4(1, 0, 0, 0),
+            simd_float4(0, 0, 1, 0),
+            simd_float4(0, 1, 0, 1)
+        )
+        let flippedImage = try harness.makeImage(width: 4, height: 2)
+        flippedImage.textureTransform = .textureVerticalFlip
+        let rotatedImage = try harness.makeImage(width: 4, height: 2)
+        rotatedImage.textureTransform = quarterTurn
+
+        let standardNode = StandardMaterialNode(context: harness.context)
+        standardNode.inputDiffuseTexture.send(flippedImage, force: true)
+        standardNode.inputNormalTexture.send(rotatedImage, force: true)
+        try harness.execute(standardNode)
+
+        let baseColorTransform = try #require(
+            standardNode.material.parameters.get(
+                PBRTextureType.baseColor.texcoordName.titleCase,
+                as: Float4x4Parameter.self
+            )
+        )
+        let normalTransform = try #require(
+            standardNode.material.parameters.get(
+                PBRTextureType.normal.texcoordName.titleCase,
+                as: Float4x4Parameter.self
+            )
+        )
+        expectEqual(baseColorTransform.value, .textureVerticalFlip)
+        expectEqual(normalTransform.value, quarterTurn)
+
+        let pbrNode = PBRMaterialNode(context: harness.context)
+        pbrNode.inputBumpTexture.send(flippedImage, force: true)
+        pbrNode.inputTransmissionTexture.send(rotatedImage, force: true)
+        pbrNode.inputClearcoatRoughTexture.send(flippedImage, force: true)
+        pbrNode.inputClearcoatGlossTexture.send(rotatedImage, force: true)
+        try harness.execute(pbrNode)
+
+        let bumpTransform = try #require(
+            pbrNode.material.parameters.get(
+                PBRTextureType.bump.texcoordName.titleCase,
+                as: Float4x4Parameter.self
+            )
+        )
+        let transmissionTransform = try #require(
+            pbrNode.material.parameters.get(
+                PBRTextureType.transmission.texcoordName.titleCase,
+                as: Float4x4Parameter.self
+            )
+        )
+        let clearcoatSurfaceTransform = try #require(
+            pbrNode.material.parameters.get(
+                PBRTextureType.clearcoatRoughness.texcoordName.titleCase,
+                as: Float4x4Parameter.self
+            )
+        )
+        expectEqual(bumpTransform.value, .textureVerticalFlip)
+        expectEqual(transmissionTransform.value, quarterTurn)
+        expectEqual(clearcoatSurfaceTransform.value, .textureVerticalFlip)
+
+        let displacementNode = DisplacementMaterialNode(context: harness.context)
+        displacementNode.inputDisplacementTexture.send(flippedImage, force: true)
+        displacementNode.inputTexture.send(rotatedImage, force: true)
+        displacementNode.inputPointSpriteTexture.send(flippedImage, force: true)
+        try harness.execute(displacementNode)
+
+        let displacementTransform = try #require(
+            displacementNode.material.parameters.get(
+                "displacementTextureTransform",
+                as: Float4x4Parameter.self
+            )
+        )
+        let colorTransform = try #require(
+            displacementNode.material.parameters.get(
+                "colorTextureTransform",
+                as: Float4x4Parameter.self
+            )
+        )
+        let pointSpriteTransform = try #require(
+            displacementNode.material.parameters.get(
+                "pointSpriteTextureTransform",
+                as: Float4x4Parameter.self
+            )
+        )
+        expectEqual(displacementTransform.value, .textureVerticalFlip)
+        expectEqual(colorTransform.value, quarterTurn)
+        expectEqual(pointSpriteTransform.value, .textureVerticalFlip)
+
+        let graph = Graph(context: harness.context)
+        let planeNode = PlaneGeometryNode(context: harness.context)
+        let meshNode = MeshNode(context: harness.context)
+        graph.addNode(planeNode)
+        graph.addNode(displacementNode)
+        graph.addNode(meshNode)
+        graph.connect(planeNode.outputGeometry, to: meshNode.inputGeometry)
+        graph.connect(displacementNode.outputMaterial, to: meshNode.inputMaterial)
+
+        try harness.renderer.startExecution(graph: graph)
+        try harness.render(graph: graph, executionInfo: harness.makeExecutionInfo())
+        try harness.renderer.stopExecution(graph: graph)
+    }
+
 
     @Test("Number node outputs configured value after one render")
     func numberNodeOutputsConfiguredValue() throws {
@@ -269,7 +844,7 @@ struct GraphExecutionTests {
         #expect(light.castShadow)
     }
 
-    @Test("Spot light node supports projector image mode and flipped textures")
+    @Test("Spot light node supports projector image texture transforms")
     func spotLightNodeSupportsProjectorImages() throws {
         guard let harness = GraphExecutionTestHarness() else { return }
 
@@ -279,7 +854,7 @@ struct GraphExecutionTests {
 
         let texture = try harness.makeTexture(width: 16, height: 8)
         let image = FabricImage.unmanaged(texture: texture)
-        image.isFlipped = true
+        image.textureTransform = .textureVerticalFlip
         node.inputProjectionImage.value = image
         graph.addNode(node)
 


### PR DESCRIPTION
### Summary
Replaces FabricImage.isFlipped with a canonical texture-transform pipeline that supports flips, rotations, and video presentation metadata consistently.

### Changes
- Added FabricImage.textureTransform, presentationSize, and presentationCIImage.
- Added helpers for converting Core Video flippedness and video track transforms into Fabric sampling transforms.
- Updated movie playback, including HAP paths, to apply track orientation metadata.
- Updated Base Image shaders to receive one transform per image input and sample each texture correctly.
- Base Image effects and multi-pass blurs now render at presentation size and output identity-oriented images.
- Updated crop, resample, compute, optical-flow, Vision, and analysis paths to either consume or preserve transforms appropriately.
- Updated Image Mesh, Satin materials, displacement materials, and spotlight projections to use image presentation dimensions and texture transforms.
- Added shared Metal helpers for transformed texture coordinates and presentation dimensions.
- Updated Satin for consistent Plane/quad UV coordinates.
- Switched movie timing to host media time for stable frame cadence.
- Removed an unrelated accidental orientation-direction change.
- Cleaned up the new Swift formatting.

### Validation coverage
Added tests covering:
- Vertical flips and 90° rotations
- Core Image presentation orientation
- Base Image identity output
- Independent transforms for multi-input shaders
- Multi-pass blur behavior
- Presentation-space texture cropping
- Image Mesh sizing and UV transforms
- Satin material and spotlight texture transforms

### Intentional behavior
Vision mask nodes retain their previous mask when a new detection is unavailable. This avoids downstream output disappearing during temporary detection failures.