### PR TITLE
Open BaseGeometryNode to external plugins

### DIFF
--- a/Fabric/Nodes/Base/BaseGeometryNode.swift
+++ b/Fabric/Nodes/Base/BaseGeometryNode.swift
@@ -14,8 +14,8 @@ import Metal
 /// input, Geometry output, and publication lifecycle.
 ///
 /// External plug-ins can subclass this type, provide ``geometry``, and override
-/// ``updateGeometry(renderer:executionInfo:renderPassDescriptor:commandBuffer:)``
-/// to perform their specialized geometry work.
+/// ``execute(renderer:executionInfo:renderPassDescriptor:commandBuffer:)`` when
+/// they need specialized geometry work.
 open class BaseGeometryNode : Node
 {
     override open class var name:String { "Geometry" }
@@ -41,7 +41,7 @@ open class BaseGeometryNode : Node
         fatalError("Subclasses must override geometry")
     }
             
-    open func evaluate(geometry:Geometry, atTime:TimeInterval) -> Bool
+    public func evaluate(geometry:Geometry, atTime:TimeInterval) -> Bool
     {
         var shouldOutput = false
         
@@ -61,28 +61,9 @@ open class BaseGeometryNode : Node
         return shouldOutput
     }
     
-    /// Updates the geometry for one execution pass and reports whether the
-    /// stable geometry instance needs to be published again.
-    ///
-    /// The default implementation preserves the existing Fabric geometry-node
-    /// behavior. Plug-ins can override this throwing hook when their update
-    /// requires the renderer, command buffer, or recoverable error reporting.
-    /// Call `super` so Primitive changes and standard dirty-state publication
-    /// remain active.
-    open func updateGeometry(renderer: GraphRenderer,
-                             executionInfo: GraphExecutionInfo,
-                             renderPassDescriptor: MTLRenderPassDescriptor,
-                             commandBuffer: MTLCommandBuffer) throws -> Bool
-    {
-        evaluate(geometry: geometry, atTime: executionInfo.timing.time)
-    }
-
     override open func execute(renderer:GraphRenderer, executionInfo:GraphExecutionInfo, renderPassDescriptor: MTLRenderPassDescriptor, commandBuffer: MTLCommandBuffer) throws
     {
-        let shouldOutput = try updateGeometry(renderer: renderer,
-                                              executionInfo: executionInfo,
-                                              renderPassDescriptor: renderPassDescriptor,
-                                              commandBuffer: commandBuffer)
+        let shouldOutput = self.evaluate(geometry: self.geometry, atTime: executionInfo.timing.time)
 
         if shouldOutput
         {

--- a/Fabric/Nodes/Base/BaseGeometryNode.swift
+++ b/Fabric/Nodes/Base/BaseGeometryNode.swift
@@ -10,15 +10,21 @@ import Satin
 import simd
 import Metal
 
-public class BaseGeometryNode : Node
+/// Base implementation for geometry providers, including the standard Primitive
+/// input, Geometry output, and publication lifecycle.
+///
+/// External plug-ins can subclass this type, provide ``geometry``, and override
+/// ``updateGeometry(renderer:executionInfo:renderPassDescriptor:commandBuffer:)``
+/// to perform their specialized geometry work.
+open class BaseGeometryNode : Node
 {
-    override public class var name:String { "Geometry" }
-    override public class var nodeType:Node.NodeType { .Geometery }
-    override public class var nodeExecutionMode: Node.ExecutionMode { .Provider }
-    override public class var nodeTimeMode: Node.TimeMode { .None }
-    override public class var nodeDescription: String { "Provides \(Self.name)"}
+    override open class var name:String { "Geometry" }
+    override open class var nodeType:Node.NodeType { .Geometery }
+    override open class var nodeExecutionMode: Node.ExecutionMode { .Provider }
+    override open class var nodeTimeMode: Node.TimeMode { .None }
+    override open class var nodeDescription: String { "Provides \(Self.name)"}
 
-    override public class func registerPorts(context: Context) -> [(name: String, port: Port)] {
+    override open class func registerPorts(context: Context) -> [(name: String, port: Port)] {
         let ports = super.registerPorts(context: context)
         
         return ports +
@@ -35,7 +41,7 @@ public class BaseGeometryNode : Node
         fatalError("Subclasses must override geometry")
     }
             
-    public func evaluate(geometry:Geometry, atTime:TimeInterval) -> Bool
+    open func evaluate(geometry:Geometry, atTime:TimeInterval) -> Bool
     {
         var shouldOutput = false
         
@@ -55,9 +61,28 @@ public class BaseGeometryNode : Node
         return shouldOutput
     }
     
-    public override func execute(renderer:GraphRenderer, executionInfo:GraphExecutionInfo, renderPassDescriptor: MTLRenderPassDescriptor, commandBuffer: MTLCommandBuffer) throws
+    /// Updates the geometry for one execution pass and reports whether the
+    /// stable geometry instance needs to be published again.
+    ///
+    /// The default implementation preserves the existing Fabric geometry-node
+    /// behavior. Plug-ins can override this throwing hook when their update
+    /// requires the renderer, command buffer, or recoverable error reporting.
+    /// Call `super` so Primitive changes and standard dirty-state publication
+    /// remain active.
+    open func updateGeometry(renderer: GraphRenderer,
+                             executionInfo: GraphExecutionInfo,
+                             renderPassDescriptor: MTLRenderPassDescriptor,
+                             commandBuffer: MTLCommandBuffer) throws -> Bool
     {
-        let shouldOutput = self.evaluate(geometry: self.geometry, atTime: executionInfo.timing.time)
+        evaluate(geometry: geometry, atTime: executionInfo.timing.time)
+    }
+
+    override open func execute(renderer:GraphRenderer, executionInfo:GraphExecutionInfo, renderPassDescriptor: MTLRenderPassDescriptor, commandBuffer: MTLCommandBuffer) throws
+    {
+        let shouldOutput = try updateGeometry(renderer: renderer,
+                                              executionInfo: executionInfo,
+                                              renderPassDescriptor: renderPassDescriptor,
+                                              commandBuffer: commandBuffer)
 
         if shouldOutput
         {
@@ -71,7 +96,8 @@ public class BaseGeometryNode : Node
         }
     }
     
-    internal func primitiveType() -> MTLPrimitiveType
+    /// Resolves the standard Primitive input to its Metal primitive type.
+    public func primitiveType() -> MTLPrimitiveType
     {
         switch self.inputPrimitiveType.value
         {

--- a/Tests/BaseGeometryNodePluginAPITests.swift
+++ b/Tests/BaseGeometryNodePluginAPITests.swift
@@ -28,17 +28,17 @@ private final class PluginGeometryNode: BaseGeometryNode
     override var geometry: Geometry { triangleGeometry }
 
     private lazy var triangleGeometry = TriangleGeometry(context: context)
-    private(set) var updateInvocationCount = 0
+    private(set) var executeInvocationCount = 0
 
-    override func updateGeometry(
+    override func execute(
         renderer: GraphRenderer,
         executionInfo: GraphExecutionInfo,
         renderPassDescriptor: MTLRenderPassDescriptor,
         commandBuffer: MTLCommandBuffer
-    ) throws -> Bool
+    ) throws
     {
-        updateInvocationCount += 1
-        return try super.updateGeometry(
+        executeInvocationCount += 1
+        try super.execute(
             renderer: renderer,
             executionInfo: executionInfo,
             renderPassDescriptor: renderPassDescriptor,
@@ -73,6 +73,6 @@ struct BaseGeometryNodePluginAPITests
         #expect(node.inputPrimitiveType.value == "Triangle")
         #expect(node.primitiveType() == .triangle)
         #expect(node.outputGeometry.value === node.geometry)
-        #expect(node.updateInvocationCount == 1)
+        #expect(node.executeInvocationCount == 1)
     }
 }

--- a/Tests/BaseGeometryNodePluginAPITests.swift
+++ b/Tests/BaseGeometryNodePluginAPITests.swift
@@ -1,0 +1,78 @@
+import Fabric
+import Metal
+import Satin
+import Testing
+
+private final class PluginGeometryNode: BaseGeometryNode
+{
+    override class var name: String { "Plugin Geometry" }
+    override class var nodeTimeMode: Node.TimeMode { .TimeBase }
+
+    override class func registerPorts(context: Context) -> [(name: String, port: Fabric.Port)]
+    {
+        [
+            (
+                "inputSize",
+                ParameterPort(
+                    parameter: FloatParameter(
+                        "Size",
+                        1,
+                        .inputfield,
+                        "Geometry size"
+                    )
+                )
+            ),
+        ] + super.registerPorts(context: context)
+    }
+
+    override var geometry: Geometry { triangleGeometry }
+
+    private lazy var triangleGeometry = TriangleGeometry(context: context)
+    private(set) var updateInvocationCount = 0
+
+    override func updateGeometry(
+        renderer: GraphRenderer,
+        executionInfo: GraphExecutionInfo,
+        renderPassDescriptor: MTLRenderPassDescriptor,
+        commandBuffer: MTLCommandBuffer
+    ) throws -> Bool
+    {
+        updateInvocationCount += 1
+        return try super.updateGeometry(
+            renderer: renderer,
+            executionInfo: executionInfo,
+            renderPassDescriptor: renderPassDescriptor,
+            commandBuffer: commandBuffer
+        )
+    }
+}
+
+@Suite("Base Geometry Node Plugin API")
+struct BaseGeometryNodePluginAPITests
+{
+    @Test("An external-style subclass inherits ports and participates in execution")
+    func externalSubclassUsesBaseGeometryLifecycle() throws
+    {
+        guard let harness = GraphExecutionTestHarness() else { return }
+        guard let commandBuffer = harness.renderer.commandQueue.makeCommandBuffer() else
+        {
+            return
+        }
+
+        let node = PluginGeometryNode(context: harness.context)
+        let renderPassDescriptor = MTLRenderPassDescriptor()
+
+        try node.execute(
+            renderer: harness.renderer,
+            executionInfo: harness.makeExecutionInfo(),
+            renderPassDescriptor: renderPassDescriptor,
+            commandBuffer: commandBuffer
+        )
+
+        #expect(node.findPort(named: "inputSize", as: ParameterPort<Float>.self) != nil)
+        #expect(node.inputPrimitiveType.value == "Triangle")
+        #expect(node.primitiveType() == .triangle)
+        #expect(node.outputGeometry.value === node.geometry)
+        #expect(node.updateInvocationCount == 1)
+    }
+}


### PR DESCRIPTION
Expose the geometry-node subclassing surface, add a throwing full-context update hook, and keep primitive handling and forced geometry publication in the base lifecycle. Cover the API through a client-style subclass test.

closes #334 