### PR TITLE
Feature – NodeRegistry maintains a list of _Sub Graph_ type nodes

### DIFF
--- a/Fabric/Nodes/NodeRegistry.swift
+++ b/Fabric/Nodes/NodeRegistry.swift
@@ -56,13 +56,39 @@ public class NodeRegistry
     }
 
     /// All UTTypes accepted by drop-target nodes, for use with drop destination handlers.
-    public lazy private(set) var allSupportedDropTypes: [UTType] = {
-        return self.nodeFileLoadingClasses.flatMap { $0.supportedContentTypes }
-    }()
+    public var allSupportedDropTypes: [UTType]
+    {
+        self.nodeFileLoadingClasses.flatMap { $0.supportedContentTypes }
+    }
 
-    public lazy private(set) var availableNodes: [NodeClassWrapper] = {
-        return PluginLoader.shared.pluginNodeWrappers
-    }()
+    /// Every registered node, read live from the plugin loader so a plugin
+    /// loaded after first access is included. PluginLoader.pluginsDidChange
+    /// says when to re-read.
+    public var availableNodes: [NodeClassWrapper]
+    {
+        PluginLoader.shared.pluginNodeWrappers
+    }
+
+    /// A registered node class that is a kind of subgraph, for choices such
+    /// as Embed Selection In.
+    public struct SubgraphNodeType: Identifiable
+    {
+        public let wrapper: NodeClassWrapper
+        public let subgraphClass: SubgraphNode.Type
+
+        public var id: UUID { wrapper.id }
+        public var name: String { wrapper.nodeName }
+    }
+
+    /// The one list of subgraph node types, in registration order: the core
+    /// kinds and any a plugin adds.
+    public var subgraphNodeTypes: [SubgraphNodeType]
+    {
+        self.availableNodes.compactMap { wrapper in
+            guard let subgraphClass = wrapper.nodeClass as? SubgraphNode.Type else { return nil }
+            return SubgraphNodeType(wrapper: wrapper, subgraphClass: subgraphClass)
+        }
+    }
 
     public var pluginLoadErrors: [PluginLoadError]
     {

--- a/Fabric/Nodes/NodeRegistry.swift
+++ b/Fabric/Nodes/NodeRegistry.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Combine
 import Satin
 import UniformTypeIdentifiers
 
@@ -26,6 +27,38 @@ public class NodeRegistry
     init() throws
     {
         try loadPluginsIfNeeded()
+
+        // The initial load's signal has fired by now; from here on each
+        // signal marks the derived lists stale, and the next read rebuilds.
+        pluginChangeSubscription = PluginLoader.shared.pluginsDidChange.sink { [weak self] in
+            guard let self else { return }
+            self.derivedListLock.withLock { self.derivedListGeneration += 1 }
+        }
+    }
+
+    private var pluginChangeSubscription: AnyCancellable?
+    private let derivedListLock = NSLock()
+
+    /// Bumped by the loader's change signal. The lists derived from the node
+    /// list rebuild once per generation, on the first read after the bump.
+    internal private(set) var derivedListGeneration = 0
+    internal private(set) var derivedListBuildCount = 0
+    private var builtGeneration = -1
+    private var cachedSubgraphNodeTypes: [SubgraphNodeType] = []
+    private var cachedDropTypes: [UTType] = []
+
+    private func rebuildDerivedListsIfStale()
+    {
+        derivedListLock.withLock {
+            guard builtGeneration != derivedListGeneration else { return }
+            cachedSubgraphNodeTypes = self.availableNodes.compactMap { wrapper in
+                guard let subgraphClass = wrapper.nodeClass as? SubgraphNode.Type else { return nil }
+                return SubgraphNodeType(wrapper: wrapper, subgraphClass: subgraphClass)
+            }
+            cachedDropTypes = self.nodeFileLoadingClasses.flatMap { $0.supportedContentTypes }
+            builtGeneration = derivedListGeneration
+            derivedListBuildCount += 1
+        }
     }
 
     public func nodeClass(pluginID: String, nodeID: String) -> (Node.Type)?
@@ -58,7 +91,8 @@ public class NodeRegistry
     /// All UTTypes accepted by drop-target nodes, for use with drop destination handlers.
     public var allSupportedDropTypes: [UTType]
     {
-        self.nodeFileLoadingClasses.flatMap { $0.supportedContentTypes }
+        rebuildDerivedListsIfStale()
+        return derivedListLock.withLock { cachedDropTypes }
     }
 
     /// Every registered node, read live from the plugin loader so a plugin
@@ -81,13 +115,11 @@ public class NodeRegistry
     }
 
     /// The one list of subgraph node types, in registration order: the core
-    /// kinds and any a plugin adds.
+    /// kinds and any a plugin adds. Built once per plugin change.
     public var subgraphNodeTypes: [SubgraphNodeType]
     {
-        self.availableNodes.compactMap { wrapper in
-            guard let subgraphClass = wrapper.nodeClass as? SubgraphNode.Type else { return nil }
-            return SubgraphNodeType(wrapper: wrapper, subgraphClass: subgraphClass)
-        }
+        rebuildDerivedListsIfStale()
+        return derivedListLock.withLock { cachedSubgraphNodeTypes }
     }
 
     public var pluginLoadErrors: [PluginLoadError]

--- a/Fabric/Nodes/NodeRegistry.swift
+++ b/Fabric/Nodes/NodeRegistry.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import Combine
 import Satin
 import UniformTypeIdentifiers
 
@@ -27,38 +26,30 @@ public class NodeRegistry
     init() throws
     {
         try loadPluginsIfNeeded()
-
-        // The initial load's signal has fired by now; from here on each
-        // signal marks the derived lists stale, and the next read rebuilds.
-        pluginChangeSubscription = PluginLoader.shared.pluginsDidChange.sink { [weak self] in
-            guard let self else { return }
-            self.derivedListLock.withLock { self.derivedListGeneration += 1 }
-        }
+        rebuildNodeLists()
     }
 
-    private var pluginChangeSubscription: AnyCancellable?
-    private let derivedListLock = NSLock()
-
-    /// Bumped by the loader's change signal. The lists derived from the node
-    /// list rebuild once per generation, on the first read after the bump.
-    internal private(set) var derivedListGeneration = 0
-    internal private(set) var derivedListBuildCount = 0
-    private var builtGeneration = -1
-    private var cachedSubgraphNodeTypes: [SubgraphNodeType] = []
-    private var cachedDropTypes: [UTType] = []
-
-    private func rebuildDerivedListsIfStale()
+    /// Loads a plugin bundle after startup and rebuilds the node lists.
+    public func loadPlugin(at url: URL) throws
     {
-        derivedListLock.withLock {
-            guard builtGeneration != derivedListGeneration else { return }
-            cachedSubgraphNodeTypes = self.availableNodes.compactMap { wrapper in
-                guard let subgraphClass = wrapper.nodeClass as? SubgraphNode.Type else { return nil }
-                return SubgraphNodeType(wrapper: wrapper, subgraphClass: subgraphClass)
-            }
-            cachedDropTypes = self.nodeFileLoadingClasses.flatMap { $0.supportedContentTypes }
-            builtGeneration = derivedListGeneration
-            derivedListBuildCount += 1
+        pluginLoadLock.lock()
+        defer { pluginLoadLock.unlock() }
+
+        let loader = PluginLoader.shared
+        try loader.loadPlugin(at: url, existingNodeNames: Set(loader.pluginNodeWrappers.map(\.nodeName)))
+        rebuildNodeLists()
+    }
+
+    /// The node lists are fixed between plugin loads: computed once here,
+    /// read as plain arrays until the next load.
+    private func rebuildNodeLists()
+    {
+        availableNodes = PluginLoader.shared.pluginNodeWrappers
+        subgraphNodeTypes = availableNodes.compactMap { wrapper in
+            guard let subgraphClass = wrapper.nodeClass as? SubgraphNode.Type else { return nil }
+            return SubgraphNodeType(wrapper: wrapper, subgraphClass: subgraphClass)
         }
+        allSupportedDropTypes = nodeFileLoadingClasses.flatMap { $0.supportedContentTypes }
     }
 
     public func nodeClass(pluginID: String, nodeID: String) -> (Node.Type)?
@@ -89,19 +80,10 @@ public class NodeRegistry
     }
 
     /// All UTTypes accepted by drop-target nodes, for use with drop destination handlers.
-    public var allSupportedDropTypes: [UTType]
-    {
-        rebuildDerivedListsIfStale()
-        return derivedListLock.withLock { cachedDropTypes }
-    }
+    public private(set) var allSupportedDropTypes: [UTType] = []
 
-    /// Every registered node, read live from the plugin loader so a plugin
-    /// loaded after first access is included. PluginLoader.pluginsDidChange
-    /// says when to re-read.
-    public var availableNodes: [NodeClassWrapper]
-    {
-        PluginLoader.shared.pluginNodeWrappers
-    }
+    /// Every registered node.
+    public private(set) var availableNodes: [NodeClassWrapper] = []
 
     /// A registered node class that is a kind of subgraph, for choices such
     /// as Embed Selection In.
@@ -114,13 +96,9 @@ public class NodeRegistry
         public var name: String { wrapper.nodeName }
     }
 
-    /// The one list of subgraph node types, in registration order: the core
-    /// kinds and any a plugin adds. Built once per plugin change.
-    public var subgraphNodeTypes: [SubgraphNodeType]
-    {
-        rebuildDerivedListsIfStale()
-        return derivedListLock.withLock { cachedSubgraphNodeTypes }
-    }
+    /// The subgraph node types, in registration order: the core kinds and
+    /// any a plugin adds.
+    public private(set) var subgraphNodeTypes: [SubgraphNodeType] = []
 
     public var pluginLoadErrors: [PluginLoadError]
     {

--- a/Fabric/Nodes/Plugin/PluginLoader.swift
+++ b/Fabric/Nodes/Plugin/PluginLoader.swift
@@ -8,10 +8,15 @@
 import Foundation
 import Satin
 import os
+import Combine
 
 /// Loads Fabric's embedded core plugin plus optional external node plugin bundles.
 public final class PluginLoader
 {
+    /// Fires after a plugin's node classes are registered, so anything built
+    /// from the node list (the library, subgraph type menus) can refresh.
+    public let pluginsDidChange = PassthroughSubject<Void, Never>()
+
     public static let shared = PluginLoader()
     public static let currentAPIVersion = 1
     public static let pluginExtension = "fabricplugin"
@@ -211,6 +216,7 @@ public final class PluginLoader
 
             pluginNodeWrappers.append(contentsOf: FabricCoreNodesPlugin.dynamicNodeWrappers())
             loadedPlugins[Self.coreNodesPluginID] = pluginInfo
+            pluginsDidChange.send()
             logger.info("Loaded embedded Fabric core nodes plugin")
         }
         catch let error as PluginLoadError
@@ -284,6 +290,7 @@ public final class PluginLoader
 
         loadedPlugins[pluginInfo.id] = pluginInfo
         logger.info("Loaded Fabric plugin '\(pluginInfo.displayName)' with \(nodeClasses.count) node class(es)")
+        pluginsDidChange.send()
     }
 
     public func nodeClass(pluginID: String, nodeID: String) -> Node.Type?

--- a/Fabric/Nodes/Plugin/PluginLoader.swift
+++ b/Fabric/Nodes/Plugin/PluginLoader.swift
@@ -13,9 +13,20 @@ import Combine
 /// Loads Fabric's embedded core plugin plus optional external node plugin bundles.
 public final class PluginLoader
 {
-    /// Fires after a plugin's node classes are registered, so anything built
-    /// from the node list (the library, subgraph type menus) can refresh.
+    /// Fires after node classes are registered, so anything built from the
+    /// node list (the library, subgraph type menus) can refresh: once for the
+    /// whole initial load, after its lock is released, and once per plugin
+    /// loaded later. Subscribers run on the loading thread.
     public let pluginsDidChange = PassthroughSubject<Void, Never>()
+
+    /// Set for the initial load so its plugins signal once, together, after
+    /// the lock is released rather than one at a time under it.
+    private var coalesceChangeSignal = false
+
+    private func notePluginsChanged()
+    {
+        if !coalesceChangeSignal { pluginsDidChange.send() }
+    }
 
     public static let shared = PluginLoader()
     public static let currentAPIVersion = 1
@@ -99,11 +110,20 @@ public final class PluginLoader
 
     public func loadAllPlugins() throws
     {
+        let loaded = try loadAllPluginsUnderLock()
+        if loaded { pluginsDidChange.send() }
+    }
+
+    private func loadAllPluginsUnderLock() throws -> Bool
+    {
         pluginLoadLock.lock()
         defer { pluginLoadLock.unlock() }
 
-        guard !pluginsLoaded else { return }
+        guard !pluginsLoaded else { return false }
         pluginsLoaded = true
+
+        coalesceChangeSignal = true
+        defer { coalesceChangeSignal = false }
 
         loadErrors.removeAll()
         do
@@ -116,6 +136,7 @@ public final class PluginLoader
             pluginsLoaded = false
             throw error
         }
+        return true
     }
 
     /// Loads every discovered plugin bundle.
@@ -216,7 +237,7 @@ public final class PluginLoader
 
             pluginNodeWrappers.append(contentsOf: FabricCoreNodesPlugin.dynamicNodeWrappers())
             loadedPlugins[Self.coreNodesPluginID] = pluginInfo
-            pluginsDidChange.send()
+            notePluginsChanged()
             logger.info("Loaded embedded Fabric core nodes plugin")
         }
         catch let error as PluginLoadError
@@ -290,7 +311,7 @@ public final class PluginLoader
 
         loadedPlugins[pluginInfo.id] = pluginInfo
         logger.info("Loaded Fabric plugin '\(pluginInfo.displayName)' with \(nodeClasses.count) node class(es)")
-        pluginsDidChange.send()
+        notePluginsChanged()
     }
 
     public func nodeClass(pluginID: String, nodeID: String) -> Node.Type?

--- a/Fabric/Nodes/Plugin/PluginLoader.swift
+++ b/Fabric/Nodes/Plugin/PluginLoader.swift
@@ -8,26 +8,10 @@
 import Foundation
 import Satin
 import os
-import Combine
 
 /// Loads Fabric's embedded core plugin plus optional external node plugin bundles.
 public final class PluginLoader
 {
-    /// Fires after node classes are registered, so anything built from the
-    /// node list (the library, subgraph type menus) can refresh: once for the
-    /// whole initial load, after its lock is released, and once per plugin
-    /// loaded later. Subscribers run on the loading thread.
-    public let pluginsDidChange = PassthroughSubject<Void, Never>()
-
-    /// Set for the initial load so its plugins signal once, together, after
-    /// the lock is released rather than one at a time under it.
-    private var coalesceChangeSignal = false
-
-    private func notePluginsChanged()
-    {
-        if !coalesceChangeSignal { pluginsDidChange.send() }
-    }
-
     public static let shared = PluginLoader()
     public static let currentAPIVersion = 1
     public static let pluginExtension = "fabricplugin"
@@ -110,20 +94,11 @@ public final class PluginLoader
 
     public func loadAllPlugins() throws
     {
-        let loaded = try loadAllPluginsUnderLock()
-        if loaded { pluginsDidChange.send() }
-    }
-
-    private func loadAllPluginsUnderLock() throws -> Bool
-    {
         pluginLoadLock.lock()
         defer { pluginLoadLock.unlock() }
 
-        guard !pluginsLoaded else { return false }
+        guard !pluginsLoaded else { return }
         pluginsLoaded = true
-
-        coalesceChangeSignal = true
-        defer { coalesceChangeSignal = false }
 
         loadErrors.removeAll()
         do
@@ -136,7 +111,6 @@ public final class PluginLoader
             pluginsLoaded = false
             throw error
         }
-        return true
     }
 
     /// Loads every discovered plugin bundle.
@@ -237,7 +211,6 @@ public final class PluginLoader
 
             pluginNodeWrappers.append(contentsOf: FabricCoreNodesPlugin.dynamicNodeWrappers())
             loadedPlugins[Self.coreNodesPluginID] = pluginInfo
-            notePluginsChanged()
             logger.info("Loaded embedded Fabric core nodes plugin")
         }
         catch let error as PluginLoadError
@@ -311,7 +284,6 @@ public final class PluginLoader
 
         loadedPlugins[pluginInfo.id] = pluginInfo
         logger.info("Loaded Fabric plugin '\(pluginInfo.displayName)' with \(nodeClasses.count) node class(es)")
-        notePluginsChanged()
     }
 
     public func nodeClass(pluginID: String, nodeID: String) -> Node.Type?

--- a/Fabric/Views/Graph/GraphNodesView.swift
+++ b/Fabric/Views/Graph/GraphNodesView.swift
@@ -172,21 +172,20 @@ struct GraphNodesView: View
             }
 
             Menu("Embed Selection In...") {
-                let embedClasses = [SubgraphNode.self, IteratorNode.self, EnvironmentNode.self, DeferredSubgraphNode.self]
+                let subgraphTypes = (try? NodeRegistry.shared.subgraphNodeTypes) ?? []
 
-                ForEach(0 ..< embedClasses.count, id: \.self) { embedClassIndex in
-                    let embedClass = embedClasses[embedClassIndex]
+                ForEach(subgraphTypes) { subgraphType in
                     Button {
                         do {
                             _ = try currentGraph.createSubgraph(from: currentGraph.selectedNodes,
                                                                centeredOn: currentNode,
-                                                               usingClass: embedClass)
+                                                               usingClass: subgraphType.subgraphClass)
                         }
                         catch {
                             print("Create subgraph failed: \(error.localizedDescription)")
                         }
                     } label: {
-                        Text(embedClass.name)
+                        Text(subgraphType.name)
                     }
                 }
             }

--- a/Fabric/Views/NodeRegisitryView.swift
+++ b/Fabric/Views/NodeRegisitryView.swift
@@ -153,9 +153,6 @@ public struct NodeRegisitryView: View {
         .searchable(text: $searchString, placement: .sidebar)
         .searchFocused(focus, equals: .registrySearch)
         .searchPresentationToolbarBehavior(.avoidHidingContent)
-        .onReceive(PluginLoader.shared.pluginsDidChange.receive(on: DispatchQueue.main)) { _ in
-            self.updateFilteredNodes()
-        }
         .onChange(of: self.searchString) { _, _ in
             self.updateFilteredNodes()
             

--- a/Fabric/Views/NodeRegisitryView.swift
+++ b/Fabric/Views/NodeRegisitryView.swift
@@ -153,6 +153,9 @@ public struct NodeRegisitryView: View {
         .searchable(text: $searchString, placement: .sidebar)
         .searchFocused(focus, equals: .registrySearch)
         .searchPresentationToolbarBehavior(.avoidHidingContent)
+        .onReceive(PluginLoader.shared.pluginsDidChange.receive(on: DispatchQueue.main)) { _ in
+            self.updateFilteredNodes()
+        }
         .onChange(of: self.searchString) { _, _ in
             self.updateFilteredNodes()
             

--- a/Tests/SubgraphNodeTypesTests.swift
+++ b/Tests/SubgraphNodeTypesTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Metal
+import Testing
+@testable import Fabric
+import Satin
+
+/// The one list of subgraph node types that Embed Selection In and any other
+/// "which kind of subgraph" choice draw from: derived from the registry, so a
+/// plugin's subgraph subclass appears alongside the core ones.
+@Suite("Subgraph Node Types")
+struct SubgraphNodeTypesTests
+{
+    private func makeContext() -> Context?
+    {
+        guard let device = MTLCreateSystemDefaultDevice() else { return nil }
+        return Context(device: device,
+                       sampleCount: 1,
+                       colorPixelFormat: .bgra8Unorm,
+                       depthPixelFormat: .depth32Float,
+                       stencilPixelFormat: .invalid)
+    }
+
+    @Test("The registry lists every SubgraphNode subclass it holds, and nothing else")
+    func registryListsSubgraphTypes() throws
+    {
+        let registry = try NodeRegistry.shared
+        let types = registry.subgraphNodeTypes
+
+        let classNames = types.map { String(describing: $0.subgraphClass) }
+        #expect(classNames.contains("SubgraphNode"))
+        #expect(classNames.contains("DeferredSubgraphNode"))
+        #expect(classNames.contains("IteratorNode"))
+        #expect(classNames.contains("EnvironmentNode"))
+        #expect(types.allSatisfy { $0.wrapper.nodeClass == $0.subgraphClass })
+
+        let expectedCount = registry.availableNodes.filter { $0.nodeClass is SubgraphNode.Type }.count
+        #expect(types.count == expectedCount)
+        #expect(types.map(\.name) == types.map(\.wrapper.nodeName))
+    }
+
+    @Test("The registry's node list is the plugin loader's, not a snapshot")
+    func availableNodesAreLive() throws
+    {
+        let registry = try NodeRegistry.shared
+        let loaded = PluginLoader.shared.pluginNodeWrappers
+
+        #expect(registry.availableNodes.count == loaded.count)
+        #expect(zip(registry.availableNodes, loaded).allSatisfy { $0.id == $1.id })
+    }
+
+    @Test("A selection can be embedded in every registered subgraph type")
+    func everySubgraphTypeEmbeds() throws
+    {
+        guard let context = makeContext() else { return }
+        let registry = try NodeRegistry.shared
+
+        for type in registry.subgraphNodeTypes
+        {
+            let graph = Graph(context: context)
+            let node = NumberBinaryOperator(context: context)
+            graph.addNode(node)
+
+            let container = try graph.createSubgraph(from: [node], centeredOn: node, usingClass: type.subgraphClass)
+
+            #expect(Swift.type(of: container) == type.subgraphClass, "\(type.name)")
+            #expect(container.subGraph.nodes.contains { $0 === node }, "\(type.name)")
+        }
+    }
+}

--- a/Tests/SubgraphNodeTypesTests.swift
+++ b/Tests/SubgraphNodeTypesTests.swift
@@ -67,3 +67,29 @@ struct SubgraphNodeTypesTests
         }
     }
 }
+
+extension SubgraphNodeTypesTests
+{
+    @Test("Derived lists are built once per plugin change, not per read")
+    func derivedListsAreCachedUntilPluginsChange() throws
+    {
+        let registry = try NodeRegistry.shared
+
+        let first = registry.subgraphNodeTypes
+        let second = registry.subgraphNodeTypes
+        #expect(registry.derivedListGeneration == registry.derivedListGeneration)
+        #expect(first.map(\.id) == second.map(\.id))
+        let builtBefore = registry.derivedListBuildCount
+
+        _ = registry.subgraphNodeTypes
+        _ = registry.allSupportedDropTypes
+        _ = registry.allSupportedDropTypes
+        #expect(registry.derivedListBuildCount == builtBefore)
+
+        PluginLoader.shared.pluginsDidChange.send()
+        _ = registry.subgraphNodeTypes
+        #expect(registry.derivedListBuildCount == builtBefore + 1)
+        _ = registry.subgraphNodeTypes
+        #expect(registry.derivedListBuildCount == builtBefore + 1)
+    }
+}

--- a/Tests/SubgraphNodeTypesTests.swift
+++ b/Tests/SubgraphNodeTypesTests.swift
@@ -4,9 +4,8 @@ import Testing
 @testable import Fabric
 import Satin
 
-/// The one list of subgraph node types that Embed Selection In and any other
-/// "which kind of subgraph" choice draw from: derived from the registry, so a
-/// plugin's subgraph subclass appears alongside the core ones.
+/// The registry's list of subgraph node types, which Embed Selection In
+/// offers: the core kinds and any a plugin adds, fixed between plugin loads.
 @Suite("Subgraph Node Types")
 struct SubgraphNodeTypesTests
 {
@@ -36,16 +35,7 @@ struct SubgraphNodeTypesTests
         let expectedCount = registry.availableNodes.filter { $0.nodeClass is SubgraphNode.Type }.count
         #expect(types.count == expectedCount)
         #expect(types.map(\.name) == types.map(\.wrapper.nodeName))
-    }
-
-    @Test("The registry's node list is the plugin loader's, not a snapshot")
-    func availableNodesAreLive() throws
-    {
-        let registry = try NodeRegistry.shared
-        let loaded = PluginLoader.shared.pluginNodeWrappers
-
-        #expect(registry.availableNodes.count == loaded.count)
-        #expect(zip(registry.availableNodes, loaded).allSatisfy { $0.id == $1.id })
+        #expect(registry.availableNodes.map(\.id) == PluginLoader.shared.pluginNodeWrappers.map(\.id))
     }
 
     @Test("A selection can be embedded in every registered subgraph type")
@@ -65,31 +55,5 @@ struct SubgraphNodeTypesTests
             #expect(Swift.type(of: container) == type.subgraphClass, "\(type.name)")
             #expect(container.subGraph.nodes.contains { $0 === node }, "\(type.name)")
         }
-    }
-}
-
-extension SubgraphNodeTypesTests
-{
-    @Test("Derived lists are built once per plugin change, not per read")
-    func derivedListsAreCachedUntilPluginsChange() throws
-    {
-        let registry = try NodeRegistry.shared
-
-        let first = registry.subgraphNodeTypes
-        let second = registry.subgraphNodeTypes
-        #expect(registry.derivedListGeneration == registry.derivedListGeneration)
-        #expect(first.map(\.id) == second.map(\.id))
-        let builtBefore = registry.derivedListBuildCount
-
-        _ = registry.subgraphNodeTypes
-        _ = registry.allSupportedDropTypes
-        _ = registry.allSupportedDropTypes
-        #expect(registry.derivedListBuildCount == builtBefore)
-
-        PluginLoader.shared.pluginsDidChange.send()
-        _ = registry.subgraphNodeTypes
-        #expect(registry.derivedListBuildCount == builtBefore + 1)
-        _ = registry.subgraphNodeTypes
-        #expect(registry.derivedListBuildCount == builtBefore + 1)
     }
 }


### PR DESCRIPTION
...and with that, the “Embed Selection In...” context menu item also shows third-party nodes that are _Sub Graph_ subclasses. This list used to be hard-coded.

<img width="675" height="355" alt="Screenshot 2026-09-10 at 08 09 42" src="https://github.com/user-attachments/assets/4f1cf284-3a43-423f-892d-61e361ae1462" />
