### PR TITLE
Feature – Sub Graphs can be cloned within documents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,13 +81,14 @@ For all development:
   - `class var name` — override: the stable name the type is registered and listed under, and the default instance title.
   - `func deriveTitle() -> String` — override only when an instance has a more specific authoritative title, such as a shader-backed `BaseImageNode`; defaults to `Self.name`.
   - `func deriveSubtitle() -> String?` — override where the node describes itself, nil otherwise: Math Expression's expression, StrategyNode's strategy.
+  - `func deriveTitleIcon() -> NodeTitleIcon?` — override where the node has something to flag at the trailing edge of its title row, with a tooltip: Math Expression's parse error. nil otherwise.
   - `var userName: String?` — final: the user's rename, serialized and public for rename-specific callers.
   - An empty name is no name: `userName` normalizes "" to nil at set and decode.
 - From those it composes, both final:
   - `var title` — the normalized result of `deriveTitle()`, falling back to `Self.name` when empty.
   - `var subtitle` — `userName ?? deriveSubtitle()`, normalized so empty values and values equal to `title` read as nil. General consumers read this rather than `userName`.
   - `var debugDescription` — the title plus resolved subtitle, e.g. `Math Expression (My Rename)`. `print(node)` and `"\(node)"` give it; diagnostic labels and traces use it when they need both values.
-- Fire `subtitleSubject.send()` whenever state feeding `deriveTitle()` or `deriveSubtitle()` changes; `NodeViewModel` mirrors the node's `title` / `subtitle` observably and keeps `userName` only for rename editing, clearing, and undo.
+- Fire `subtitleSubject.send()` whenever state feeding `deriveTitle()`, `deriveSubtitle()` or `deriveTitleIcon()` changes; `NodeViewModel` mirrors the node's `title` / `subtitle` / `titleIcon` observably and keeps `userName` only for rename editing, clearing, and undo.
 - Execution is **pull-based**; one execute per node per pass.
 - `GraphRenderer` (executor and scheduler) today does not use `nodeExecutionMode` or `nodeTimeMode` but will in the future.
 - **Iterator (QC-style)** remains the multi-evaluation macro; refinements allowed, paradigm fixed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,7 @@ Some nodes operate identically regardless of what data flows through them (e.g. 
 ### 3.4  Subgraph Behavior
 - Iterator applies per-iteration params before subgraph execute.
 - Render-to-Image-with-Depth sizes to inputs, attaches depth, outputs typed textures.
+- Clone sets (`CloneSet`, `Graph+CloneSet.swift`, `Graph+CloneReconcile.swift`): what a node encodes is its design and replicates across members; what it does not encode is runtime and stays per member. Published inlet values are the one encoded exception. Identity across members is the member's `cloneRecord` (template id → local id), never a field on Node; a settings change that rebuilds ports replaces the sibling's node under the ids it recorded, everything else reconciles in place. Edits reach siblings through `Graph.noteContentChanged()`: the Graph mutation API bumps it, and a member's `CloneMemberObserver` bumps it for the signals nodes, ports and parameters already publish. Nothing clone-specific belongs on Node or Port.
 
 ---
 

--- a/Fabric Editor/FabricDocument.swift
+++ b/Fabric Editor/FabricDocument.swift
@@ -336,7 +336,8 @@ class FabricDocument: FileDocument
     {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted]
-        
+
+        self.editingContext.rootGraph.flushPendingCloneSync()
         let data = try encoder.encode(self.editingContext.rootGraph)
         
         return .init(regularFileWithContents: data)

--- a/Fabric Editor/Views/BreadcrumbEntry.swift
+++ b/Fabric Editor/Views/BreadcrumbEntry.swift
@@ -1,0 +1,39 @@
+//
+//  BreadcrumbEntry.swift
+//  Fabric Editor
+//
+//  Created by Claude on 9/9/26.
+//
+
+import SwiftUI
+import Fabric
+
+/// A breadcrumb entry: the subgraph node's title, preceded by its title icon
+/// where it has one (a clone set member's glyph), with the icon's tooltip on
+/// hover, the same way the node shows it on the canvas.
+struct BreadcrumbEntry: View
+{
+    let node: SubgraphNode
+    let nodeViewModel: NodeViewModel?
+    let action: () -> Void
+
+    var body: some View
+    {
+        let titleIcon = nodeViewModel?.titleIcon
+
+        Button(action: action)
+        {
+            HStack(spacing: 4)
+            {
+                if let titleIcon
+                {
+                    Image(systemName: titleIcon.systemName)
+                }
+                Text(node.title)
+            }
+        }
+        .font(.headline)
+        .buttonStyle(.plain)
+        .help(titleIcon?.tooltip ?? "")
+    }
+}

--- a/Fabric Editor/Views/ContentView.swift
+++ b/Fabric Editor/Views/ContentView.swift
@@ -76,9 +76,11 @@ struct ContentView: View {
                     ForEach(self.document.editingContext.entries) { node in
                         Text("›")
                             .font(.headline)
-                        Button(node.title) { self.document.editingContext.popTo(node) }
-                            .font(.headline)
-                            .buttonStyle(.plain)
+                        BreadcrumbEntry(node: node,
+                                        nodeViewModel: node.graph?.viewModelIfPresent(for: node))
+                        {
+                            self.document.editingContext.popTo(node)
+                        }
                     }
                 }
                 .padding(.horizontal)

--- a/Fabric/Graph/CloneSet.swift
+++ b/Fabric/Graph/CloneSet.swift
@@ -1,0 +1,77 @@
+//
+//  CloneSet.swift
+//  Fabric
+//
+//  Created by Claude on 9/10/26.
+//
+
+import Foundation
+internal import AnyCodable
+
+/// A clone set: the template every member is kept identical to, held as
+/// data, plus the set's name. Owned by the document's root graph and saved
+/// with it. Members refer to it by id and keep a record mapping the
+/// template's ids to their own; see SubgraphNode.cloneSetID.
+///
+/// The template is the encoded form of a member's sub graph with every id
+/// rewritten to the template's own ids. It is refreshed from whichever member
+/// was edited last, materialised when a member is created without a live
+/// source, and is the form that can be stored or shared outside the document.
+public final class CloneSet: Codable, Identifiable
+{
+    public let id: UUID
+    public internal(set) var name: String
+
+    /// Canonical JSON of the template graph, keys sorted, so two templates
+    /// with the same design compare equal byte for byte.
+    public internal(set) var templateJSON: Data
+
+    init(id: UUID = UUID(), name: String, templateJSON: Data)
+    {
+        self.id = id
+        self.name = name
+        self.templateJSON = templateJSON
+    }
+
+    /// The template as a JSON object, for rewriting ids.
+    var templateObject: [String: Any]
+    {
+        get
+        {
+            (try? JSONSerialization.jsonObject(with: templateJSON) as? [String: Any]) ?? [:]
+        }
+        set
+        {
+            templateJSON = Self.canonicalJSON(newValue)
+        }
+    }
+
+    static func canonicalJSON(_ object: [String: Any]) -> Data
+    {
+        (try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])) ?? Data()
+    }
+
+    private enum CodingKeys: String, CodingKey
+    {
+        case id
+        case name
+        case template
+    }
+
+    public required init(from decoder: any Decoder) throws
+    {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(UUID.self, forKey: .id)
+        self.name = try container.decode(String.self, forKey: .name)
+        let template = try container.decode(AnyCodable.self, forKey: .template).value as? [String: Any] ?? [:]
+        self.templateJSON = Self.canonicalJSON(template)
+    }
+
+    public func encode(to encoder: any Encoder) throws
+    {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.id, forKey: .id)
+        try container.encode(self.name, forKey: .name)
+        try container.encode(AnyCodable(self.templateObject), forKey: .template)
+    }
+}

--- a/Fabric/Graph/CloneSet.swift
+++ b/Fabric/Graph/CloneSet.swift
@@ -22,28 +22,28 @@ public final class CloneSet: Codable, Identifiable
     public let id: UUID
     public internal(set) var name: String
 
+    /// The registered type of the set's members (a Subgraph, Iterator, ...),
+    /// as the document spells it, so a member can be made from the template
+    /// alone.
+    public let memberNodeType: String
+
     /// Canonical JSON of the template graph, keys sorted, so two templates
     /// with the same design compare equal byte for byte.
     public internal(set) var templateJSON: Data
 
-    init(id: UUID = UUID(), name: String, templateJSON: Data)
+    init(id: UUID = UUID(), name: String, memberNodeType: String, templateJSON: Data)
     {
         self.id = id
         self.name = name
+        self.memberNodeType = memberNodeType
         self.templateJSON = templateJSON
     }
 
     /// The template as a JSON object, for rewriting ids.
     var templateObject: [String: Any]
     {
-        get
-        {
-            (try? JSONSerialization.jsonObject(with: templateJSON) as? [String: Any]) ?? [:]
-        }
-        set
-        {
-            templateJSON = Self.canonicalJSON(newValue)
-        }
+        get { Self.jsonObject(from: templateJSON) ?? [:] }
+        set { templateJSON = Self.canonicalJSON(newValue) }
     }
 
     static func canonicalJSON(_ object: [String: Any]) -> Data
@@ -51,10 +51,20 @@ public final class CloneSet: Codable, Identifiable
         (try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])) ?? Data()
     }
 
+    /// JSON parsed into Swift-typed values. JSONSerialization's NSNumbers
+    /// re-encode 0 and 1 as booleans through AnyCodable, which breaks any
+    /// number that goes back through a decoder, so parse this way wherever
+    /// the object will be encoded again.
+    static func jsonObject(from data: Data) -> [String: Any]?
+    {
+        (try? JSONDecoder().decode(AnyCodable.self, from: data))?.value as? [String: Any]
+    }
+
     private enum CodingKeys: String, CodingKey
     {
         case id
         case name
+        case memberNodeType
         case template
     }
 
@@ -63,6 +73,7 @@ public final class CloneSet: Codable, Identifiable
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.id = try container.decode(UUID.self, forKey: .id)
         self.name = try container.decode(String.self, forKey: .name)
+        self.memberNodeType = try container.decode(String.self, forKey: .memberNodeType)
         let template = try container.decode(AnyCodable.self, forKey: .template).value as? [String: Any] ?? [:]
         self.templateJSON = Self.canonicalJSON(template)
     }
@@ -72,6 +83,7 @@ public final class CloneSet: Codable, Identifiable
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(self.id, forKey: .id)
         try container.encode(self.name, forKey: .name)
+        try container.encode(self.memberNodeType, forKey: .memberNodeType)
         try container.encode(AnyCodable(self.templateObject), forKey: .template)
     }
 }

--- a/Fabric/Graph/CloneSetCoordinator.swift
+++ b/Fabric/Graph/CloneSetCoordinator.swift
@@ -7,17 +7,84 @@
 
 import Foundation
 
-/// Per-document clone set state, owned by the root graph. See Graph+CloneSet.
+/// Per-document clone set state, owned by the root graph: the reconcile
+/// re-entrancy flag and the debounced sync that follows edits inside a
+/// member. See Graph+CloneSet.
 public final class CloneSetCoordinator
 {
     /// Set while a member is being brought in line with its set, so the
     /// writes that reconcile makes are never mistaken for edits of their own.
     var isReconciling = false
 
+    /// How long edits must pause before pending syncs run.
+    public var debounceInterval: Duration = .milliseconds(100)
+
     private(set) weak var rootGraph: Graph?
+    private let lock = NSLock()
+    private var pendingGraphs: [Graph] = []
+    private var debounceTask: Task<Void, Never>?
 
     init(rootGraph: Graph)
     {
         self.rootGraph = rootGraph
+    }
+
+    /// True between an edit inside a member and the sync that follows it.
+    public var hasPendingSync: Bool
+    {
+        lock.withLock { !pendingGraphs.isEmpty }
+    }
+
+    /// An edit landed in `graph`. Coalesces with other edits until they pause.
+    func noteContentChanged(in graph: Graph)
+    {
+        let interval = self.debounceInterval
+        let task = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: interval)
+            guard !Task.isCancelled else { return }
+            self?.flush()
+        }
+
+        let superseded: Task<Void, Never>? = lock.withLock {
+            if !pendingGraphs.contains(where: { $0 === graph }) { pendingGraphs.append(graph) }
+            defer { debounceTask = task }
+            return debounceTask
+        }
+        superseded?.cancel()
+    }
+
+    /// Runs every pending sync now. Each edited graph is the source for the
+    /// sets around it; a graph edited while a sync was pending is picked up
+    /// by that sync. The members involved then re-subscribe to their node
+    /// trees, which the sync may have changed. No-op while a reconcile is
+    /// already running.
+    public func flush()
+    {
+        guard !isReconciling, let rootGraph else { return }
+
+        let (graphs, task): ([Graph], Task<Void, Never>?) = lock.withLock {
+            defer
+            {
+                pendingGraphs.removeAll()
+                debounceTask = nil
+            }
+            return (pendingGraphs, debounceTask)
+        }
+        task?.cancel()
+
+        var touchedSetIDs = Set<UUID>()
+        for graph in graphs
+        {
+            rootGraph.reconcileCloneSets(enclosing: graph)
+            touchedSetIDs.formUnion(graph.enclosingCloneMembers.compactMap(\.cloneSetID))
+        }
+
+        for setID in touchedSetIDs
+        {
+            for member in rootGraph.cloneSetMembers(of: setID)
+            {
+                member.cloneObserver?.refresh()
+            }
+        }
     }
 }

--- a/Fabric/Graph/CloneSetCoordinator.swift
+++ b/Fabric/Graph/CloneSetCoordinator.swift
@@ -1,0 +1,23 @@
+//
+//  CloneSetCoordinator.swift
+//  Fabric
+//
+//  Created by Claude on 9/10/26.
+//
+
+import Foundation
+
+/// Per-document clone set state, owned by the root graph. See Graph+CloneSet.
+public final class CloneSetCoordinator
+{
+    /// Set while a member is being brought in line with its set, so the
+    /// writes that reconcile makes are never mistaken for edits of their own.
+    var isReconciling = false
+
+    private(set) weak var rootGraph: Graph?
+
+    init(rootGraph: Graph)
+    {
+        self.rootGraph = rootGraph
+    }
+}

--- a/Fabric/Graph/CloneSetCoordinator.swift
+++ b/Fabric/Graph/CloneSetCoordinator.swift
@@ -10,6 +10,10 @@ import Foundation
 /// Per-document clone set state, owned by the root graph: the reconcile
 /// re-entrancy flag and the debounced sync that follows edits inside a
 /// member. See Graph+CloneSet.
+///
+/// Main thread only. Edits, syncs and the debounce all happen there, as does
+/// every other edit of a graph; a call from elsewhere is moved to the main
+/// actor rather than run in place.
 public final class CloneSetCoordinator
 {
     /// Set while a member is being brought in line with its set, so the
@@ -20,7 +24,6 @@ public final class CloneSetCoordinator
     public var debounceInterval: Duration = .milliseconds(100)
 
     private(set) weak var rootGraph: Graph?
-    private let lock = NSLock()
     private var pendingGraphs: [Graph] = []
     private var debounceTask: Task<Void, Never>?
 
@@ -32,25 +35,27 @@ public final class CloneSetCoordinator
     /// True between an edit inside a member and the sync that follows it.
     public var hasPendingSync: Bool
     {
-        lock.withLock { !pendingGraphs.isEmpty }
+        !pendingGraphs.isEmpty
     }
 
     /// An edit landed in `graph`. Coalesces with other edits until they pause.
     func noteContentChanged(in graph: Graph)
     {
+        guard Thread.isMainThread else
+        {
+            Task { @MainActor [weak self] in self?.noteContentChanged(in: graph) }
+            return
+        }
+
+        if !pendingGraphs.contains(where: { $0 === graph }) { pendingGraphs.append(graph) }
+
+        debounceTask?.cancel()
         let interval = self.debounceInterval
-        let task = Task { @MainActor [weak self] in
+        debounceTask = Task { @MainActor [weak self] in
             try? await Task.sleep(for: interval)
             guard !Task.isCancelled else { return }
             self?.flush()
         }
-
-        let superseded: Task<Void, Never>? = lock.withLock {
-            if !pendingGraphs.contains(where: { $0 === graph }) { pendingGraphs.append(graph) }
-            defer { debounceTask = task }
-            return debounceTask
-        }
-        superseded?.cancel()
     }
 
     /// Runs every pending sync now. Each edited graph is the source for the
@@ -60,17 +65,17 @@ public final class CloneSetCoordinator
     /// already running.
     public func flush()
     {
+        guard Thread.isMainThread else
+        {
+            Task { @MainActor [weak self] in self?.flush() }
+            return
+        }
         guard !isReconciling, let rootGraph else { return }
 
-        let (graphs, task): ([Graph], Task<Void, Never>?) = lock.withLock {
-            defer
-            {
-                pendingGraphs.removeAll()
-                debounceTask = nil
-            }
-            return (pendingGraphs, debounceTask)
-        }
-        task?.cancel()
+        debounceTask?.cancel()
+        debounceTask = nil
+        let graphs = pendingGraphs
+        pendingGraphs.removeAll()
 
         var touchedSetIDs = Set<UUID>()
         for graph in graphs
@@ -86,5 +91,12 @@ public final class CloneSetCoordinator
                 member.cloneObserver?.refresh()
             }
         }
+    }
+
+    /// Waits for a pending debounce to run its sync, for callers that need
+    /// the siblings in step now rather than after the pause.
+    public func settle() async
+    {
+        await debounceTask?.value
     }
 }

--- a/Fabric/Graph/Graph+CloneReconcile.swift
+++ b/Fabric/Graph/Graph+CloneReconcile.swift
@@ -1,0 +1,557 @@
+//
+//  Graph+CloneReconcile.swift
+//  Fabric
+//
+//  Created by Claude on 9/10/26.
+//
+
+import Foundation
+internal import AnyCodable
+
+/// What one reconcile pass changed on the target, summed over nested graphs.
+public struct CloneReconcileReport: Equatable
+{
+    public var nodesAdded = 0
+    public var nodesRemoved = 0
+    public var nodesReplaced = 0
+    public var nodesUpdated = 0
+    public var connectionsAdded = 0
+    public var connectionsRemoved = 0
+    public var connectionsToggled = 0
+    public var notesReplaced = 0
+
+    public init() { }
+
+    public var isEmpty: Bool { self == CloneReconcileReport() }
+}
+
+/// The id correspondence one reconcile works through: the source member's
+/// local ids to template ids, and template ids to the target member's local
+/// ids. The target side grows as the target gains what the source has; the
+/// source side grows only where the source had an id its record did not,
+/// which a template refresh beforehand makes rare.
+struct CloneSyncContext
+{
+    private(set) var templateByLocal: [String: String]
+    private(set) var localByTemplate: [String: String]
+    private(set) var sourceRecordGrowth: [String: String] = [:]
+
+    init(source: SubgraphNode, target: SubgraphNode)
+    {
+        self.templateByLocal = Dictionary(source.cloneRecord.map { ($0.value, $0.key) },
+                                          uniquingKeysWith: { first, _ in first })
+        self.localByTemplate = target.cloneRecord
+    }
+
+    /// The template id of one of the source's ids, assigned if unknown.
+    mutating func templateID(forSourceLocal localID: String) -> String
+    {
+        if let known = templateByLocal[localID] { return known }
+        let templateID = UUID().uuidString
+        templateByLocal[localID] = templateID
+        sourceRecordGrowth[templateID] = localID
+        return templateID
+    }
+
+    func templateID(forSourceLocal id: UUID) -> String?
+    {
+        templateByLocal[id.uuidString]
+    }
+
+    /// The target's id for a template id, assigned and recorded if unknown.
+    mutating func targetLocalID(forTemplate templateID: String) -> String
+    {
+        if let known = localByTemplate[templateID] { return known }
+        let localID = UUID().uuidString
+        localByTemplate[templateID] = localID
+        return localID
+    }
+
+    func targetLocalID(forTemplate templateID: String) -> UUID?
+    {
+        localByTemplate[templateID].flatMap(UUID.init(uuidString:))
+    }
+
+    /// The target's id that stands for one of the source's ids, where both
+    /// records already know it.
+    func targetLocalID(forSourceLocal id: UUID) -> UUID?
+    {
+        guard let templateID = templateByLocal[id.uuidString] else { return nil }
+        return targetLocalID(forTemplate: templateID)
+    }
+
+    mutating func record(targetLocal localID: UUID, forTemplate templateID: String)
+    {
+        localByTemplate[templateID] = localID.uuidString
+    }
+
+    /// Template ids the target currently records, by the target's local id.
+    var templateByTargetLocal: [String: String]
+    {
+        Dictionary(localByTemplate.map { ($0.value, $0.key) }, uniquingKeysWith: { first, _ in first })
+    }
+}
+
+extension Graph
+{
+    // MARK: - Sync
+
+    /// Refreshes the set's template from `member`, then brings every sibling
+    /// in line with it. Siblings nested inside the member, or containing it,
+    /// are skipped: a set cannot contain itself.
+    public func reconcileCloneSiblings(of member: SubgraphNode)
+    {
+        guard member.cloneSetID != nil else { return }
+        self.refreshCloneTemplate(from: member)
+
+        for sibling in self.cloneSiblings(of: member)
+        {
+            self.reconcileCloneMember(sibling, from: member)
+        }
+    }
+
+    /// Syncs every set that `graph` sits inside, innermost first, taking the
+    /// enclosing member as the source each time.
+    public func reconcileCloneSets(enclosing graph: Graph)
+    {
+        var current: Graph? = graph
+        while let owner = current?.ownerNode
+        {
+            if owner.cloneSetID != nil, let ownerGraph = owner.graph
+            {
+                ownerGraph.reconcileCloneSiblings(of: owner)
+            }
+            current = owner.graph
+        }
+    }
+
+    /// Makes `target` match `source` node for node through the two members'
+    /// records, touching only what differs so runtime state survives, and
+    /// grows the records with anything new. A target with no record cannot be
+    /// matched and is rebuilt from the template instead. Registers no undo
+    /// steps: the edit that caused this is undone on the source, and the
+    /// siblings follow again. Returns what changed; empty where nothing did
+    /// or the pair cannot be synced.
+    @discardableResult
+    public func reconcileCloneMember(_ target: SubgraphNode, from source: SubgraphNode) -> CloneReconcileReport
+    {
+        var report = CloneReconcileReport()
+        guard target !== source,
+              let setID = source.cloneSetID, target.cloneSetID == setID,
+              !target.subGraph.isDescendant(of: source.subGraph),
+              !source.subGraph.isDescendant(of: target.subGraph)
+        else { return report }
+
+        let coordinator = self.cloneSetCoordinator
+        let wasReconciling = coordinator.isReconciling
+        coordinator.isReconciling = true
+        defer { coordinator.isReconciling = wasReconciling }
+
+        if target.cloneRecord.isEmpty
+        {
+            return self.recoverCloneMember(target)
+        }
+
+        var context = CloneSyncContext(source: source, target: target)
+        target.subGraph.reconcile(from: source.subGraph, context: &context, report: &report)
+
+        if context.localByTemplate != target.cloneRecord { target.cloneRecord = context.localByTemplate }
+        if !context.sourceRecordGrowth.isEmpty
+        {
+            source.cloneRecord.merge(context.sourceRecordGrowth) { current, _ in current }
+        }
+        return report
+    }
+
+    /// Replaces `member` with a fresh instance of its set's template, in the
+    /// same place with the same rename, re-binding the parent graph's wires
+    /// to its published ports by their names. For a member whose record is
+    /// missing, so nothing in it can be matched.
+    @discardableResult
+    internal func recoverCloneMember(_ member: SubgraphNode) -> CloneReconcileReport
+    {
+        var report = CloneReconcileReport()
+        guard let setID = member.cloneSetID, let parent = member.graph else { return report }
+
+        struct ParentWire { let otherPort: Port; let proxyName: String; let proxyKind: PortKind; let active: Bool }
+        let memberPortIDs = Set(member.ports.map(\.id))
+        let wires: [ParentWire] = parent.connections.compactMap { connection in
+            guard let outlet = connection.outletPort, let inlet = connection.inletPort else { return nil }
+            if memberPortIDs.contains(inlet.id)
+            {
+                return ParentWire(otherPort: outlet, proxyName: inlet.displayName, proxyKind: .Inlet, active: connection.active)
+            }
+            if memberPortIDs.contains(outlet.id)
+            {
+                return ParentWire(otherPort: inlet, proxyName: outlet.displayName, proxyKind: .Outlet, active: connection.active)
+            }
+            return nil
+        }
+
+        parent.withoutUndoRegistration {
+            guard let fresh = parent.instantiateCloneSetMember(of: setID, at: member.offset) else { return }
+            fresh.userName = member.userName
+            report.nodesRemoved += member.subGraph.nodesRecursive().count
+            report.nodesAdded += fresh.subGraph.nodesRecursive().count
+
+            for wire in wires
+            {
+                guard let proxy = fresh.ports.first(where: { $0.kind == wire.proxyKind && $0.displayName == wire.proxyName })
+                else { continue }
+                let connection = wire.proxyKind == .Inlet
+                    ? parent.connect(wire.otherPort, to: proxy)
+                    : parent.connect(proxy, to: wire.otherPort)
+                if let connection
+                {
+                    report.connectionsAdded += 1
+                    if !wire.active { parent.setConnection(connection, active: false) }
+                }
+            }
+
+            parent.delete(node: member)
+        }
+        return report
+    }
+
+    // MARK: - Template as source
+
+    /// A new member of the set made from the template alone, added to this
+    /// graph at `offset`: every id fresh and recorded, the set's member class.
+    @discardableResult
+    public func instantiateCloneSetMember(of setID: UUID, at offset: CGSize = .zero) -> SubgraphNode?
+    {
+        guard let set = self.cloneSet(for: setID) else { return nil }
+        return self.instantiateMember(of: set, at: offset)
+    }
+
+    /// The same for a set this graph's document may not hold, as for the
+    /// transient source an updated template is applied through.
+    internal func instantiateMember(of set: CloneSet, at offset: CGSize = .zero) -> SubgraphNode?
+    {
+        let remap = Dictionary(uniqueKeysWithValues: Self.findAllUUIDs(in: set.templateObject).map { ($0, UUID().uuidString) })
+        let subGraphObject = Self.remapUUIDs(in: set.templateObject, remap: remap, preservingKeys: [Self.cloneSetIDKey])
+
+        let qualified = Self.qualifiedNodeID(fromSerializedType: set.memberNodeType)
+        guard let registry = try? NodeRegistry.shared,
+              let memberClass = registry.nodeClass(pluginID: qualified.pluginID, nodeID: qualified.nodeID) as? SubgraphNode.Type
+        else { return nil }
+
+        // Decode a member the way a document does: a blank node of the class
+        // encoded for its own keys, with the template put in as its sub graph.
+        let blank = memberClass.init(context: self.context)
+        guard let blankData = try? JSONEncoder().encode(blank),
+              var object = CloneSet.jsonObject(from: blankData)
+        else { return nil }
+        object["subGraph"] = subGraphObject
+        object["proxyPorts"] = nil
+        object[Self.cloneSetIDKey] = set.id.uuidString
+        object["cloneRecord"] = remap
+
+        let map = AnyCodableMap(type: set.memberNodeType, value: AnyCodable(object))
+        guard let node = self.decodeNode(from: map) as? SubgraphNode else { return nil }
+        node.offset = offset
+        self.addNode(node)
+        return node
+    }
+
+    /// Takes `templateJSON` as the set's template, as when a shared template
+    /// changes outside the document, and reconciles every member from it.
+    /// A transient member is made from the new template to serve as the
+    /// source, then discarded.
+    @discardableResult
+    public func applyCloneTemplate(_ templateJSON: Data, to setID: UUID) -> [CloneReconcileReport]
+    {
+        guard let set = self.cloneSet(for: setID),
+              let object = CloneSet.jsonObject(from: templateJSON)
+        else { return [] }
+        set.templateObject = object
+
+        let scratch = Graph(context: self.context)
+        guard let transient = scratch.instantiateMember(of: set) else { return [] }
+        defer { scratch.delete(node: transient) }
+
+        return self.cloneSetMembers(of: setID).map { member in
+            self.reconcileCloneMember(member, from: transient)
+        }
+    }
+
+    /// True when this graph is `ancestor` or sits anywhere inside it.
+    internal func isDescendant(of ancestor: Graph) -> Bool
+    {
+        var current: Graph? = self
+        while let graph = current
+        {
+            if graph === ancestor { return true }
+            current = graph.ownerNode?.graph
+        }
+        return false
+    }
+
+    // MARK: - Reconcile one graph
+
+    /// Makes this graph's design match `source` through `context`. Nested
+    /// sub graphs reconcile first, so the proxies the parent's wires land on
+    /// exist before the wires are diffed.
+    internal func reconcile(from source: Graph, context: inout CloneSyncContext, report: inout CloneReconcileReport)
+    {
+        self.performWithBatchedConnectionTopologyChanges {
+            self.withoutUndoRegistration {
+                self.reconcileNodes(from: source, context: &context, report: &report)
+                self.reconcileConnections(from: source, context: &context, report: &report)
+                self.reconcileNotes(from: source, report: &report)
+            }
+        }
+
+        if !report.isEmpty
+        {
+            self.rebuildPublishedParameterGroup()
+            self.markConnectionsChanged()
+        }
+    }
+
+    private func reconcileNodes(from source: Graph, context: inout CloneSyncContext, report: inout CloneReconcileReport)
+    {
+        let sourceTemplateIDs = Set(source.nodes.map { context.templateID(forSourceLocal: $0.id.uuidString) })
+        let templateByTargetLocal = context.templateByTargetLocal
+        for node in self.nodes
+        {
+            let templateID = templateByTargetLocal[node.id.uuidString]
+            guard templateID == nil || !sourceTemplateIDs.contains(templateID!) else { continue }
+            self.delete(node: node)
+            report.nodesRemoved += 1
+        }
+
+        for sourceNode in source.nodes
+        {
+            let templateID = context.templateID(forSourceLocal: sourceNode.id.uuidString)
+            if let localID = context.targetLocalID(forTemplate: templateID), let target = self.node(forID: localID)
+            {
+                if target.canReconcileInPlace(from: sourceNode)
+                {
+                    self.reconcileNodeState(target, from: sourceNode, context: &context, report: &report)
+                    continue
+                }
+
+                self.delete(node: target)
+                report.nodesReplaced += 1
+            }
+            else
+            {
+                report.nodesAdded += 1
+            }
+
+            if let copy = self.cloneNodeInstance(of: sourceNode, context: &context)
+            {
+                self.addNode(copy)
+            }
+        }
+    }
+
+    /// Layout, rename, published state and the values of inlets that are
+    /// neither published nor wired, port by port through the records with
+    /// the port's name as the fallback. Published inlet values are the
+    /// member's own. A sub graph reconciles first.
+    private func reconcileNodeState(_ target: Node, from source: Node,
+                                    context: inout CloneSyncContext, report: inout CloneReconcileReport)
+    {
+        if let targetSubgraph = target as? SubgraphNode, let sourceSubgraph = source as? SubgraphNode
+        {
+            targetSubgraph.subGraph.reconcile(from: sourceSubgraph.subGraph, context: &context, report: &report)
+        }
+
+        var changed = false
+
+        if target.offset != source.offset
+        {
+            target.offset = source.offset
+            changed = true
+        }
+
+        if target.userName != source.userName
+        {
+            target.userName = source.userName
+            changed = true
+        }
+
+        for sourcePort in source.ports
+        {
+            let templateID = context.templateID(forSourceLocal: sourcePort.id.uuidString)
+            var port = context.targetLocalID(forTemplate: templateID).flatMap { localID in
+                target.ports.first { $0.id == localID }
+            }
+            if port == nil,
+               let byName = target.ports.first(where: {
+                   $0.kind == sourcePort.kind && $0.name == sourcePort.name && $0.portType == sourcePort.portType
+               })
+            {
+                port = byName
+                context.record(targetLocal: byName.id, forTemplate: templateID)
+            }
+            guard let port else { continue }
+
+            if port.published != sourcePort.published
+            {
+                port.published = sourcePort.published
+                changed = true
+            }
+
+            if port.publishedName != sourcePort.publishedName
+            {
+                port.publishedName = sourcePort.publishedName
+                changed = true
+            }
+
+            guard sourcePort.kind == .Inlet,
+                  !sourcePort.published,
+                  sourcePort.connections.isEmpty,
+                  !(sourcePort is any ProxyPortProtocol),
+                  sourcePort.portType == port.portType
+            else { continue }
+
+            let sourceValue = sourcePort.snapshotValue()
+            if port.snapshotValue() != sourceValue
+            {
+                port.restoreValue(from: sourceValue)
+                changed = true
+            }
+        }
+
+        if changed { report.nodesUpdated += 1 }
+    }
+
+    private func reconcileConnections(from source: Graph, context: inout CloneSyncContext, report: inout CloneReconcileReport)
+    {
+        report.connectionsRemoved += self.pruneDanglingConnections()
+
+        var desired: [UUID: [UUID: Bool]] = [:]
+        for connection in source.connections
+        {
+            guard let outletID = context.targetLocalID(forSourceLocal: connection.outletPortID),
+                  let inletID = context.targetLocalID(forSourceLocal: connection.inletPortID),
+                  self.nodePort(forID: outletID) != nil, self.nodePort(forID: inletID) != nil
+            else { continue }
+
+            desired[outletID, default: [:]][inletID] = connection.active
+        }
+
+        var presentPairs: [UUID: Set<UUID>] = [:]
+        for connection in self.connections
+        {
+            guard let active = desired[connection.outletPortID]?[connection.inletPortID]
+            else
+            {
+                if self.disconnect(connection) { report.connectionsRemoved += 1 }
+                continue
+            }
+
+            presentPairs[connection.outletPortID, default: []].insert(connection.inletPortID)
+            if connection.active != active, self.setConnection(connection, active: active)
+            {
+                report.connectionsToggled += 1
+            }
+        }
+
+        for (outletID, inlets) in desired
+        {
+            for (inletID, active) in inlets where presentPairs[outletID]?.contains(inletID) != true
+            {
+                guard let outlet = self.nodePort(forID: outletID),
+                      let inlet = self.nodePort(forID: inletID),
+                      let connection = self.connect(outlet, to: inlet)
+                else { continue }
+
+                report.connectionsAdded += 1
+                if !active { self.setConnection(connection, active: false) }
+            }
+        }
+    }
+
+    private func reconcileNotes(from source: Graph, report: inout CloneReconcileReport)
+    {
+        let unchanged = self.notes.count == source.notes.count
+            && zip(self.notes, source.notes).allSatisfy { $0.note == $1.note && $0.rect == $1.rect }
+        guard !unchanged else { return }
+
+        for note in self.notes { self.deleteNote(note) }
+        for note in source.notes { self.addNote(Note(note: note.note, rect: note.rect)) }
+        report.notesReplaced += 1
+    }
+
+    // MARK: - Node copies
+
+    /// A fresh instance of `node` for this graph: every id mapped through the
+    /// records to the target's id for it, existing or newly assigned, so a
+    /// replaced node keeps the ids the parent's wires and the host know.
+    private func cloneNodeInstance(of node: Node, context: inout CloneSyncContext) -> Node?
+    {
+        do
+        {
+            let qualifiedNodeID = try self.qualifiedNodeID(for: type(of: node))
+            let map = AnyCodableMap(type: qualifiedNodeID.description, value: AnyCodable(node))
+            let data = try JSONEncoder().encode(map)
+
+            var remap: [String: String] = [:]
+            for sourceLocal in Graph.findAllUUIDs(in: data)
+            {
+                let templateID = context.templateID(forSourceLocal: sourceLocal)
+                remap[sourceLocal] = context.targetLocalID(forTemplate: templateID)
+            }
+            guard let rewritten = Graph.rewriteUUIDs(in: data, remap: remap, preservingKeys: [Self.cloneSetIDKey])
+            else { return nil }
+
+            let rewrittenMap = try JSONDecoder().decode(AnyCodableMap.self, from: rewritten)
+            return self.decodeNode(from: rewrittenMap)
+        }
+        catch
+        {
+            print("cloneNodeInstance: failed for \(node): \(error)")
+            return nil
+        }
+    }
+}
+
+// MARK: - Settings
+
+extension Node
+{
+    /// Same class and same settings: the port set the code declares matches,
+    /// so state can be applied port by port instead of replacing the node.
+    fileprivate func canReconcileInPlace(from source: Node) -> Bool
+    {
+        type(of: self) == type(of: source)
+            && self.cloneSettingsSignature() == source.cloneSettingsSignature()
+    }
+
+    /// Encoded keys that are not settings: identity, layout, port state, and
+    /// for a subgraph the sub graph and clone links, all reconciled in place.
+    private var cloneSettingsExcludedKeys: Set<String>
+    {
+        var keys: Set<String> = ["id", "nodeOffset", "ports", "userName"]
+        if self is SubgraphNode
+        {
+            keys.formUnion(["subGraph", "proxyPorts", Graph.cloneSetIDKey, "cloneRecord"])
+        }
+        return keys
+    }
+
+    /// The node's settings as a comparable blob: its encoded form minus the
+    /// excluded keys, with every UUID normalised. Two members whose nodes
+    /// compare equal here can be reconciled in place; otherwise the sibling's
+    /// node is replaced, since only decode rebuilds a settings-driven port set.
+    internal func cloneSettingsSignature() -> Data?
+    {
+        guard let data = try? JSONEncoder().encode(self),
+              var object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+
+        for key in self.cloneSettingsExcludedKeys
+        {
+            object[key] = nil
+        }
+
+        let placeholder = "uuid"
+        let remap = Dictionary(uniqueKeysWithValues: Graph.findAllUUIDs(in: object).map { ($0, placeholder) })
+        let normalised = Graph.remapUUIDs(in: object, remap: remap)
+        return try? JSONSerialization.data(withJSONObject: normalised, options: [.sortedKeys])
+    }
+}

--- a/Fabric/Graph/Graph+CloneReconcile.swift
+++ b/Fabric/Graph/Graph+CloneReconcile.swift
@@ -275,6 +275,13 @@ extension Graph
         }
     }
 
+    /// Runs any sync still waiting on the debounce, so a document is saved
+    /// with every set in step.
+    public func flushPendingCloneSync()
+    {
+        self.cloneSetCoordinator.flush()
+    }
+
     /// True when this graph is `ancestor` or sits anywhere inside it.
     internal func isDescendant(of ancestor: Graph) -> Bool
     {

--- a/Fabric/Graph/Graph+CloneSet.swift
+++ b/Fabric/Graph/Graph+CloneSet.swift
@@ -67,7 +67,8 @@ extension Graph
         let previousRecord = node.cloneRecord
         if node.cloneSetID == nil
         {
-            let set = CloneSet(name: self.nextFreeCloneSetName(), templateJSON: Data())
+            guard let memberNodeType = try? self.qualifiedNodeID(for: type(of: node)).description else { return nil }
+            let set = CloneSet(name: self.nextFreeCloneSetName(), memberNodeType: memberNodeType, templateJSON: Data())
             self.addCloneSetUndoably(set)
             self.setCloneMembership(setID: set.id, record: [:], on: node)
         }
@@ -86,17 +87,29 @@ extension Graph
 
     // MARK: - Template
 
-    /// Rewrites the set's template from `member`'s current design. Any id the
-    /// member has that the template did not is given a template id and
-    /// recorded, so the template and the record together describe the member
-    /// exactly. Returns false where the member is in no set.
+    /// Rewrites the set's template from `member`'s current design. Returns
+    /// false where the member is in no set.
     @discardableResult
     internal func refreshCloneTemplate(from member: SubgraphNode) -> Bool
     {
         guard let setID = member.cloneSetID, let set = self.cloneSet(for: setID),
-              let data = try? JSONEncoder().encode(member.subGraph),
-              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+              let canonical = self.cloneTemplateJSON(from: member)
         else { return false }
+
+        if canonical != set.templateJSON { set.templateJSON = canonical }
+        return true
+    }
+
+    /// `member`'s current design in the template's ids: canonical JSON of its
+    /// sub graph with every local id rewritten to the id the member records
+    /// for it. Any id the record did not have is given a template id and
+    /// recorded first, so the template and the record together describe the
+    /// member exactly. Does not touch the set.
+    public func cloneTemplateJSON(from member: SubgraphNode) -> Data?
+    {
+        guard let data = try? JSONEncoder().encode(member.subGraph),
+              let object = CloneSet.jsonObject(from: data)
+        else { return nil }
 
         var record = member.cloneRecord
         var templateIDsByLocal = Dictionary(record.map { ($0.value, $0.key) },
@@ -112,9 +125,7 @@ extension Graph
         let templateObject = Self.remapUUIDs(in: object,
                                              remap: templateIDsByLocal,
                                              preservingKeys: [Self.cloneSetIDKey]) as? [String: Any] ?? [:]
-        let canonical = CloneSet.canonicalJSON(templateObject)
-        if canonical != set.templateJSON { set.templateJSON = canonical }
-        return true
+        return CloneSet.canonicalJSON(templateObject)
     }
 
     // MARK: - Discovery
@@ -214,7 +225,7 @@ extension Graph
             guard let nestedSet = self.cloneSet(for: nestedSetID) else { continue }
             let name = self.nextFreeCloneSetName(excluding: claimedNames)
             claimedNames.insert(name)
-            detachedSets[nestedSetID] = CloneSet(name: name, templateJSON: nestedSet.templateJSON)
+            detachedSets[nestedSetID] = CloneSet(name: name, memberNodeType: nestedSet.memberNodeType, templateJSON: nestedSet.templateJSON)
         }
 
         undoManager?.beginUndoGrouping()

--- a/Fabric/Graph/Graph+CloneSet.swift
+++ b/Fabric/Graph/Graph+CloneSet.swift
@@ -1,0 +1,307 @@
+//
+//  Graph+CloneSet.swift
+//  Fabric
+//
+//  Created by Claude on 9/10/26.
+//
+
+import Foundation
+internal import AnyCodable
+
+/// A member's view of its set: the source of its title icon, its subtitle
+/// and their tooltip. See SubgraphNode.cloneSetInfo.
+public struct CloneSetInfo: Equatable
+{
+    public let setID: UUID
+    public let name: String
+    public let memberCount: Int
+
+    public init(setID: UUID, name: String, memberCount: Int)
+    {
+        self.setID = setID
+        self.name = name
+        self.memberCount = memberCount
+    }
+
+    /// The glyph every clone set member wears.
+    public static let symbolName = "square.on.square"
+
+    public var tooltip: String
+    {
+        "Clone set: \(name), \(memberCount) \(memberCount == 1 ? "member" : "members"). Edits here reach every member."
+    }
+
+    /// The member's title icon: the clone glyph, with the set and its size on hover.
+    public var titleIcon: NodeTitleIcon
+    {
+        NodeTitleIcon(systemName: Self.symbolName, tooltip: tooltip)
+    }
+}
+
+/// Clone sets: groups of SubgraphNodes kept identical in design to a shared
+/// template while each executes on its own. Members are peers to edit: the
+/// member you edit refreshes the template and its siblings are reconciled
+/// from it. See CloneSet for the template and SubgraphNode.cloneRecord for
+/// how a member's ids relate to it.
+extension Graph
+{
+    // MARK: - Creation
+
+    /// Adds a sibling of `node` to this graph: a duplicate that shares the
+    /// node's clone set and records the same template ids against fresh ids
+    /// of its own. Starts a set, with the node's design as its template, if
+    /// the node is not in one yet. One undo step.
+    @discardableResult
+    public func duplicateAsClone(_ node: SubgraphNode,
+                                 offset: CGSize = CGSize(width: 20, height: 20)) -> SubgraphNode?
+    {
+        guard node.graph === self else { return nil }
+
+        undoManager?.beginUndoGrouping()
+        defer
+        {
+            undoManager?.endUndoGrouping()
+            undoManager?.setActionName("Duplicate as Clone")
+        }
+
+        let previousRecord = node.cloneRecord
+        if node.cloneSetID == nil
+        {
+            let set = CloneSet(name: self.nextFreeCloneSetName(), templateJSON: Data())
+            self.addCloneSetUndoably(set)
+            self.setCloneMembership(setID: set.id, record: [:], on: node)
+        }
+
+        // The template and the source's record must be complete before the
+        // copy is taken, since the copy's record is the source's, rewritten.
+        self.refreshCloneTemplate(from: node)
+        self.registerRecordUndo(on: node, previousRecord: previousRecord)
+
+        let copies = self.duplicateNodes([node], offset: offset, preservingCloneLinks: true)
+        guard let copy = copies.first as? SubgraphNode else { return nil }
+
+        self.cloneSetMembershipChanged(setID: copy.cloneSetID)
+        return copy
+    }
+
+    // MARK: - Template
+
+    /// Rewrites the set's template from `member`'s current design. Any id the
+    /// member has that the template did not is given a template id and
+    /// recorded, so the template and the record together describe the member
+    /// exactly. Returns false where the member is in no set.
+    @discardableResult
+    internal func refreshCloneTemplate(from member: SubgraphNode) -> Bool
+    {
+        guard let setID = member.cloneSetID, let set = self.cloneSet(for: setID),
+              let data = try? JSONEncoder().encode(member.subGraph),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return false }
+
+        var record = member.cloneRecord
+        var templateIDsByLocal = Dictionary(record.map { ($0.value, $0.key) },
+                                            uniquingKeysWith: { first, _ in first })
+        for localID in Self.findAllUUIDs(in: object) where templateIDsByLocal[localID] == nil
+        {
+            let templateID = UUID().uuidString
+            record[templateID] = localID
+            templateIDsByLocal[localID] = templateID
+        }
+        if record != member.cloneRecord { member.cloneRecord = record }
+
+        let templateObject = Self.remapUUIDs(in: object,
+                                             remap: templateIDsByLocal,
+                                             preservingKeys: [Self.cloneSetIDKey]) as? [String: Any] ?? [:]
+        let canonical = CloneSet.canonicalJSON(templateObject)
+        if canonical != set.templateJSON { set.templateJSON = canonical }
+        return true
+    }
+
+    // MARK: - Discovery
+
+    /// Every member of the set anywhere in the document, in document order.
+    public func cloneSetMembers(of setID: UUID) -> [SubgraphNode]
+    {
+        self.rootGraph.subgraphNodesRecursive().filter { $0.cloneSetID == setID }
+    }
+
+    /// The other members of `node`'s set; empty outside a set.
+    public func cloneSiblings(of node: SubgraphNode) -> [SubgraphNode]
+    {
+        guard let setID = node.cloneSetID else { return [] }
+        return self.cloneSetMembers(of: setID).filter { $0 !== node }
+    }
+
+    /// Subgraph nodes in this graph and, depth first, in their sub graphs.
+    internal func subgraphNodesRecursive() -> [SubgraphNode]
+    {
+        self.nodes.flatMap { node -> [SubgraphNode] in
+            guard let subgraphNode = node as? SubgraphNode else { return [] }
+            return [subgraphNode] + subgraphNode.subGraph.subgraphNodesRecursive()
+        }
+    }
+
+    // MARK: - Names
+
+    /// Renames the set. Whitespace is trimmed; an empty name goes back to a
+    /// system name, the lowest not in use by another set. Undoable.
+    public func renameCloneSet(_ setID: UUID, to name: String)
+    {
+        guard let set = self.cloneSet(for: setID) else { return }
+
+        var trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty
+        {
+            trimmed = self.nextFreeCloneSetName(ignoring: setID)
+        }
+        let previous = set.name
+        guard previous != trimmed else { return }
+
+        set.name = trimmed
+        self.cloneSetMembershipChanged(setID: setID)
+
+        undoManager?.registerUndo(withTarget: self) { graph in
+            graph.renameCloneSet(setID, to: previous)
+        }
+        undoManager?.setActionName("Rename Clone Set")
+    }
+
+    /// "Set A", "Set B", ... "Set Z", "Set AA", ...: the first not in use by
+    /// any set in the document, `excluding` names claimed in the same edit
+    /// and `ignoring` the set being renamed, whose own name is free to it.
+    internal func nextFreeCloneSetName(excluding claimed: Set<String> = [], ignoring setID: UUID? = nil) -> String
+    {
+        let used = Set(self.rootGraph.cloneSets.filter { $0.id != setID }.map(\.name)).union(claimed)
+        var index = 0
+        while true
+        {
+            let candidate = "Set \(Self.cloneSetLetters(for: index))"
+            if !used.contains(candidate) { return candidate }
+            index += 1
+        }
+    }
+
+    private static func cloneSetLetters(for index: Int) -> String
+    {
+        let alphabet = Array("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+        var letters = ""
+        var remaining = index
+        repeat
+        {
+            letters.insert(alphabet[remaining % alphabet.count], at: letters.startIndex)
+            remaining = remaining / alphabet.count - 1
+        }
+        while remaining >= 0
+        return letters
+    }
+
+    // MARK: - Unlink
+
+    /// Takes `node` out of its set: it keeps its contents and becomes an
+    /// ordinary subgraph. Sets nested inside it get sets of their own, each
+    /// on a copy of the nested template, so their records still resolve while
+    /// they detach from their counterparts in the former siblings. Undoable.
+    public func unlinkClone(_ node: SubgraphNode)
+    {
+        guard node.graph === self, let setID = node.cloneSetID else { return }
+
+        let nestedMembers = node.subGraph.subgraphNodesRecursive().filter { $0.cloneSetID != nil }
+        let nestedSetIDs = Set(nestedMembers.compactMap(\.cloneSetID))
+        var claimedNames = Set<String>()
+        var detachedSets: [UUID: CloneSet] = [:]
+        for nestedSetID in nestedSetIDs.sorted(by: { $0.uuidString < $1.uuidString })
+        {
+            guard let nestedSet = self.cloneSet(for: nestedSetID) else { continue }
+            let name = self.nextFreeCloneSetName(excluding: claimedNames)
+            claimedNames.insert(name)
+            detachedSets[nestedSetID] = CloneSet(name: name, templateJSON: nestedSet.templateJSON)
+        }
+
+        undoManager?.beginUndoGrouping()
+        defer
+        {
+            undoManager?.endUndoGrouping()
+            undoManager?.setActionName("Unlink from Clones")
+        }
+
+        for set in detachedSets.values { self.addCloneSetUndoably(set) }
+
+        self.setCloneMembership(setID: nil, record: [:], on: node)
+        for nestedMember in nestedMembers
+        {
+            guard let nestedSetID = nestedMember.cloneSetID, let detached = detachedSets[nestedSetID] else { continue }
+            self.setCloneMembership(setID: detached.id, record: nestedMember.cloneRecord, on: nestedMember)
+        }
+
+        self.cloneSetMembershipChanged(setID: setID)
+    }
+
+    // MARK: - Bookkeeping
+
+    internal func addCloneSetUndoably(_ set: CloneSet)
+    {
+        self.addCloneSet(set)
+        undoManager?.registerUndo(withTarget: self) { graph in
+            graph.removeCloneSetUndoably(set)
+        }
+    }
+
+    internal func removeCloneSetUndoably(_ set: CloneSet)
+    {
+        self.removeCloneSet(set)
+        undoManager?.registerUndo(withTarget: self) { graph in
+            graph.addCloneSetUndoably(set)
+        }
+    }
+
+    /// Undoable assignment of a node's set and record. The badge on every
+    /// member of the sets touched is refreshed by `cloneSetMembershipChanged`.
+    internal func setCloneMembership(setID: UUID?, record: [String: String], on node: SubgraphNode)
+    {
+        let previousID = node.cloneSetID
+        let previousRecord = node.cloneRecord
+        guard previousID != setID || previousRecord != record else { return }
+
+        node.cloneSetID = setID
+        node.cloneRecord = record
+        node.subtitleSubject.send()
+
+        undoManager?.registerUndo(withTarget: self) { graph in
+            graph.setCloneMembership(setID: previousID, record: previousRecord, on: node)
+            graph.cloneSetMembershipChanged(setID: previousID)
+            graph.cloneSetMembershipChanged(setID: setID)
+        }
+    }
+
+    /// A record grown by a template refresh inside an undoable edit goes back
+    /// with that edit.
+    private func registerRecordUndo(on node: SubgraphNode, previousRecord: [String: String])
+    {
+        let grown = node.cloneRecord
+        guard grown != previousRecord else { return }
+        undoManager?.registerUndo(withTarget: self) { graph in
+            node.cloneRecord = previousRecord
+            graph.registerRecordUndo(on: node, previousRecord: grown)
+        }
+    }
+
+    /// The member count a set's badge shows changed; refresh every member.
+    internal func cloneSetMembershipChanged(setID: UUID?)
+    {
+        guard let setID else { return }
+        for member in self.cloneSetMembers(of: setID)
+        {
+            member.subtitleSubject.send()
+        }
+    }
+
+    /// Strips clone links from a node and everything nested in it, for copies
+    /// that must not be members.
+    internal static func clearCloneLinks(in node: Node)
+    {
+        guard let subgraphNode = node as? SubgraphNode else { return }
+        subgraphNode.cloneSetID = nil
+        subgraphNode.cloneRecord = [:]
+        for inner in subgraphNode.subGraph.nodes { clearCloneLinks(in: inner) }
+    }
+}

--- a/Fabric/Graph/Graph.swift
+++ b/Fabric/Graph/Graph.swift
@@ -167,6 +167,39 @@ internal import AnyCodable
         return shouldSyncScene
     }
 
+    /// Clone set bookkeeping lives on the document's root graph; every graph
+    /// in the document reaches the same coordinator.
+    @ObservationIgnored private var rootCloneSetCoordinator: CloneSetCoordinator?
+    internal var cloneSetCoordinator: CloneSetCoordinator
+    {
+        let root = self.rootGraph
+        guard root === self else { return root.cloneSetCoordinator }
+        if let rootCloneSetCoordinator { return rootCloneSetCoordinator }
+        let coordinator = CloneSetCoordinator(rootGraph: self)
+        self.rootCloneSetCoordinator = coordinator
+        return coordinator
+    }
+
+    /// Drops wires whose ports no longer resolve in this graph, e.g. to a
+    /// proxy that disappeared when its inner port was unpublished.
+    internal func pruneDanglingConnections() -> Int
+    {
+        let dangling = connections.filter {
+            nodePort(forID: $0.outletPortID) == nil || nodePort(forID: $0.inletPortID) == nil
+        }
+        guard !dangling.isEmpty else { return 0 }
+
+        for connection in dangling
+        {
+            connection.graph = nil
+            connection.outletPortReference = nil
+            connection.inletPortReference = nil
+        }
+        connections.removeAll { connection in dangling.contains { $0 === connection } }
+        markConnectionTopologyChanged()
+        return dangling.count
+    }
+
     public let publishedParameterGroup:ParameterGroup = ParameterGroup("Published")
 
     /// Called when the set of published ports changes. SubgraphNode uses
@@ -1585,7 +1618,7 @@ internal import AnyCodable
         return requirementsByID.values.sorted { $0.id < $1.id }
     }
 
-    private static func qualifiedNodeID(fromSerializedType serializedType: String) -> PluginQualifiedNodeID
+    internal static func qualifiedNodeID(fromSerializedType serializedType: String) -> PluginQualifiedNodeID
     {
         guard let separatorRange = serializedType.range(of: PluginQualifiedNodeID.separator) else
         {

--- a/Fabric/Graph/Graph.swift
+++ b/Fabric/Graph/Graph.swift
@@ -164,6 +164,18 @@ internal import AnyCodable
     public func noteContentChanged()
     {
         contentRevision += 1
+        self.scheduleCloneSyncIfNeeded()
+    }
+
+    /// The coordinator and its flag are main-thread state; an edit made
+    /// elsewhere is handed to the main actor to schedule.
+    private func scheduleCloneSyncIfNeeded()
+    {
+        guard Thread.isMainThread else
+        {
+            Task { @MainActor [weak self] in self?.scheduleCloneSyncIfNeeded() }
+            return
+        }
 
         let coordinator = self.cloneSetCoordinator
         guard !coordinator.isReconciling, !self.enclosingCloneMembers.isEmpty else { return }

--- a/Fabric/Graph/Graph.swift
+++ b/Fabric/Graph/Graph.swift
@@ -61,6 +61,19 @@ internal import AnyCodable
     public let version: Graph.Version
     @ObservationIgnored public let context:Context
     @ObservationIgnored public weak var undoManager: UndoManager?
+    /// The SubgraphNode whose sub graph this is; nil for a document's root graph.
+    @ObservationIgnored public internal(set) weak var ownerNode: SubgraphNode?
+    /// The document's root graph, reached by walking up through owner nodes.
+    public var rootGraph: Graph
+    {
+        var graph = self
+        while let parent = graph.ownerNode?.graph { graph = parent }
+        return graph
+    }
+    /// The document's clone sets, held by the root graph and empty elsewhere.
+    /// Members refer to a set by SubgraphNode.cloneSetID. A set no member
+    /// refers to any more is dropped on save.
+    public private(set) var cloneSets: [CloneSet] = []
 
     public private(set) var nodes: [Node]
     public private(set) var notes: [Note]
@@ -169,6 +182,35 @@ internal import AnyCodable
         case portConnectionMap
         case connections
         case notes
+        case cloneSets
+    }
+
+    // MARK: - Clone sets
+
+    public func cloneSet(for setID: UUID) -> CloneSet?
+    {
+        self.rootGraph.cloneSets.first { $0.id == setID }
+    }
+
+    internal func addCloneSet(_ set: CloneSet)
+    {
+        let root = self.rootGraph
+        guard !root.cloneSets.contains(where: { $0.id == set.id }) else { return }
+        root.cloneSets.append(set)
+    }
+
+    internal func removeCloneSet(_ set: CloneSet)
+    {
+        self.rootGraph.cloneSets.removeAll { $0.id == set.id }
+    }
+
+    /// Every node in this graph and, depth first, in nested sub graphs.
+    public func nodesRecursive() -> [Node]
+    {
+        self.nodes.flatMap { node -> [Node] in
+            guard let subgraphNode = node as? SubgraphNode else { return [node] }
+            return [node] + subgraphNode.subGraph.nodesRecursive()
+        }
     }
     
     public init(context:Context)
@@ -200,6 +242,7 @@ internal import AnyCodable
         self.scene = Object(context: context)
 
         self.notes = try container.decodeIfPresent([Note].self, forKey: .notes) ?? []
+        self.cloneSets = try container.decodeIfPresent([CloneSet].self, forKey: .cloneSets) ?? []
         let requiredPlugins = try container.decodeIfPresent([PluginRequirement].self, forKey: .requiredPlugins) ?? []
         let nodeRegistry = try NodeRegistry.shared
         try nodeRegistry.validatePluginRequirements(requiredPlugins)
@@ -460,7 +503,14 @@ internal import AnyCodable
         }
         
         try container.encode(self.notes, forKey: .notes)
-        
+
+        let liveSetIDs = Set(self.subgraphNodesRecursive().compactMap(\.cloneSetID))
+        let liveSets = self.cloneSets.filter { liveSetIDs.contains($0.id) }
+        if !liveSets.isEmpty
+        {
+            try container.encode(liveSets, forKey: .cloneSets)
+        }
+
         try container.encode( nodeMap, forKey: .nodeMap)
         try container.encode(self.connections.filter { connection in
             self.nodePort(forID: connection.outletPortID) != nil &&
@@ -515,6 +565,7 @@ internal import AnyCodable
 
         self.updateRenderingNodes()
         self.rebuildPublishedParameterGroup()
+        self.cloneSetMembershipChanged(setID: (node as? SubgraphNode)?.cloneSetID)
     }
 
     
@@ -556,6 +607,7 @@ internal import AnyCodable
 
         self.updateRenderingNodes()
         self.rebuildPublishedParameterGroup()
+        self.cloneSetMembershipChanged(setID: (node as? SubgraphNode)?.cloneSetID)
     }
 
     private func restoreDeletedNode(_ node: Node,
@@ -578,6 +630,7 @@ internal import AnyCodable
             rebuildPublishedParameterGroup()
             syncNodesToScene()
             markConnectionsChanged()
+            cloneSetMembershipChanged(setID: (node as? SubgraphNode)?.cloneSetID)
         }
 
         undoManager?.registerUndo(withTarget: self) { graph in
@@ -1337,7 +1390,7 @@ internal import AnyCodable
         operation()
     }
 
-    private func performWithBatchedConnectionTopologyChanges(_ operation: () -> Void)
+    internal func performWithBatchedConnectionTopologyChanges(_ operation: () -> Void)
     {
         connectionTopologyBatchDepth += 1
         defer {
@@ -1390,7 +1443,7 @@ internal import AnyCodable
     // MARK: - Private Decode API Helpers -
     
     /// Decodes a single node from an AnyCodableMap, replicating the type resolution from Graph.init(from:)
-    private func decodeNode(from map: AnyCodableMap) -> Node?
+    internal func decodeNode(from map: AnyCodableMap) -> Node?
     {
         // Graph.init(from:) closes each node's hydration window once every node
         // is decoded; duplicate and paste come through here instead, so the
@@ -1490,7 +1543,7 @@ internal import AnyCodable
         }
     }
 
-    private func qualifiedNodeID(for nodeClass: Node.Type) throws -> PluginQualifiedNodeID
+    internal func qualifiedNodeID(for nodeClass: Node.Type) throws -> PluginQualifiedNodeID
     {
         let registry = try NodeRegistry.shared
 
@@ -1545,7 +1598,7 @@ internal import AnyCodable
     }
 
     /// Finds all UUID-formatted strings in JSON data by traversing the parsed structure
-    private static func findAllUUIDs(in jsonData: Data) -> Set<String>
+    internal static func findAllUUIDs(in jsonData: Data) -> Set<String>
     {
         guard let object = try? JSONSerialization.jsonObject(with: jsonData) else { return [] }
         var uuids = Set<String>()
@@ -1553,8 +1606,11 @@ internal import AnyCodable
         return uuids
     }
 
-    /// Recursively replaces UUID strings in a JSON object using a remap table
-    private static func remapUUIDs(in object: Any, remap: [String: String]) -> Any
+    /// Recursively replaces UUID strings in a JSON object using a remap table.
+    /// Values under `preservingKeys` are left as they are, at any depth.
+    /// Dictionary keys are never rewritten: a clone record's keys are template
+    /// ids and stay valid through every rewrite of the record's values.
+    internal static func remapUUIDs(in object: Any, remap: [String: String], preservingKeys: Set<String> = []) -> Any
     {
         switch object
         {
@@ -1562,13 +1618,15 @@ internal import AnyCodable
             return remap[string] ?? string
 
         case let array as [Any]:
-            return array.map { remapUUIDs(in: $0, remap: remap) }
+            return array.map { remapUUIDs(in: $0, remap: remap, preservingKeys: preservingKeys) }
 
         case let dict as [String: Any]:
             var newDict = [String: Any]()
             for (key, value) in dict
             {
-                newDict[key] = remapUUIDs(in: value, remap: remap)
+                newDict[key] = preservingKeys.contains(key)
+                    ? value
+                    : remapUUIDs(in: value, remap: remap, preservingKeys: preservingKeys)
             }
             return newDict
 
@@ -1578,11 +1636,21 @@ internal import AnyCodable
     }
 
     /// Rewrites UUID strings in JSON data using a remap table
-    private static func rewriteUUIDs(in jsonData: Data, remap: [String: String]) -> Data?
+    internal static func rewriteUUIDs(in jsonData: Data,
+                                      remap: [String: String],
+                                      preservingKeys: Set<String> = []) -> Data?
     {
         guard let object = try? JSONSerialization.jsonObject(with: jsonData) else { return nil }
-        let remapped = remapUUIDs(in: object, remap: remap)
+        let remapped = remapUUIDs(in: object, remap: remap, preservingKeys: preservingKeys)
         return try? JSONSerialization.data(withJSONObject: remapped)
+    }
+
+    /// Collects every UUID-formatted string in a JSON object.
+    internal static func findAllUUIDs(in object: Any) -> Set<String>
+    {
+        var uuids = Set<String>()
+        collectUUIDs(from: object, into: &uuids)
+        return uuids
     }
 
     /// Builds a connection map containing only connections where both ports belong to nodes in the given set
@@ -1609,11 +1677,25 @@ internal import AnyCodable
         return connectionMap
     }
 
-    /// Duplicates the given nodes, preserving connections between them, and adds them to the graph
+    /// Duplicates the given nodes, preserving connections between them, and adds them to the graph.
+    /// The copies carry no clone links: a plain duplicate of a clone set member, or of anything
+    /// containing one, is an ordinary subgraph. See `duplicateAsClone`.
     @discardableResult
     public func duplicateNodes(_ nodesToDuplicate: [Node], offset: CGSize = CGSize(width: 20, height: 20)) -> [Node]
     {
+        self.duplicateNodes(nodesToDuplicate, offset: offset, preservingCloneLinks: false)
+    }
+
+    /// The JSON key whose UUID value ties a node to its clone set, kept as-is when duplicating as a
+    /// clone. A member's record needs no such care: its keys are template ids, which a rewrite
+    /// never touches, and its values are local ids, which a rewrite maps along with the nodes.
+    internal static let cloneSetIDKey = "cloneSetID"
+
+    @discardableResult
+    internal func duplicateNodes(_ nodesToDuplicate: [Node], offset: CGSize, preservingCloneLinks: Bool) -> [Node]
+    {
         guard !nodesToDuplicate.isEmpty else { return [] }
+        let preservedKeys: Set<String> = preservingCloneLinks ? [Self.cloneSetIDKey] : []
 
         // 1. Capture internal connections before anything changes
         let internalConnections = self.buildInternalConnectionMap(for: nodesToDuplicate)
@@ -1655,7 +1737,7 @@ internal import AnyCodable
 
         for data in encodedEntries
         {
-            guard let rewrittenData = Graph.rewriteUUIDs(in: data, remap: uuidRemap) else { continue }
+            guard let rewrittenData = Graph.rewriteUUIDs(in: data, remap: uuidRemap, preservingKeys: preservedKeys) else { continue }
 
             do
             {
@@ -1664,6 +1746,7 @@ internal import AnyCodable
                 if let newNode = self.decodeNode(from: rewrittenMap)
                 {
                     newNode.offset = newNode.offset + offset
+                    if !preservingCloneLinks { Self.clearCloneLinks(in: newNode) }
                     newNodes.append(newNode)
                 }
             }

--- a/Fabric/Graph/Graph.swift
+++ b/Fabric/Graph/Graph.swift
@@ -148,6 +148,39 @@ internal import AnyCodable
         connectionRevision += 1
         pendingConnectionSceneSync = true
         connectionTopologyGeneration += 1
+        noteContentChanged()
+    }
+
+    /// Bumped by every edit of the graph's design: topology, layout, renames,
+    /// published state, unwired parameter values, notes. Runtime traffic
+    /// (values arriving on wired or published inlets) does not count. The
+    /// graph's own mutation API bumps it; a clone set member's observer bumps
+    /// it for the edits nodes and ports publish.
+    @ObservationIgnored public private(set) var contentRevision = 0
+
+    /// Records an edit and, when this graph sits inside a clone set, asks the
+    /// coordinator to sync the set once edits pause. Writes made while a
+    /// member is being reconciled are not edits and schedule nothing.
+    public func noteContentChanged()
+    {
+        contentRevision += 1
+
+        let coordinator = self.cloneSetCoordinator
+        guard !coordinator.isReconciling, !self.enclosingCloneMembers.isEmpty else { return }
+        coordinator.noteContentChanged(in: self)
+    }
+
+    /// The clone set members this graph sits inside, innermost first.
+    internal var enclosingCloneMembers: [SubgraphNode]
+    {
+        var members: [SubgraphNode] = []
+        var current: Graph? = self
+        while let owner = current?.ownerNode
+        {
+            if owner.cloneSetID != nil { members.append(owner) }
+            current = owner.graph
+        }
+        return members
     }
 
     public func markExecutionTopologyChanged()
@@ -556,11 +589,13 @@ internal import AnyCodable
     public func addNote(_ note: Note)
     {
         self.notes.append(note)
+        self.noteContentChanged()
     }
     
     public func deleteNote(_ note:Note)
     {
         self.notes.removeAll(where: { $0.id == note.id })
+        self.noteContentChanged()
     }
     
     //MARK: - Nodes API -
@@ -811,6 +846,7 @@ internal import AnyCodable
         guard connection.active != active else { return true }
         let previousActive = connection.active
         connection.active = active
+        noteContentChanged()
 
         undoManager?.registerUndo(withTarget: self) { graph in
             graph.setConnection(connection, active: previousActive)

--- a/Fabric/Graph/GraphCanvasContext.swift
+++ b/Fabric/Graph/GraphCanvasContext.swift
@@ -201,21 +201,27 @@ public class GraphCanvasContext
     public func pop()
     {
         guard !entries.isEmpty else { return }
+        let leaving = currentGraph
         entries.removeLast()
         syncUndoManager()
+        syncCloneSets(leaving: leaving)
     }
 
     public func popTo(_ node: SubgraphNode)
     {
         guard let index = entries.firstIndex(where: { $0.id == node.id }) else { return }
+        let leaving = currentGraph
         entries = Array(entries.prefix(through: index))
         syncUndoManager()
+        syncCloneSets(leaving: leaving)
     }
 
     public func popToRoot()
     {
+        let leaving = currentGraph
         entries.removeAll()
         syncUndoManager()
+        syncCloneSets(leaving: leaving)
     }
 
     // MARK: - Interactive Node Addition
@@ -260,6 +266,13 @@ public class GraphCanvasContext
     }
 
     // MARK: - Private
+
+    /// Leaving a canvas is the point where edits made there are known to be
+    /// complete, so every clone set around it is brought in line.
+    private func syncCloneSets(leaving graph: Graph)
+    {
+        rootGraph.reconcileCloneSets(enclosing: graph)
+    }
 
     /// Propagate the undo manager to the active subgraph so undo works at any nesting level.
     private func syncUndoManager()

--- a/Fabric/Graph/Node/Node.swift
+++ b/Fabric/Graph/Node/Node.swift
@@ -78,6 +78,13 @@ open class Node : Codable, Equatable, Identifiable, Hashable, Copyable, CustomDe
     // allowed here and reads as absence. Read `subtitle`, never this.
     open func deriveSubtitle() -> String? { nil }
 
+    // The glyph at the trailing edge of the title row, with its tooltip:
+    // Math Expression's parse error, for one. Override where the node has
+    // something to flag; nil for none. Read `titleIcon`, never this.
+    open func deriveTitleIcon() -> NodeTitleIcon? { nil }
+
+    final public var titleIcon: NodeTitleIcon? { self.deriveTitleIcon() }
+
     // User-supplied rename. Wins over the node-derived subtitle. Empty is
     // absence: a cleared rename must reveal the derived subtitle again.
     final public var userName: String?
@@ -171,8 +178,8 @@ open class Node : Codable, Equatable, Identifiable, Hashable, Copyable, CustomDe
     /// Fires whenever the port list changes (addDynamicPort / removePort).
     internal let portsChangedSubject = PassthroughSubject<Void, Never>()
 
-    /// Fires whenever state feeding `title` or `subtitle` changes. NodeViewModel
-    /// subscribes and refreshes its observable naming mirrors.
+    /// Fires whenever state feeding `title`, `subtitle` or `titleIcon` changes.
+    /// NodeViewModel subscribes and refreshes its observable title row mirrors.
     internal let subtitleSubject = PassthroughSubject<Void, Never>()
 
     // Dirty Handling

--- a/Fabric/Graph/Node/NodeTitleIcon.swift
+++ b/Fabric/Graph/Node/NodeTitleIcon.swift
@@ -1,0 +1,36 @@
+//
+//  NodeTitleIcon.swift
+//  Fabric
+//
+//  Created by Claude on 9/9/26.
+//
+
+import Foundation
+
+/// A glyph a node shows at the trailing edge of its title row, with a
+/// tooltip on the row: a parse error, a link to something outside the node.
+/// Nodes derive one through `Node.deriveTitleIcon()`.
+public struct NodeTitleIcon: Equatable
+{
+    /// How the glyph is coloured against the title band.
+    public enum Tint: Equatable
+    {
+        /// Reads as part of the title.
+        case neutral
+        /// Something to look at.
+        case warning
+        /// Something broken.
+        case error
+    }
+
+    public let systemName: String
+    public let tooltip: String
+    public let tint: Tint
+
+    public init(systemName: String, tooltip: String, tint: Tint = .neutral)
+    {
+        self.systemName = systemName
+        self.tooltip = tooltip
+        self.tint = tint
+    }
+}

--- a/Fabric/Nodes/Geometry/MathExpressionParametricGeometryNode.swift
+++ b/Fabric/Nodes/Geometry/MathExpressionParametricGeometryNode.swift
@@ -65,16 +65,27 @@ public class MathExpressionParametricGeometryNode: BaseGeometryNode
     // u and v are always resolved by the generator; they never become ports.
     private static let parametricBindings: Set<String> = ["u", "v"]
 
-    /// Shown as the node's title: the three axis expressions, ⚠-prefixed when any
-    /// fails to compile. Falls back to the type name when all axes are blank; a
-    /// user `userName` overrides it. Refreshed via subtitleSubject in parseExpressions().
+    /// Shown as the node's title: the three axis expressions. Falls back to the
+    /// type name when all axes are blank; a user `userName` overrides it.
+    /// Refreshed via subtitleSubject in parseExpressions().
     override public func deriveSubtitle() -> String? {
         let axes = [expressionX, expressionY, expressionZ]
         guard axes.contains(where: { !$0.isEmpty }) else { return nil }
         // Collapse newlines to spaces so the single-line node title reads cleanly.
-        let combined = axes.joined(separator: ", ").replacingOccurrences(of: "\n", with: " ")
-        let hasError = evalX == nil || evalY == nil || evalZ == nil
-        return hasError ? "⚠ \(combined)" : combined
+        return axes.joined(separator: ", ").replacingOccurrences(of: "\n", with: " ")
+    }
+
+    /// An axis that fails to compile is flagged at the title's trailing edge,
+    /// naming the failing axes in the tooltip.
+    override public func deriveTitleIcon() -> NodeTitleIcon? {
+        let failing = zip(["X", "Y", "Z"], [evalX, evalY, evalZ])
+            .filter { $0.1 == nil }
+            .map(\.0)
+        guard !failing.isEmpty else { return nil }
+        let axes = failing.joined(separator: ", ")
+        return NodeTitleIcon(systemName: "xmark.octagon.fill",
+                             tooltip: "\(axes) expression\(failing.count == 1 ? " does" : "s do") not compile.",
+                             tint: .error)
     }
 
     // MARK: - Settings Model

--- a/Fabric/Nodes/Geometry/SuperShape/SuperShapeGeometryNode.swift
+++ b/Fabric/Nodes/Geometry/SuperShape/SuperShapeGeometryNode.swift
@@ -144,7 +144,7 @@ class SuperShapeGeometryNode : BaseGeometryNode
             ("m1Param",  ParameterPort(parameter:FloatParameter("M1", 10, 0, 20, .slider, "Rotational symmetry count for the first supershape"))),
             ("n11Param", ParameterPort(parameter:FloatParameter("N11", 1.087265, 0.0, 100.0, .slider, "First shape exponent n1 for the first supershape"))),
             ("n21Param", ParameterPort(parameter:FloatParameter("N21", 0.938007, 0.0, 100.0, .slider, "Second shape exponent n2 for the first supershape"))),
-            ("n31Param", ParameterPort(parameter:FloatParameter("N31", -0.615898, 0.0, 100.0, .slider, "Third shape exponent n3 for the first supershape"))),
+            ("n31Param", ParameterPort(parameter:FloatParameter("N31", -0.615898, -100.0, 100.0, .slider, "Third shape exponent n3 for the first supershape"))),
             ("r2Param",  ParameterPort(parameter:FloatParameter("R2", 0.984062, 0, 2, .slider, "Radial scale factor for the second supershape formula"))),
             ("a2Param",  ParameterPort(parameter:FloatParameter("A2", 1.513944, 0.0, 5.0, .slider, "Horizontal stretch factor for the second supershape"))),
             ("b2Param",  ParameterPort(parameter:FloatParameter("B2", 0.642890, 0.0, 5.0, .slider, "Vertical stretch factor for the second supershape"))),

--- a/Fabric/Nodes/Object/SubGraph/CloneMemberObserver.swift
+++ b/Fabric/Nodes/Object/SubGraph/CloneMemberObserver.swift
@@ -1,0 +1,128 @@
+//
+//  CloneMemberObserver.swift
+//  Fabric
+//
+//  Created by Claude on 9/10/26.
+//
+
+import Foundation
+import Combine
+import Observation
+import Satin
+
+/// Watches everything inside a clone set member for edits of its design,
+/// through the signals nodes, ports and parameters already publish, and
+/// reports them to the member's graph so the set is synced once edits
+/// pause. Owned by the member; nothing on Node or Port knows about it.
+///
+/// What counts as an edit: a node moved or renamed, a port published,
+/// unpublished or renamed, a resting parameter value changed from the main
+/// thread. Values arriving on wired or published inlets, and anything the
+/// render thread writes, are runtime traffic and are ignored. Topology
+/// changes reach the graph directly through its mutation API.
+final class CloneMemberObserver
+{
+    private weak var member: SubgraphNode?
+    private var cancellables: [AnyCancellable] = []
+    private var userNames: [UUID: String?] = [:]
+    private var active = true
+
+    init(member: SubgraphNode)
+    {
+        self.member = member
+        self.refresh()
+    }
+
+    /// Re-subscribes to the member's current node tree. Called after a sync,
+    /// which is when nodes may have come or gone.
+    func refresh()
+    {
+        cancellables.removeAll()
+        userNames.removeAll()
+        guard active, let member else { return }
+
+        for node in member.subGraph.nodesRecursive()
+        {
+            self.watch(node)
+        }
+    }
+
+    func stop()
+    {
+        active = false
+        cancellables.removeAll()
+    }
+
+    private func noteEdit()
+    {
+        member?.subGraph.noteContentChanged()
+    }
+
+    private func watch(_ node: Node)
+    {
+        userNames[node.id] = node.userName
+
+        node.offsetSubject
+            .dropFirst()
+            .sink { [weak self] _ in self?.noteEdit() }
+            .store(in: &cancellables)
+
+        // The subject also fires for derived subtitles, some of which follow
+        // a port every frame; only the rename is an edit.
+        node.subtitleSubject
+            .sink { [weak self, weak node] in
+                guard let self, let node else { return }
+                let userName = node.userName
+                guard self.userNames[node.id] != .some(userName) else { return }
+                self.userNames[node.id] = userName
+                self.noteEdit()
+            }
+            .store(in: &cancellables)
+
+        node.portsChangedSubject
+            .sink { [weak self] in self?.noteEdit() }
+            .store(in: &cancellables)
+
+        for port in node.ports
+        {
+            self.watchPublishedState(of: port)
+            if let parameter = port.parameter
+            {
+                self.watchValue(of: parameter, on: port)
+            }
+        }
+    }
+
+    /// Port is Observable: one registration per change, renewed on each.
+    private func watchPublishedState(of port: Port)
+    {
+        guard active else { return }
+        withObservationTracking {
+            _ = port.published
+            _ = port.publishedName
+        } onChange: { [weak self, weak port] in
+            guard let self, self.active else { return }
+            self.noteEdit()
+            if let port { self.watchPublishedState(of: port) }
+        }
+    }
+
+    private func watchValue(of parameter: any Parameter, on port: Port)
+    {
+        self.watchValue(parameter, on: port)
+    }
+
+    private func watchValue<P: Parameter>(_ parameter: P, on port: Port)
+    {
+        parameter.valuePublisher
+            .sink { [weak self, weak port] _ in
+                guard let self, let port,
+                      Thread.isMainThread,
+                      !port.published,
+                      port.connections.isEmpty
+                else { return }
+                self.noteEdit()
+            }
+            .store(in: &cancellables)
+    }
+}

--- a/Fabric/Nodes/Object/SubGraph/CloneMemberObserver.swift
+++ b/Fabric/Nodes/Object/SubGraph/CloneMemberObserver.swift
@@ -16,10 +16,13 @@ import Satin
 /// pause. Owned by the member; nothing on Node or Port knows about it.
 ///
 /// What counts as an edit: a node moved or renamed, a port published,
-/// unpublished or renamed, a resting parameter value changed from the main
-/// thread. Values arriving on wired or published inlets, and anything the
-/// render thread writes, are runtime traffic and are ignored. Topology
-/// changes reach the graph directly through its mutation API.
+/// unpublished or renamed, a resting parameter value changed. Edits happen
+/// on the main thread; every signal here is delivered on the thread that
+/// sent it, and some send every frame from the render thread (a subtitle
+/// following a port, a value arriving on a wire), so each sink first drops
+/// anything not on the main thread. Values arriving on wired or published
+/// inlets are ignored as well. Topology changes reach the graph directly
+/// through its mutation API.
 final class CloneMemberObserver
 {
     private weak var member: SubgraphNode?
@@ -64,14 +67,17 @@ final class CloneMemberObserver
 
         node.offsetSubject
             .dropFirst()
-            .sink { [weak self] _ in self?.noteEdit() }
+            .sink { [weak self] _ in
+                guard Thread.isMainThread else { return }
+                self?.noteEdit()
+            }
             .store(in: &cancellables)
 
         // The subject also fires for derived subtitles, some of which follow
         // a port every frame; only the rename is an edit.
         node.subtitleSubject
             .sink { [weak self, weak node] in
-                guard let self, let node else { return }
+                guard Thread.isMainThread, let self, let node else { return }
                 let userName = node.userName
                 guard self.userNames[node.id] != .some(userName) else { return }
                 self.userNames[node.id] = userName
@@ -80,7 +86,10 @@ final class CloneMemberObserver
             .store(in: &cancellables)
 
         node.portsChangedSubject
-            .sink { [weak self] in self?.noteEdit() }
+            .sink { [weak self] in
+                guard Thread.isMainThread else { return }
+                self?.noteEdit()
+            }
             .store(in: &cancellables)
 
         for port in node.ports
@@ -101,7 +110,7 @@ final class CloneMemberObserver
             _ = port.published
             _ = port.publishedName
         } onChange: { [weak self, weak port] in
-            guard let self, self.active else { return }
+            guard Thread.isMainThread, let self, self.active else { return }
             self.noteEdit()
             if let port { self.watchPublishedState(of: port) }
         }

--- a/Fabric/Nodes/Object/SubGraph/SubgraphNode.swift
+++ b/Fabric/Nodes/Object/SubGraph/SubgraphNode.swift
@@ -28,6 +28,19 @@ open class SubgraphNode: BaseObjectNode
     /// Mutate through Graph.duplicateAsClone / unlinkClone so the change is
     /// undoable. See CloneSet.
     public internal(set) var cloneSetID: UUID?
+    {
+        didSet { if oldValue != cloneSetID { self.cloneMembershipDidChange() } }
+    }
+
+    /// Watches the sub graph for edits while this node is a member; see
+    /// CloneMemberObserver.
+    internal private(set) var cloneObserver: CloneMemberObserver?
+
+    private func cloneMembershipDidChange()
+    {
+        self.cloneObserver?.stop()
+        self.cloneObserver = self.cloneSetID == nil ? nil : CloneMemberObserver(member: self)
+    }
 
     /// The member's record: every id in the set's template mapped to this
     /// member's own id for the same node, port, wire or nested graph. Keys are
@@ -303,6 +316,8 @@ open class SubgraphNode: BaseObjectNode
         self.wireSubGraphCallback()
         self.proxyPorts.forEach { $0.node = self }
         self.rebuildProxyPorts()
+        // didSet does not fire in init; a decoded member starts watching here.
+        self.cloneMembershipDidChange()
     }
 
     private static func decodeProxyPortsIfPossible(from container: KeyedDecodingContainer<CodingKeys>,

--- a/Fabric/Nodes/Object/SubGraph/SubgraphNode.swift
+++ b/Fabric/Nodes/Object/SubGraph/SubgraphNode.swift
@@ -52,7 +52,7 @@ open class SubgraphNode: BaseObjectNode
         didSet { self.templateIDsByLocal = nil }
     }
 
-    @ObservationIgnored private var templateIDsByLocal: [String: String]?
+    private var templateIDsByLocal: [String: String]?
 
     /// The template id this member records for one of its own ids.
     public func templateID(forLocal localID: UUID) -> UUID?

--- a/Fabric/Nodes/Object/SubGraph/SubgraphNode.swift
+++ b/Fabric/Nodes/Object/SubGraph/SubgraphNode.swift
@@ -20,6 +20,63 @@ open class SubgraphNode: BaseObjectNode
 
     public private(set) var subGraph:Graph
 
+    /// The clone set this node belongs to, nil outside any set. Members of a
+    /// set keep their sub graphs identical in design (node set, wiring,
+    /// published ports, unpublished values, layout) to the set's template
+    /// while each executes on its own. Published inlet values are the
+    /// per-member exception: the parent graph sets them through the proxy.
+    /// Mutate through Graph.duplicateAsClone / unlinkClone so the change is
+    /// undoable. See CloneSet.
+    public internal(set) var cloneSetID: UUID?
+
+    /// The member's record: every id in the set's template mapped to this
+    /// member's own id for the same node, port, wire or nested graph. Keys are
+    /// template ids, values local ids, both as UUID strings so the record is
+    /// rewritten correctly whenever the node is duplicated. Empty outside a
+    /// set. Grows as edits here add ids the template did not have.
+    public internal(set) var cloneRecord: [String: String] = [:]
+    {
+        didSet { self.templateIDsByLocal = nil }
+    }
+
+    @ObservationIgnored private var templateIDsByLocal: [String: String]?
+
+    /// The template id this member records for one of its own ids.
+    public func templateID(forLocal localID: UUID) -> UUID?
+    {
+        if self.templateIDsByLocal == nil
+        {
+            self.templateIDsByLocal = Dictionary(self.cloneRecord.map { ($0.value, $0.key) },
+                                                 uniquingKeysWith: { first, _ in first })
+        }
+        return self.templateIDsByLocal?[localID.uuidString].flatMap(UUID.init(uuidString:))
+    }
+
+    /// This member's id for a template id, nil where the template has
+    /// something this member does not yet.
+    public func localID(forTemplate templateID: UUID) -> UUID?
+    {
+        self.cloneRecord[templateID.uuidString].flatMap(UUID.init(uuidString:))
+    }
+
+    /// The set as seen from this member, nil outside a set. Refreshed through
+    /// subtitleSubject whenever membership or the name changes.
+    public var cloneSetInfo: CloneSetInfo?
+    {
+        guard let graph = self.graph, let setID = self.cloneSetID, let set = graph.cloneSet(for: setID)
+        else { return nil }
+        return CloneSetInfo(setID: setID,
+                            name: set.name,
+                            memberCount: graph.cloneSiblings(of: self).count + 1)
+    }
+
+    /// A member describes itself by its set's name, the way a Strategy node
+    /// shows its strategy. The member count lives in the icon's tooltip.
+    override open func deriveSubtitle() -> String? { self.cloneSetInfo?.name }
+
+    /// A member wears the clone glyph, with the set's details on hover.
+    override open func deriveTitleIcon() -> NodeTitleIcon? { self.cloneSetInfo?.titleIcon }
+
     /// ProxyPorts wrapping the sub graph's published ports.
     /// Each proxy has node = self (the SubgraphNode) and published = false.
     /// The parent graph independently decides whether to publish them further.
@@ -194,6 +251,8 @@ open class SubgraphNode: BaseObjectNode
     {
         case subGraph
         case proxyPorts
+        case cloneSetID
+        case cloneRecord
     }
     
     open override func encode(to encoder:Encoder) throws
@@ -202,6 +261,11 @@ open class SubgraphNode: BaseObjectNode
         
         try container.encode(self.subGraph, forKey: .subGraph)
         try container.encode(self.proxyPorts.map(AnyPort.init), forKey: .proxyPorts)
+        try container.encodeIfPresent(self.cloneSetID, forKey: .cloneSetID)
+        if !self.cloneRecord.isEmpty
+        {
+            try container.encode(self.cloneRecord, forKey: .cloneRecord)
+        }
         
         try super.encode(to: encoder)
     }
@@ -211,7 +275,9 @@ open class SubgraphNode: BaseObjectNode
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         self.subGraph = try container.decode(Graph.self, forKey: .subGraph)
-        
+        self.cloneSetID = try container.decodeIfPresent(UUID.self, forKey: .cloneSetID)
+        self.cloneRecord = try container.decodeIfPresent([String: String].self, forKey: .cloneRecord) ?? [:]
+
         // We set the current graph to the subgraph
         // to allow proxy ports and any other decode contexts to work correctly
         
@@ -255,6 +321,7 @@ open class SubgraphNode: BaseObjectNode
 
     private func wireSubGraphCallback()
     {
+        self.subGraph.ownerNode = self
         self.subGraph.onPublishedPortsChanged = { [weak self] in
             self?.rebuildProxyPorts()
         }

--- a/Fabric/Nodes/Parameters/Number/MathExpressionNode.swift
+++ b/Fabric/Nodes/Parameters/Number/MathExpressionNode.swift
@@ -188,10 +188,15 @@ public class MathExpressionNode: Node
     /// previous node so existing behaviour is preserved.
     public class var defaultExpression: String { "sin(x) + y^2" }
 
-    /// Shown as the node's title: the expression, or a ⚠-prefixed form on error.
-    /// nil (empty) falls back to the type name; a user `userName` overrides this.
+    /// Shown as the node's title: the salient part of the expression. nil
+    /// (empty) falls back to the type name; a user `userName` overrides this.
     override public func deriveSubtitle() -> String? { evaluatedSubtitle }
     private var evaluatedSubtitle: String = ""
+
+    /// A compile error is flagged at the title's trailing edge, with the
+    /// diagnostics as the tooltip.
+    override public func deriveTitleIcon() -> NodeTitleIcon? { errorTitleIcon }
+    private var errorTitleIcon: NodeTitleIcon?
 
     /// Extracts the salient part of a (possibly multi-statement) expression for
     /// use as the node title. A leading `//` comment is taken verbatim as an
@@ -416,16 +421,14 @@ public class MathExpressionNode: Node
             self.needsEvaluation = true
         }
 
-        let hasError = result.diagnostics.contains { $0.severity == .error }
-        let salientTitle = Self.salientTitle(from: self.stringExpression)
-        // An empty title with an error would otherwise render as a bare "⚠ "
-        // — non-empty, so subtitle's type-name fallback never kicks in.
-        self.evaluatedSubtitle = switch (hasError, salientTitle.isEmpty)
-        {
-            case (true, true):  "⚠ \(Self.name)"
-            case (true, false): "⚠ \(salientTitle)"
-            case (false, _):    salientTitle
-        }
+        self.evaluatedSubtitle = Self.salientTitle(from: self.stringExpression)
+
+        let errors = result.diagnostics.filter { $0.severity == .error }
+        self.errorTitleIcon = errors.isEmpty
+            ? nil
+            : NodeTitleIcon(systemName: "xmark.octagon.fill",
+                            tooltip: errors.map(\.message).joined(separator: "\n"),
+                            tint: .error)
 
         // Keep the settings model mirroring the node, not just model → node.
         // Its didSet guards on equality, so this cannot loop.

--- a/Fabric/Views/Graph/CloneSetContextMenu.swift
+++ b/Fabric/Views/Graph/CloneSetContextMenu.swift
@@ -7,13 +7,22 @@
 
 import SwiftUI
 
+/// A rename in progress: which node's set, and the draft name. Created with
+/// the set's current name when the menu item is chosen, so the alert opens
+/// showing it; the draft is what OK commits, empty included.
+struct CloneSetRenameRequest: Equatable
+{
+    let nodeID: UUID
+    var name: String
+}
+
 /// Clone set items of a Subgraph node's context menu. Renaming presents the
 /// alert owned by CloneSetRenameAlert on the node, keyed by node id.
 struct CloneSetContextMenu: View
 {
     let subgraphNode: SubgraphNode
     let currentGraph: Graph
-    @Binding var renamingNodeID: UUID?
+    @Binding var renameRequest: CloneSetRenameRequest?
 
     var body: some View
     {
@@ -27,10 +36,10 @@ struct CloneSetContextMenu: View
             Text("Duplicate as Clone")
         }
 
-        if subgraphNode.cloneSetID != nil
+        if let setInfo = subgraphNode.cloneSetInfo
         {
             Button {
-                renamingNodeID = subgraphNode.id
+                renameRequest = CloneSetRenameRequest(nodeID: subgraphNode.id, name: setInfo.name)
             } label: {
                 Text("Rename Clone Set…")
             }
@@ -57,46 +66,47 @@ struct CloneSetContextMenu: View
     }
 }
 
-/// Owns the rename alert for a Subgraph node's clone set, presented when the
-/// canvas's renaming id names this node.
+/// Owns the rename alert for a Subgraph node's clone set, presented while
+/// the canvas's request names this node. The text field edits the request's
+/// draft directly, so there is no hand-off to time against the alert.
 struct CloneSetRenameAlert: ViewModifier
 {
     let subgraphNode: SubgraphNode
     let graph: Graph
-    @Binding var renamingNodeID: UUID?
+    @Binding var renameRequest: CloneSetRenameRequest?
 
-    @State private var renameText = ""
-
-    private var isRenaming: Binding<Bool>
+    private var isPresented: Binding<Bool>
     {
         Binding(
-            get: { renamingNodeID == subgraphNode.id },
-            set: { presenting in if !presenting, renamingNodeID == subgraphNode.id { renamingNodeID = nil } }
+            get: { renameRequest?.nodeID == subgraphNode.id },
+            set: { presenting in if !presenting, renameRequest?.nodeID == subgraphNode.id { renameRequest = nil } }
+        )
+    }
+
+    private var draftName: Binding<String>
+    {
+        Binding(
+            get: { renameRequest?.name ?? "" },
+            set: { renameRequest?.name = $0 }
         )
     }
 
     func body(content: Content) -> some View
     {
         content
-            .alert("Rename Clone Set", isPresented: isRenaming) {
-                TextField("Set name", text: $renameText)
+            .alert("Rename Clone Set", isPresented: isPresented) {
+                TextField("Set name", text: draftName)
                 Button("OK", action: commitRename)
                 Button("Cancel", role: .cancel) { }
             } message: {
                 Text("The name shows on every member of the set. Leave it empty for a system name.")
             }
-            .onChange(of: isRenaming.wrappedValue) {
-                if isRenaming.wrappedValue
-                {
-                    renameText = subgraphNode.cloneSetInfo?.name ?? ""
-                }
-            }
     }
 
     private func commitRename()
     {
-        guard let setID = subgraphNode.cloneSetID else { return }
-        graph.renameCloneSet(setID, to: renameText)
+        guard let setID = subgraphNode.cloneSetID, let request = renameRequest else { return }
+        graph.renameCloneSet(setID, to: request.name)
     }
 }
 
@@ -105,7 +115,7 @@ struct CloneSetRenameAlertIfSubgraph: ViewModifier
 {
     let node: Node
     let graph: Graph
-    @Binding var renamingNodeID: UUID?
+    @Binding var renameRequest: CloneSetRenameRequest?
 
     func body(content: Content) -> some View
     {
@@ -113,7 +123,7 @@ struct CloneSetRenameAlertIfSubgraph: ViewModifier
         {
             content.modifier(CloneSetRenameAlert(subgraphNode: subgraphNode,
                                                  graph: graph,
-                                                 renamingNodeID: $renamingNodeID))
+                                                 renameRequest: $renameRequest))
         }
         else
         {

--- a/Fabric/Views/Graph/CloneSetContextMenu.swift
+++ b/Fabric/Views/Graph/CloneSetContextMenu.swift
@@ -1,0 +1,123 @@
+//
+//  CloneSetContextMenu.swift
+//  Fabric
+//
+//  Created by Claude on 9/9/26.
+//
+
+import SwiftUI
+
+/// Clone set items of a Subgraph node's context menu. Renaming presents the
+/// alert owned by CloneSetRenameAlert on the node, keyed by node id.
+struct CloneSetContextMenu: View
+{
+    let subgraphNode: SubgraphNode
+    let currentGraph: Graph
+    @Binding var renamingNodeID: UUID?
+
+    var body: some View
+    {
+        let siblings = currentGraph.cloneSiblings(of: subgraphNode)
+
+        Divider()
+
+        Button {
+            currentGraph.duplicateAsClone(subgraphNode)
+        } label: {
+            Text("Duplicate as Clone")
+        }
+
+        if subgraphNode.cloneSetID != nil
+        {
+            Button {
+                renamingNodeID = subgraphNode.id
+            } label: {
+                Text("Rename Clone Set…")
+            }
+        }
+
+        if !siblings.isEmpty
+        {
+            Button {
+                currentGraph.deselectAllNodes()
+                for sibling in siblings where sibling.graph === currentGraph
+                {
+                    currentGraph.selectNode(node: sibling, expandSelection: true)
+                }
+            } label: {
+                Text("Select Sibling Clones")
+            }
+
+            Button {
+                currentGraph.unlinkClone(subgraphNode)
+            } label: {
+                Text("Unlink from Clones")
+            }
+        }
+    }
+}
+
+/// Owns the rename alert for a Subgraph node's clone set, presented when the
+/// canvas's renaming id names this node.
+struct CloneSetRenameAlert: ViewModifier
+{
+    let subgraphNode: SubgraphNode
+    let graph: Graph
+    @Binding var renamingNodeID: UUID?
+
+    @State private var renameText = ""
+
+    private var isRenaming: Binding<Bool>
+    {
+        Binding(
+            get: { renamingNodeID == subgraphNode.id },
+            set: { presenting in if !presenting, renamingNodeID == subgraphNode.id { renamingNodeID = nil } }
+        )
+    }
+
+    func body(content: Content) -> some View
+    {
+        content
+            .alert("Rename Clone Set", isPresented: isRenaming) {
+                TextField("Set name", text: $renameText)
+                Button("OK", action: commitRename)
+                Button("Cancel", role: .cancel) { }
+            } message: {
+                Text("The name shows on every member of the set. Leave it empty for a system name.")
+            }
+            .onChange(of: isRenaming.wrappedValue) {
+                if isRenaming.wrappedValue
+                {
+                    renameText = subgraphNode.cloneSetInfo?.name ?? ""
+                }
+            }
+    }
+
+    private func commitRename()
+    {
+        guard let setID = subgraphNode.cloneSetID else { return }
+        graph.renameCloneSet(setID, to: renameText)
+    }
+}
+
+/// Applies CloneSetRenameAlert to Subgraph nodes and leaves other nodes as they are.
+struct CloneSetRenameAlertIfSubgraph: ViewModifier
+{
+    let node: Node
+    let graph: Graph
+    @Binding var renamingNodeID: UUID?
+
+    func body(content: Content) -> some View
+    {
+        if let subgraphNode = node as? SubgraphNode
+        {
+            content.modifier(CloneSetRenameAlert(subgraphNode: subgraphNode,
+                                                 graph: graph,
+                                                 renamingNodeID: $renamingNodeID))
+        }
+        else
+        {
+            content
+        }
+    }
+}

--- a/Fabric/Views/Graph/GraphNodesView.swift
+++ b/Fabric/Views/Graph/GraphNodesView.swift
@@ -22,6 +22,7 @@ struct GraphNodesView: View
 
     @State private var initialOffsets: [UUID: CGSize] = [:]
     @State private var activeDragAnchor: UUID? = nil
+    @State private var renamingCloneSetNodeID: UUID? = nil
 
     var body: some View
     {
@@ -80,6 +81,9 @@ struct GraphNodesView: View
                 .onChange(of: nodeViewModel.showSettings) { _, show in
                     self.sychronizeSettingsFor(nodeViewModel: nodeViewModel, show: show)
                 }
+                .modifier(CloneSetRenameAlertIfSubgraph(node: currentNode,
+                                                        graph: currentGraph,
+                                                        renamingNodeID: $renamingCloneSetNodeID))
         }
     }
 
@@ -214,6 +218,13 @@ struct GraphNodesView: View
             currentGraph.duplicateNodes(nodesToDuplicate)
         } label: {
             Text("Duplicate")
+        }
+
+        if let subgraphNode = currentNode as? SubgraphNode
+        {
+            CloneSetContextMenu(subgraphNode: subgraphNode,
+                                currentGraph: currentGraph,
+                                renamingNodeID: $renamingCloneSetNodeID)
         }
     }
 

--- a/Fabric/Views/Graph/GraphNodesView.swift
+++ b/Fabric/Views/Graph/GraphNodesView.swift
@@ -22,7 +22,7 @@ struct GraphNodesView: View
 
     @State private var initialOffsets: [UUID: CGSize] = [:]
     @State private var activeDragAnchor: UUID? = nil
-    @State private var renamingCloneSetNodeID: UUID? = nil
+    @State private var cloneSetRenameRequest: CloneSetRenameRequest? = nil
 
     var body: some View
     {
@@ -83,7 +83,7 @@ struct GraphNodesView: View
                 }
                 .modifier(CloneSetRenameAlertIfSubgraph(node: currentNode,
                                                         graph: currentGraph,
-                                                        renamingNodeID: $renamingCloneSetNodeID))
+                                                        renameRequest: $cloneSetRenameRequest))
         }
     }
 
@@ -224,7 +224,7 @@ struct GraphNodesView: View
         {
             CloneSetContextMenu(subgraphNode: subgraphNode,
                                 currentGraph: currentGraph,
-                                renamingNodeID: $renamingCloneSetNodeID)
+                                renameRequest: $cloneSetRenameRequest)
         }
     }
 

--- a/Fabric/Views/Nodes/NodeTitleView.swift
+++ b/Fabric/Views/Nodes/NodeTitleView.swift
@@ -15,17 +15,44 @@ struct NodeTitleView: View
     @State private var renamingText: String = ""
     @FocusState private var renameFieldFocused: Bool
 
-    private var title: String { nodeViewModel.title }
+    /// Leading inset in the port column's own coordinates, so the title sits
+    /// with the port labels below it.
+    private let leadingInset: CGFloat = 20
 
-    // Nil when the node has neither a rename nor a generated name, so the title
-    // is its type name alone.
-    private var primaryLabel: String? { nodeViewModel.subtitle }
+    /// The row's inset from the node's top edge, and the icon cell's inset
+    /// from the trailing edge: one number, so the icon is centred the same
+    /// distance from both edges.
+    private let rowInset: CGFloat = 5
+
+    /// The row's height, and the icon cell's side.
+    private let rowHeight: CGFloat = 20
+
+    /// NodeView lays the port columns out one inlet radius wider than the
+    /// node and centres them in it, which is what puts the port circles
+    /// astride both edges. It also shifts everything in those columns, this
+    /// row included, half a radius to the left of the node. The row runs
+    /// that much wider so its trailing edge lands on the node's real edge.
+    private let portOverhangShift: CGFloat = NodeInletView.radius / 2
+
+    private var titleIcon: NodeTitleIcon? { nodeViewModel.titleIcon }
+
+    /// The row's full width, from the column's leading edge to the node's
+    /// real trailing edge.
+    private var rowWidth: CGFloat { nodeViewModel.nodeSize.width + portOverhangShift }
+
+    /// The width the title text may occupy: the row less the leading inset
+    /// and, when there is an icon, its cell and inset.
+    private var textWidth: CGFloat
+    {
+        max(rowWidth - leadingInset - (titleIcon == nil ? 0 : rowHeight + rowInset), 1)
+    }
 
     /// Opaque across the title, fading to clear over the last ~1 character so an
-    /// over-long title dissolves at the node's right edge rather than hard-clipping.
+    /// over-long title dissolves at the text area's right edge rather than
+    /// hard-clipping, before the icon where there is one.
     private var titleEdgeFade: LinearGradient
     {
-        let width = max(nodeViewModel.nodeSize.width, 1)
+        let width = textWidth
         let fade = min(8, width)
         let solid = max(0, (width - fade) / width)
         return LinearGradient(
@@ -39,72 +66,41 @@ struct NodeTitleView: View
         )
     }
 
-   
-
     var body: some View
     {
-        Group
-        {
-            let secondaryColor = nodeViewModel.nodeType.secondaryColor()
-            
-            if renaming
+        NodeTitleText(nodeViewModel: nodeViewModel,
+                      renaming: $renaming,
+                      renamingText: $renamingText,
+                      renameFieldFocused: $renameFieldFocused,
+                      commitRename: commitRename)
+            // Lay the title out at its full intrinsic width (single line, no
+            // ellipsis), then constrain to the text area and soft-fade the
+            // trailing edge so an over-long title dissolves there instead of
+            // hard-clipping with a "…".
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
+            .frame(width: textWidth, height: rowHeight, alignment: .leading)
+            .clipped()
+            .mask(titleEdgeFade)
+            // The icon is placed against the row's trailing edge, independent
+            // of the text: the text only leaves it room via textWidth. It is
+            // centred in a square cell the row's height, inset from the edge
+            // by the row's own top inset, so its distance from the trailing
+            // edge matches its distance from the top.
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .overlay(alignment: .trailing)
             {
-                HStack(spacing: 0)
+                if let titleIcon
                 {
-                    // Placeholder previews the empty-commit outcome: with no
-                    // rename, the node-derived subtitle shows; the registered
-                    // title already follows as the suffix Text.
-                    TextField(nodeViewModel.subtitle ?? "", text: $renamingText)
-                        .textFieldStyle(.plain)
-                        .focused($renameFieldFocused)
-                        .font(.system(size: 9))
-                        .bold()
-                        .foregroundStyle(.white)
-                        .fixedSize(horizontal: true, vertical: false)
-                        .onSubmit(commitRename)
-                        .onDisappear
-                        {
-                            renaming = false
-                        }
-
-                    Text(verbatim: " \(title)")
-                        .font(.system(size: 9))
-                        .bold()
-                        .foregroundStyle(secondaryColor)
+                    NodeTitleIconView(icon: titleIcon, cellSide: rowHeight)
+                        .padding(.trailing, rowInset)
                 }
             }
-            else if let primaryLabel
-            {
-                // Text(verbatim:) + concatenation: these are data strings, not UI
-                // copy — the literal-interpolation initializer would do a doomed
-                // localization lookup on every render.
-                let primary = Text(primaryLabel).foregroundStyle(.white)
-                let secondary = Text(verbatim: " \(title)").foregroundStyle(secondaryColor)
-                (primary + secondary)
-                    .font(.system(size: 9))
-                    .bold()
-            }
-            else
-            {
-                Text(title)
-                    .font(.system(size: 9))
-                    .bold()
-                    .foregroundStyle(nodeViewModel.nodeType.color())
-            }
-        }
-        // Lay the title out at its full intrinsic width (single line, no
-        // ellipsis), then constrain to the node width and soft-fade the trailing
-        // edge so an over-long title dissolves at the node boundary instead of
-        // hard-clipping with a "…".
-        .lineLimit(1)
-        .fixedSize(horizontal: true, vertical: false)
-        .frame(maxHeight: 20)
-        .padding(.top, 5)
-        .padding(.leading, 20)
-        .frame(width: nodeViewModel.nodeSize.width, alignment: .leading)
-        .clipped()
-        .mask(titleEdgeFade)
+        .padding(.top, rowInset)
+        .padding(.leading, leadingInset)
+        .frame(width: rowWidth, alignment: .leading)
         .contentShape(Rectangle())
+        .help(titleIcon?.tooltip ?? "")
         .onTapGesture(count: 2)
         {
             if !renaming { renaming = true }
@@ -149,5 +145,102 @@ struct NodeTitleView: View
 
         nodeViewModel.userName = newUserName
         renaming = false
+    }
+}
+
+/// The title text alone: the rename field while renaming, otherwise the
+/// subtitle and type name, or the type name by itself.
+private struct NodeTitleText: View
+{
+    let nodeViewModel: NodeViewModel
+    @Binding var renaming: Bool
+    @Binding var renamingText: String
+    let renameFieldFocused: FocusState<Bool>.Binding
+    let commitRename: () -> Void
+
+    private var title: String { nodeViewModel.title }
+
+    // Nil when the node has neither a rename nor a generated name, so the title
+    // is its type name alone.
+    private var primaryLabel: String? { nodeViewModel.subtitle }
+
+    var body: some View
+    {
+        Group
+        {
+            let secondaryColor = nodeViewModel.nodeType.secondaryColor()
+
+            if renaming
+            {
+                HStack(spacing: 0)
+                {
+                    // Placeholder previews the empty-commit outcome: with no
+                    // rename, the node-derived subtitle shows; the registered
+                    // title already follows as the suffix Text.
+                    TextField(nodeViewModel.subtitle ?? "", text: $renamingText)
+                        .textFieldStyle(.plain)
+                        .focused(renameFieldFocused)
+                        .font(.system(size: 9))
+                        .bold()
+                        .foregroundStyle(.white)
+                        .fixedSize(horizontal: true, vertical: false)
+                        .onSubmit(commitRename)
+                        .onDisappear
+                        {
+                            renaming = false
+                        }
+
+                    Text(verbatim: " \(title)")
+                        .font(.system(size: 9))
+                        .bold()
+                        .foregroundStyle(secondaryColor)
+                }
+            }
+            else if let primaryLabel
+            {
+                // Text(verbatim:) + concatenation: these are data strings, not UI
+                // copy — the literal-interpolation initializer would do a doomed
+                // localization lookup on every render.
+                let primary = Text(primaryLabel).foregroundStyle(.white)
+                let secondary = Text(verbatim: " \(title)").foregroundStyle(secondaryColor)
+                (primary + secondary)
+                    .font(.system(size: 9))
+                    .bold()
+            }
+            else
+            {
+                Text(title)
+                    .font(.system(size: 9))
+                    .bold()
+                    .foregroundStyle(nodeViewModel.nodeType.color())
+            }
+        }
+    }
+}
+
+/// A title icon in its square cell, coloured by its tint.
+private struct NodeTitleIconView: View
+{
+    let icon: NodeTitleIcon
+    let cellSide: CGFloat
+
+    private var color: Color
+    {
+        switch icon.tint
+        {
+        case .neutral: .white
+        case .warning: .yellow
+        case .error:   .red
+        }
+    }
+
+    var body: some View
+    {
+        Image(systemName: icon.systemName)
+            .font(.system(size: 9))
+            .bold()
+            .foregroundStyle(color)
+            .frame(width: cellSide, height: cellSide)
+            .accessibilityLabel(icon.tooltip)
     }
 }

--- a/Fabric/Views/Nodes/NodeViewModel.swift
+++ b/Fabric/Views/Nodes/NodeViewModel.swift
@@ -69,6 +69,9 @@ import Satin
     /// `Node.subtitle`, cached and kept fresh by subtitleSubject.
     public private(set) var subtitle: String?
 
+    /// `Node.titleIcon`, cached and kept fresh by subtitleSubject.
+    public private(set) var titleIcon: NodeTitleIcon?
+
     // MARK: - Forwarded node metadata
 
     public var nodeType: Node.NodeType { node.nodeType }
@@ -100,6 +103,7 @@ import Satin
         self._userName    = node.userName
         self.title        = node.title
         self.subtitle     = node.subtitle
+        self.titleIcon    = node.titleIcon
         self.ports        = node.ports
         self.nodeSize     = node.nodeSize
 
@@ -137,6 +141,8 @@ import Satin
                 if newTitle != self.title { self.title = newTitle }
                 let newSubtitle = node.subtitle
                 if newSubtitle != self.subtitle { self.subtitle = newSubtitle }
+                let newTitleIcon = node.titleIcon
+                if newTitleIcon != self.titleIcon { self.titleIcon = newTitleIcon }
             }
             .store(in: &cancellables)
     }

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -124,6 +124,9 @@ A Port on a Node inside a Subgraph that is marked `published = true`, exposing i
 ### Deferred Subgraph
 A SubgraphNode variant that renders its content to textures (colour + depth) rather than contributing objects to the parent scene. Useful for post-processing pipelines.
 
+### Clone Set
+A `CloneSet` on the document's root graph: a name and a template, the encoded form of a member's sub graph in the template's own ids, held as data. Its members are SubgraphNodes with that `cloneSetID`, kept identical in design to the template while each executes on its own. Members are peers to edit: the one you edit refreshes the template and its siblings are reconciled from it through their `cloneRecord`s, each mapping template ids to that member's own. Published inlet values are the per-member exception. A member wears the `square.on.square` glyph as its title icon, on the canvas and in the breadcrumb, shows the set name as its subtitle, and gives the member count on hover. See `CloneSet.swift`, `Graph+CloneSet.swift` and `Graph+CloneReconcile.swift`.
+
 ### Iterator
 A SubgraphNode variant that executes its contained Graph multiple times per frame, providing iteration index, progress, and count via an Iterator Info Node.
 

--- a/Tests/CloneSetTests.swift
+++ b/Tests/CloneSetTests.swift
@@ -949,3 +949,63 @@ extension CloneSetTests
         #expect(pair.target.nodes.count == 3)
     }
 }
+
+// MARK: - Fidelity
+
+extension CloneSetTests
+{
+    /// Node types that need a device, a permission, a download or a file to
+    /// construct; the encode/decode contract they rely on is the same.
+    private static let liveSourceNamePattern = #"Camera|Audio|Screen|Syphon|Model|Movie|Video|Hand|Face|Pose|Vision|MIDI|OSC|Capture|Microphone|Speech|Image Loader|Loader|Recorder|Writer|Export"#
+
+    @Test("Every core node type clones with nothing left for reconcile to change")
+    func everyCoreNodeTypeClonesCleanly() throws
+    {
+        guard let context = makeContext() else { return }
+        let registry = try NodeRegistry.shared
+        let graph = Graph(context: context)
+        let member = SubgraphNode(context: context)
+        graph.addNode(member)
+
+        var constructed: [String] = []
+        var skipped: [String] = []
+        for wrapper in registry.availableNodes
+        where wrapper.pluginBundleID == FabricCoreNodesPlugin.pluginID
+            && wrapper.nodeName.range(of: Self.liveSourceNamePattern, options: .regularExpression) == nil
+        {
+            guard let node = try? wrapper.initializeNode(context: context) else
+            {
+                skipped.append(wrapper.nodeName)
+                continue
+            }
+            member.subGraph.addNode(node)
+            constructed.append(wrapper.nodeName)
+        }
+        #expect(constructed.count > 50, "constructed \(constructed.count), skipped \(skipped)")
+
+        let sibling = try #require(graph.duplicateAsClone(member))
+        #expect(sibling.subGraph.nodes.count == member.subGraph.nodes.count)
+
+        var mismatched: [String] = []
+        for node in member.subGraph.nodes
+        {
+            guard let templateID = member.templateID(forLocal: node.id),
+                  let localID = sibling.localID(forTemplate: templateID),
+                  let copy = sibling.subGraph.node(forID: localID)
+            else { mismatched.append("\(type(of: node)) did not clone"); continue }
+            if copy.cloneSettingsSignature() != node.cloneSettingsSignature()
+            {
+                mismatched.append("\(type(of: node)) settings signature differs after cloning")
+            }
+        }
+        #expect(mismatched.isEmpty, "\(mismatched)")
+
+        let report = graph.reconcileCloneMember(sibling, from: member)
+        #expect(report.isEmpty, "\(report)")
+
+        // A member made from the template alone matches too.
+        let made = try #require(graph.instantiateCloneSetMember(of: member.cloneSetID!))
+        #expect(made.subGraph.nodes.count == member.subGraph.nodes.count)
+        #expect(graph.reconcileCloneMember(made, from: member).isEmpty)
+    }
+}

--- a/Tests/CloneSetTests.swift
+++ b/Tests/CloneSetTests.swift
@@ -1,0 +1,376 @@
+import Foundation
+import Metal
+import Testing
+@testable import Fabric
+import Satin
+
+/// Clone sets: Subgraph nodes kept identical in design to a set's template
+/// while each executes on its own. A set is a root-level object holding the
+/// template as data; each member keeps a record mapping the template's ids to
+/// its own. See CloneSet and SubgraphNode.cloneSetID.
+@Suite("Clone Sets")
+struct CloneSetTests
+{
+    private func makeContext() -> Context?
+    {
+        guard let device = MTLCreateSystemDefaultDevice() else { return nil }
+        return Context(device: device,
+                       sampleCount: 1,
+                       colorPixelFormat: .bgra8Unorm,
+                       depthPixelFormat: .depth32Float,
+                       stencilPixelFormat: .invalid)
+    }
+
+    private func roundTrip(_ graph: Graph, context: Context) throws -> Graph
+    {
+        let data = try JSONEncoder().encode(graph)
+        let decoder = JSONDecoder()
+        decoder.context = DecoderContext(documentContext: context)
+        return try decoder.decode(Graph.self, from: data)
+    }
+
+    /// A member with two wired inner nodes, one published inlet and a nested
+    /// subgraph, so the record and wiring survive cloning at every level.
+    private struct MemberFixture
+    {
+        let graph: Graph
+        let member: SubgraphNode
+        let first: NumberBinaryOperator
+        let second: NumberBinaryOperator
+        let nested: SubgraphNode
+        let nestedInner: NumberBinaryOperator
+    }
+
+    private func makeMemberFixture(context: Context) throws -> MemberFixture
+    {
+        let graph = Graph(context: context)
+        let member = SubgraphNode(context: context)
+        graph.addNode(member)
+
+        let first = NumberBinaryOperator(context: context)
+        let second = NumberBinaryOperator(context: context)
+        let nested = SubgraphNode(context: context)
+        let nestedInner = NumberBinaryOperator(context: context)
+        member.subGraph.addNode(first)
+        member.subGraph.addNode(second)
+        member.subGraph.addNode(nested)
+        nested.subGraph.addNode(nestedInner)
+
+        _ = try #require(member.subGraph.connect(first.outputNumber, to: second.inputNumber1))
+        first.inputNumber1.published = true
+        first.inputNumber1.publishedName = "Amount"
+        member.subGraph.rebuildPublishedParameterGroup()
+
+        return MemberFixture(graph: graph, member: member, first: first, second: second,
+                             nested: nested, nestedInner: nestedInner)
+    }
+
+    /// The node in `member` that stands for `node` of `source`, found through
+    /// both members' records: source local id → template id → member local id.
+    private func counterpart<T: Node>(of node: T, from source: SubgraphNode, in member: SubgraphNode) -> T?
+    {
+        guard let templateID = source.templateID(forLocal: node.id),
+              let localID = member.localID(forTemplate: templateID)
+        else { return nil }
+        return member.subGraph.nodesRecursive().first { $0.id == localID } as? T
+    }
+
+    // MARK: - Ownership
+
+    @Test("A sub graph knows the node that owns it, after init and after decode")
+    func subGraphKnowsOwner() throws
+    {
+        guard let context = makeContext() else { return }
+        let graph = Graph(context: context)
+        let outer = SubgraphNode(context: context)
+        let inner = SubgraphNode(context: context)
+        graph.addNode(outer)
+        outer.subGraph.addNode(inner)
+
+        #expect(graph.ownerNode == nil)
+        #expect(outer.subGraph.ownerNode === outer)
+        #expect(inner.subGraph.rootGraph === graph)
+
+        let decoded = try roundTrip(graph, context: context)
+        let decodedOuter = try #require(decoded.nodes.first as? SubgraphNode)
+        let decodedInner = try #require(decodedOuter.subGraph.nodes.first as? SubgraphNode)
+        #expect(decodedOuter.subGraph.ownerNode === decodedOuter)
+        #expect(decodedInner.subGraph.rootGraph === decoded)
+    }
+
+    // MARK: - Sets and records
+
+    @Test("Duplicate as Clone starts a set on the root graph and records both members against its template")
+    func duplicateAsCloneStartsASet() throws
+    {
+        guard let context = makeContext() else { return }
+        let fixture = try makeMemberFixture(context: context)
+        #expect(fixture.member.cloneSetID == nil)
+        #expect(fixture.graph.cloneSets.isEmpty)
+
+        let copy = try #require(fixture.graph.duplicateAsClone(fixture.member))
+
+        let set = try #require(fixture.graph.cloneSets.first)
+        #expect(fixture.graph.cloneSets.count == 1)
+        #expect(fixture.member.cloneSetID == set.id)
+        #expect(copy.cloneSetID == set.id)
+        #expect(set.name == "Set A")
+        #expect(fixture.graph.cloneSet(for: set.id) === set)
+
+        // Every local id of the source is recorded against a template id, and
+        // the copy records the same template ids against its own fresh ids.
+        for node in fixture.member.subGraph.nodesRecursive()
+        {
+            let templateID = try #require(fixture.member.templateID(forLocal: node.id), "\(node)")
+            let copyLocal = try #require(copy.localID(forTemplate: templateID))
+            #expect(copyLocal != node.id)
+            for port in node.ports
+            {
+                let portTemplateID = try #require(fixture.member.templateID(forLocal: port.id))
+                #expect(copy.localID(forTemplate: portTemplateID) != nil)
+            }
+        }
+        #expect(Set(copy.subGraph.nodesRecursive().map(\.id)).isDisjoint(with: fixture.member.subGraph.nodesRecursive().map(\.id)))
+
+        let copiedFirst = try #require(counterpart(of: fixture.first, from: fixture.member, in: copy))
+        let copiedSecond = try #require(counterpart(of: fixture.second, from: fixture.member, in: copy))
+        let copiedNested = try #require(counterpart(of: fixture.nested, from: fixture.member, in: copy))
+        let copiedNestedInner = try #require(counterpart(of: fixture.nestedInner, from: fixture.member, in: copy))
+        #expect(copiedFirst.inputNumber1.published)
+        #expect(copiedFirst.inputNumber1.publishedName == "Amount")
+        #expect(copy.subGraph.connections.count == 1)
+        #expect(copy.subGraph.connections.first?.outletPort === copiedFirst.outputNumber)
+        #expect(copy.subGraph.connections.first?.inletPort === copiedSecond.inputNumber1)
+        #expect(copy.ports.contains { $0.id == copiedFirst.inputNumber1.id && $0 is any ProxyPortProtocol })
+        #expect(copiedNestedInner.graph === copiedNested.subGraph)
+    }
+
+    @Test("Sets, records and names survive a save")
+    func setsRoundTrip() throws
+    {
+        guard let context = makeContext() else { return }
+        let fixture = try makeMemberFixture(context: context)
+        let copy = try #require(fixture.graph.duplicateAsClone(fixture.member))
+        let setID = try #require(fixture.member.cloneSetID)
+        fixture.graph.renameCloneSet(setID, to: "Lyric Panel")
+
+        let decoded = try roundTrip(fixture.graph, context: context)
+
+        let decodedSet = try #require(decoded.cloneSet(for: setID))
+        #expect(decodedSet.name == "Lyric Panel")
+        let members = decoded.cloneSetMembers(of: setID)
+        #expect(members.map(\.id) == [fixture.member.id, copy.id])
+        #expect(members[0].cloneRecord == fixture.member.cloneRecord)
+        #expect(members[1].cloneRecord == copy.cloneRecord)
+        #expect(!decodedSet.templateJSON.isEmpty)
+        let original = try #require(fixture.graph.cloneSet(for: setID))
+        #expect(NSDictionary(dictionary: decodedSet.templateObject) == NSDictionary(dictionary: original.templateObject))
+    }
+
+    @Test("Duplicate as Clone is one undoable step that also undoes set creation")
+    func duplicateAsCloneUndoes() throws
+    {
+        guard let context = makeContext() else { return }
+        let fixture = try makeMemberFixture(context: context)
+        let undoManager = UndoManager()
+        fixture.graph.undoManager = undoManager
+
+        let copy = try #require(fixture.graph.duplicateAsClone(fixture.member))
+        let setID = try #require(fixture.member.cloneSetID)
+
+        undoManager.undo()
+        #expect(fixture.graph.nodes.count == 1)
+        #expect(fixture.member.cloneSetID == nil)
+        #expect(fixture.member.cloneRecord.isEmpty)
+        #expect(fixture.graph.cloneSet(for: setID) == nil)
+
+        undoManager.redo()
+        #expect(fixture.graph.nodes.count == 2)
+        #expect(fixture.member.cloneSetID == setID)
+        #expect(fixture.graph.nodes.contains { $0 === copy })
+        #expect(copy.cloneSetID == setID)
+        #expect(fixture.graph.cloneSet(for: setID) != nil)
+    }
+
+    @Test("A plain duplicate of a member carries no clone links")
+    func plainDuplicateLeavesTheSet() throws
+    {
+        guard let context = makeContext() else { return }
+        let fixture = try makeMemberFixture(context: context)
+        _ = try #require(fixture.member.subGraph.duplicateAsClone(fixture.nested))
+        _ = try #require(fixture.graph.duplicateAsClone(fixture.member))
+
+        let plain = try #require(fixture.graph.duplicateNodes([fixture.member]).first as? SubgraphNode)
+
+        #expect(plain.cloneSetID == nil)
+        #expect(plain.cloneRecord.isEmpty)
+        #expect(plain.subGraph.subgraphNodesRecursive().allSatisfy { $0.cloneSetID == nil && $0.cloneRecord.isEmpty })
+    }
+
+    @Test("Members are found across nesting levels, in document order")
+    func membersAreDiscoveredAcrossNesting() throws
+    {
+        guard let context = makeContext() else { return }
+        let fixture = try makeMemberFixture(context: context)
+        let sibling = try #require(fixture.graph.duplicateAsClone(fixture.member))
+        let setID = try #require(fixture.member.cloneSetID)
+
+        let container = SubgraphNode(context: context)
+        fixture.graph.addNode(container)
+        let deepCopy = try #require(fixture.graph.duplicateAsClone(fixture.member))
+        fixture.graph.delete(node: deepCopy)
+        container.subGraph.addNode(deepCopy)
+
+        let members = fixture.graph.cloneSetMembers(of: setID)
+        #expect(members.map(\.id) == [fixture.member.id, sibling.id, deepCopy.id])
+        #expect(container.subGraph.cloneSetMembers(of: setID).map(\.id) == members.map(\.id))
+        #expect(fixture.graph.cloneSiblings(of: sibling).map(\.id) == [fixture.member.id, deepCopy.id])
+        #expect(fixture.graph.cloneSiblings(of: container).isEmpty)
+    }
+
+    @Test("Unlink leaves the set and gives nested sets their own copied templates, undoably")
+    func unlinkDetaches() throws
+    {
+        guard let context = makeContext() else { return }
+        let fixture = try makeMemberFixture(context: context)
+
+        let nestedCopy = try #require(fixture.member.subGraph.duplicateAsClone(fixture.nested))
+        let nestedSetID = try #require(fixture.nested.cloneSetID)
+        let sibling = try #require(fixture.graph.duplicateAsClone(fixture.member))
+        let setID = try #require(fixture.member.cloneSetID)
+        #expect(fixture.graph.cloneSetMembers(of: nestedSetID).count == 4)
+        #expect(fixture.graph.cloneSets.count == 2)
+
+        let undoManager = UndoManager()
+        fixture.graph.undoManager = undoManager
+        fixture.graph.unlinkClone(sibling)
+
+        #expect(sibling.cloneSetID == nil)
+        #expect(sibling.cloneRecord.isEmpty)
+        #expect(fixture.member.cloneSetID == setID)
+        #expect(fixture.graph.cloneSetMembers(of: setID).map(\.id) == [fixture.member.id])
+
+        // The unlinked member's nested members form their own set, on a copy of
+        // the nested template, so their records still resolve.
+        let detached = sibling.subGraph.nodes.compactMap { $0 as? SubgraphNode }
+        #expect(detached.count == 2)
+        let detachedSetID = try #require(detached.first?.cloneSetID)
+        #expect(detachedSetID != nestedSetID)
+        #expect(detached.allSatisfy { $0.cloneSetID == detachedSetID })
+        let detachedSet = try #require(fixture.graph.cloneSet(for: detachedSetID))
+        #expect(detachedSet.name == "Set C")
+        #expect(detachedSet.templateJSON == fixture.graph.cloneSet(for: nestedSetID)?.templateJSON)
+        #expect(fixture.graph.cloneSetMembers(of: nestedSetID).map(\.id) == [fixture.nested.id, nestedCopy.id])
+        for node in detached[0].subGraph.nodes
+        {
+            #expect(detached[0].templateID(forLocal: node.id) != nil)
+        }
+
+        undoManager.undo()
+        #expect(sibling.cloneSetID == setID)
+        #expect(!sibling.cloneRecord.isEmpty)
+        #expect(detached.allSatisfy { $0.cloneSetID == nestedSetID })
+        #expect(fixture.graph.cloneSet(for: detachedSetID) == nil)
+
+        undoManager.redo()
+        #expect(sibling.cloneSetID == nil)
+        #expect(detached.allSatisfy { $0.cloneSetID == detachedSetID })
+    }
+
+    @Test("A set with no members left is dropped on save")
+    func emptySetsArePrunedOnSave() throws
+    {
+        guard let context = makeContext() else { return }
+        let fixture = try makeMemberFixture(context: context)
+        let copy = try #require(fixture.graph.duplicateAsClone(fixture.member))
+        let setID = try #require(fixture.member.cloneSetID)
+
+        fixture.graph.unlinkClone(copy)
+        fixture.graph.unlinkClone(fixture.member)
+        #expect(fixture.graph.cloneSet(for: setID) != nil)
+
+        let decoded = try roundTrip(fixture.graph, context: context)
+        #expect(decoded.cloneSets.isEmpty)
+    }
+
+    // MARK: - Names
+
+    @Test("Sets are named in sequence and renamed on the set, undoably; an empty name restores a system name")
+    func namesAndRename() throws
+    {
+        guard let context = makeContext() else { return }
+        let fixture = try makeMemberFixture(context: context)
+        let sibling = try #require(fixture.graph.duplicateAsClone(fixture.member))
+        let setID = try #require(fixture.member.cloneSetID)
+        #expect(fixture.graph.cloneSet(for: setID)?.name == "Set A")
+
+        let other = SubgraphNode(context: context)
+        fixture.graph.addNode(other)
+        _ = try #require(fixture.graph.duplicateAsClone(other))
+        let otherSetID = try #require(other.cloneSetID)
+        #expect(fixture.graph.cloneSet(for: otherSetID)?.name == "Set B")
+
+        _ = try #require(fixture.member.subGraph.duplicateAsClone(fixture.nested))
+        #expect(fixture.graph.cloneSet(for: fixture.nested.cloneSetID!)?.name == "Set C")
+
+        let undoManager = UndoManager()
+        fixture.graph.undoManager = undoManager
+        fixture.graph.renameCloneSet(setID, to: "  Lyric Panel ")
+        #expect(fixture.graph.cloneSet(for: setID)?.name == "Lyric Panel")
+        #expect(sibling.subtitle == "Lyric Panel")
+
+        undoManager.undo()
+        #expect(sibling.subtitle == "Set A")
+        undoManager.redo()
+        #expect(sibling.subtitle == "Lyric Panel")
+
+        // Empty goes back to the lowest free system name; A is free again.
+        fixture.graph.renameCloneSet(setID, to: "   ")
+        #expect(sibling.subtitle == "Set A")
+    }
+
+    @Test("Members show the set name as their subtitle and the clone glyph as their title icon")
+    func subtitleAndTitleIcon() throws
+    {
+        guard let context = makeContext() else { return }
+        let fixture = try makeMemberFixture(context: context)
+        #expect(fixture.member.subtitle == nil)
+        #expect(fixture.member.titleIcon == nil)
+
+        let sibling = try #require(fixture.graph.duplicateAsClone(fixture.member))
+        let setID = try #require(fixture.member.cloneSetID)
+        #expect(fixture.member.subtitle == "Set A")
+        #expect(fixture.member.cloneSetInfo == CloneSetInfo(setID: setID, name: "Set A", memberCount: 2))
+        let icon = try #require(sibling.titleIcon)
+        #expect(icon.systemName == CloneSetInfo.symbolName)
+        #expect(icon.tint == .neutral)
+        #expect(icon.tooltip == "Clone set: Set A, 2 members. Edits here reach every member.")
+
+        fixture.graph.delete(node: sibling)
+        #expect(fixture.member.titleIcon?.tooltip == "Clone set: Set A, 1 member. Edits here reach every member.")
+    }
+
+    @Test("The view model mirrors the clone glyph as membership changes")
+    @MainActor
+    func viewModelMirrorsTitleIcon() async throws
+    {
+        guard let context = makeContext() else { return }
+        let fixture = try makeMemberFixture(context: context)
+        let viewModel = fixture.graph.viewModel(for: fixture.member)
+        #expect(viewModel.titleIcon == nil)
+
+        let sibling = try #require(fixture.graph.duplicateAsClone(fixture.member))
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(viewModel.titleIcon?.tooltip.contains("2 members") == true)
+        #expect(viewModel.subtitle == "Set A")
+
+        fixture.member.userName = "Left"
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(viewModel.subtitle == "Left")
+        #expect(viewModel.titleIcon?.tooltip.contains("Set A") == true)
+
+        fixture.graph.delete(node: sibling)
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(viewModel.titleIcon?.tooltip.contains("1 member.") == true)
+    }
+}

--- a/Tests/CloneSetTests.swift
+++ b/Tests/CloneSetTests.swift
@@ -359,18 +359,27 @@ struct CloneSetTests
         let viewModel = fixture.graph.viewModel(for: fixture.member)
         #expect(viewModel.titleIcon == nil)
 
+        // Mirrors arrive on the main queue; poll briefly rather than sleep a fixed time.
+        func settle(until condition: @escaping () -> Bool) async throws
+        {
+            for _ in 0..<50 where !condition()
+            {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+        }
+
         let sibling = try #require(fixture.graph.duplicateAsClone(fixture.member))
-        try await Task.sleep(for: .milliseconds(50))
+        try await settle { viewModel.titleIcon?.tooltip.contains("2 members") == true }
         #expect(viewModel.titleIcon?.tooltip.contains("2 members") == true)
         #expect(viewModel.subtitle == "Set A")
 
         fixture.member.userName = "Left"
-        try await Task.sleep(for: .milliseconds(50))
+        try await settle { viewModel.subtitle == "Left" }
         #expect(viewModel.subtitle == "Left")
         #expect(viewModel.titleIcon?.tooltip.contains("Set A") == true)
 
         fixture.graph.delete(node: sibling)
-        try await Task.sleep(for: .milliseconds(50))
+        try await settle { viewModel.titleIcon?.tooltip.contains("1 member.") == true }
         #expect(viewModel.titleIcon?.tooltip.contains("1 member.") == true)
     }
 }
@@ -924,7 +933,7 @@ extension CloneSetTests
         pair.source.addNode(NumberBinaryOperator(context: context))
         #expect(pair.target.nodes.count == 3)
 
-        try await Task.sleep(for: .milliseconds(200))
+        await pair.graph.cloneSetCoordinator.settle()
 
         #expect(pair.target.nodes.count == 4)
         #expect(pair.graph.cloneSetCoordinator.hasPendingSync == false)

--- a/Tests/CloneSetTests.swift
+++ b/Tests/CloneSetTests.swift
@@ -756,3 +756,196 @@ extension CloneSetTests
         #expect(pair.graph.cloneSet(for: setID)?.templateJSON == newTemplate)
     }
 }
+
+// MARK: - Editor triggers
+
+extension CloneSetTests
+{
+    @Test("Leaving a member's canvas syncs its siblings")
+    func leavingMemberSyncs() throws
+    {
+        guard let context = makeContext() else { return }
+        let pair = try makePair(context: context)
+        let canvas = GraphCanvasContext(rootGraph: pair.graph)
+
+        canvas.enter(pair.member.member)
+        canvas.currentGraph.addNode(NumberBinaryOperator(context: context))
+        #expect(pair.target.nodes.count == 3)
+
+        canvas.pop()
+
+        #expect(pair.target.nodes.count == 4)
+    }
+
+    @Test("Leaving a nested member syncs every enclosing set")
+    func leavingNestedMemberSyncsEnclosingSets() throws
+    {
+        guard let context = makeContext() else { return }
+        let pair = try makePair(context: context)
+        let canvas = GraphCanvasContext(rootGraph: pair.graph)
+
+        canvas.enter(pair.member.member)
+        canvas.enter(pair.member.nested)
+        canvas.currentGraph.addNode(NumberBinaryOperator(context: context))
+
+        canvas.popToRoot()
+
+        let nestedCopy = try #require(pair.counterpart(of: pair.member.nested))
+        #expect(nestedCopy.subGraph.nodes.count == 2)
+    }
+}
+
+// MARK: - Live sync
+
+extension CloneSetTests
+{
+    @Test("Edits inside a member bump its graph's content revision, through the member's own subscriptions")
+    @MainActor
+    func editsBumpContentRevision() throws
+    {
+        guard let context = makeContext() else { return }
+        let pair = try makePair(context: context)
+        var revision = pair.source.contentRevision
+
+        func expectBump(_ what: String, sourceLocation: SourceLocation = #_sourceLocation)
+        {
+            #expect(pair.source.contentRevision > revision, "\(what) should bump", sourceLocation: sourceLocation)
+            revision = pair.source.contentRevision
+        }
+
+        // Nodes present when the member joined the set are watched already.
+        pair.member.second.offset = CGSize(width: 10, height: 10)
+        expectBump("offset")
+        pair.member.second.userName = "Renamed"
+        expectBump("userName")
+        pair.member.second.outputNumber.published = true
+        expectBump("published")
+        pair.member.second.outputNumber.publishedName = "Out"
+        expectBump("publishedName")
+        pair.member.second.inputNumber2.value = 42
+        expectBump("unwired parameter value")
+        pair.member.nestedInner.inputNumber2.value = 7
+        expectBump("nested unwired parameter value")
+
+        let added = NumberBinaryOperator(context: context)
+        pair.source.addNode(added)
+        expectBump("addNode")
+        let connection = try #require(pair.source.connect(pair.member.second.outputNumber, to: added.inputNumber1))
+        expectBump("connect")
+        #expect(pair.source.setConnection(connection, active: false))
+        expectBump("setConnection")
+        #expect(pair.source.disconnect(connection))
+        expectBump("disconnect")
+        pair.source.addNote(Note(note: "n", rect: .zero))
+        expectBump("addNote")
+        pair.source.delete(node: added)
+        expectBump("delete")
+    }
+
+    @Test("A node added after a sync is watched from the next sync on")
+    @MainActor
+    func subscriptionsFollowAddedNodes() throws
+    {
+        guard let context = makeContext() else { return }
+        let pair = try makePair(context: context)
+        let coordinator = pair.graph.cloneSetCoordinator
+
+        let added = NumberBinaryOperator(context: context)
+        pair.source.addNode(added)
+        coordinator.flush()
+        #expect(coordinator.hasPendingSync == false)
+
+        added.inputNumber2.value = 3
+        #expect(coordinator.hasPendingSync)
+        coordinator.flush()
+        let addedCopy = try #require(pair.counterpart(of: added))
+        #expect(addedCopy.inputNumber2.value == 3)
+    }
+
+    @Test("Values arriving on published or wired inlets are not edits")
+    @MainActor
+    func drivenValuesDoNotBump() throws
+    {
+        guard let context = makeContext() else { return }
+        let pair = try makePair(context: context)
+        let revision = pair.source.contentRevision
+
+        pair.member.first.inputNumber1.value = 3       // published: per member
+        pair.member.second.inputNumber1.value = 4      // wired: driven
+
+        #expect(pair.source.contentRevision == revision)
+    }
+
+    @Test("An edit inside a member schedules a sync; flushing applies it and settles")
+    @MainActor
+    func editSchedulesSync() throws
+    {
+        guard let context = makeContext() else { return }
+        let pair = try makePair(context: context)
+        let coordinator = pair.graph.cloneSetCoordinator
+        #expect(coordinator.hasPendingSync == false)
+
+        pair.source.addNode(NumberBinaryOperator(context: context))
+        #expect(coordinator.hasPendingSync)
+
+        coordinator.flush()
+
+        #expect(pair.target.nodes.count == 4)
+        #expect(coordinator.hasPendingSync == false)
+    }
+
+    @Test("Edits outside any clone set schedule nothing, and an unlinked member stops watching")
+    @MainActor
+    func editsOutsideSetsScheduleNothing() throws
+    {
+        guard let context = makeContext() else { return }
+        let pair = try makePair(context: context)
+        let coordinator = pair.graph.cloneSetCoordinator
+
+        pair.graph.addNode(NumberBinaryOperator(context: context))
+        #expect(coordinator.hasPendingSync == false)
+
+        pair.graph.unlinkClone(pair.sibling)
+        let siblingSecond = try #require(pair.target.nodes.compactMap { $0 as? NumberBinaryOperator }.last)
+        let revision = pair.target.contentRevision
+        siblingSecond.inputNumber2.value = 11
+        #expect(pair.target.contentRevision == revision)
+        #expect(coordinator.hasPendingSync == false)
+    }
+
+    @Test("The debounce fires on its own")
+    @MainActor
+    func debounceFires() async throws
+    {
+        guard let context = makeContext() else { return }
+        let pair = try makePair(context: context)
+        pair.graph.cloneSetCoordinator.debounceInterval = .milliseconds(20)
+
+        pair.source.addNode(NumberBinaryOperator(context: context))
+        #expect(pair.target.nodes.count == 3)
+
+        try await Task.sleep(for: .milliseconds(200))
+
+        #expect(pair.target.nodes.count == 4)
+        #expect(pair.graph.cloneSetCoordinator.hasPendingSync == false)
+    }
+
+    @Test("Undoing an edit on the source syncs the siblings back")
+    @MainActor
+    func undoSyncsBack() throws
+    {
+        guard let context = makeContext() else { return }
+        let pair = try makePair(context: context)
+        let coordinator = pair.graph.cloneSetCoordinator
+
+        pair.source.addNode(NumberBinaryOperator(context: context))
+        coordinator.flush()
+        #expect(pair.target.nodes.count == 4)
+
+        pair.undoManager.undo()
+        coordinator.flush()
+
+        #expect(pair.source.nodes.count == 3)
+        #expect(pair.target.nodes.count == 3)
+    }
+}

--- a/Tests/CloneSetTests.swift
+++ b/Tests/CloneSetTests.swift
@@ -374,3 +374,385 @@ struct CloneSetTests
         #expect(viewModel.titleIcon?.tooltip.contains("1 member.") == true)
     }
 }
+
+// MARK: - Reconcile
+
+extension CloneSetTests
+{
+    /// A two-member set plus a fresh undo manager, so tests can both edit the
+    /// source and assert that syncing never registers undo steps of its own.
+    private struct PairFixture
+    {
+        let member: MemberFixture
+        let sibling: SubgraphNode
+        let undoManager: UndoManager
+
+        var graph: Graph { member.graph }
+        var source: Graph { member.member.subGraph }
+        var target: Graph { sibling.subGraph }
+
+        func sync() { graph.reconcileCloneSiblings(of: member.member) }
+
+        /// Syncs with a fresh undo manager on every graph, so any undo step
+        /// left behind can only have come from the sync itself.
+        func syncExpectingNoUndo(sourceLocation: SourceLocation = #_sourceLocation)
+        {
+            let fresh = UndoManager()
+            graph.undoManager = fresh
+            source.undoManager = fresh
+            target.undoManager = fresh
+            sync()
+            #expect(fresh.canUndo == false, sourceLocation: sourceLocation)
+        }
+
+        /// The sibling's node for one of the source member's, at any depth,
+        /// through the two records.
+        func counterpart<T: Node>(of node: T) -> T?
+        {
+            guard let templateID = member.member.templateID(forLocal: node.id),
+                  let localID = sibling.localID(forTemplate: templateID)
+            else { return nil }
+            return sibling.subGraph.nodesRecursive().first { $0.id == localID } as? T
+        }
+    }
+
+    private func makePair(context: Context) throws -> PairFixture
+    {
+        let member = try makeMemberFixture(context: context)
+        let sibling = try #require(member.graph.duplicateAsClone(member.member))
+        let undoManager = UndoManager()
+        member.graph.undoManager = undoManager
+        member.member.subGraph.undoManager = undoManager
+        sibling.subGraph.undoManager = undoManager
+        return PairFixture(member: member, sibling: sibling, undoManager: undoManager)
+    }
+
+    @Test("Adding and wiring a node in one member appears in the sibling, and both records grow")
+    func addedNodeAppearsInSibling() throws
+    {
+        guard let context = makeContext() else { return }
+        let pair = try makePair(context: context)
+
+        let added = NumberBinaryOperator(context: context)
+        added.offset = CGSize(width: 300, height: 40)
+        pair.source.addNode(added)
+        _ = try #require(pair.source.connect(pair.member.second.outputNumber, to: added.inputNumber2))
+        #expect(pair.member.member.templateID(forLocal: added.id) == nil)
+
+        pair.syncExpectingNoUndo()
+
+        let addedCopy = try #require(pair.counterpart(of: added))
+        let secondCopy = try #require(pair.counterpart(of: pair.member.second))
+        #expect(addedCopy.id != added.id)
+        #expect(addedCopy.offset == added.offset)
+        #expect(pair.target.nodes.count == 4)
+        #expect(pair.target.connections.count == 2)
+        #expect(pair.target.connections.contains {
+            $0.outletPort === secondCopy.outputNumber && $0.inletPort === addedCopy.inputNumber2
+        })
+        #expect(pair.member.member.templateID(forLocal: added.inputNumber2.id) != nil)
+        #expect(pair.sibling.localID(forTemplate: pair.member.member.templateID(forLocal: added.inputNumber2.id)!) == addedCopy.inputNumber2.id)
+    }
+
+    @Test("Deleting a node in one member removes it and its wires from the sibling")
+    func deletedNodeLeavesSibling() throws
+    {
+        guard let context = makeContext() else { return }
+        let pair = try makePair(context: context)
+
+        pair.source.delete(node: pair.member.second)
+        pair.sync()
+
+        #expect(pair.counterpart(of: pair.member.second) == nil)
+        #expect(pair.target.nodes.count == 2)
+        #expect(pair.target.connections.isEmpty)
+    }
+
+    @Test("Wires and their enabled state follow the source")
+    func connectionsFollow() throws
+    {
+        guard let context = makeContext() else { return }
+        let pair = try makePair(context: context)
+        let existing = try #require(pair.source.connections.first)
+
+        #expect(pair.source.disconnect(existing))
+        let rewired = try #require(pair.source.connect(pair.member.first.outputNumber, to: pair.member.second.inputNumber2))
+        #expect(pair.source.setConnection(rewired, active: false))
+
+        pair.sync()
+
+        let firstCopy = try #require(pair.counterpart(of: pair.member.first))
+        let secondCopy = try #require(pair.counterpart(of: pair.member.second))
+        #expect(pair.target.connections.count == 1)
+        let copiedConnection = try #require(pair.target.connections.first)
+        #expect(copiedConnection.outletPort === firstCopy.outputNumber)
+        #expect(copiedConnection.inletPort === secondCopy.inputNumber2)
+        #expect(copiedConnection.active == false)
+
+        #expect(pair.source.setConnection(rewired, active: true))
+        pair.sync()
+        #expect(pair.target.connections.first?.active == true)
+    }
+
+    @Test("Publishing in the source adds a proxy on the sibling's node; unpublishing removes it")
+    func publishedPortsFollow() throws
+    {
+        guard let context = makeContext() else { return }
+        let pair = try makePair(context: context)
+        let secondCopy = try #require(pair.counterpart(of: pair.member.second))
+        let firstCopy = try #require(pair.counterpart(of: pair.member.first))
+
+        pair.member.second.outputNumber.published = true
+        pair.member.second.outputNumber.publishedName = "Result"
+        pair.member.first.inputNumber1.published = false
+        pair.source.rebuildPublishedParameterGroup()
+
+        pair.sync()
+
+        #expect(secondCopy.outputNumber.published)
+        #expect(secondCopy.outputNumber.publishedName == "Result")
+        #expect(firstCopy.inputNumber1.published == false)
+        #expect(pair.sibling.ports.contains { $0.id == secondCopy.outputNumber.id && $0 is any ProxyPortProtocol })
+        #expect(pair.sibling.ports.contains { $0.id == firstCopy.inputNumber1.id } == false)
+    }
+
+    @Test("Published inlet values stay per member; unpublished values follow the source")
+    func valuesSplitAtThePublishBoundary() throws
+    {
+        guard let context = makeContext() else { return }
+        let pair = try makePair(context: context)
+        let firstCopy = try #require(pair.counterpart(of: pair.member.first))
+        let secondCopy = try #require(pair.counterpart(of: pair.member.second))
+
+        pair.member.first.inputNumber1.value = 1
+        firstCopy.inputNumber1.value = 5
+        pair.member.second.inputNumber2.value = 7
+        secondCopy.inputNumber2.value = 8
+        pair.member.first.inputNumber2.value = 9
+        firstCopy.inputNumber2.value = 9
+
+        pair.sync()
+
+        #expect(firstCopy.inputNumber1.value == 5)
+        #expect(secondCopy.inputNumber2.value == 7)
+        #expect(firstCopy.inputNumber2.value == 9)
+        #expect(secondCopy.inputNumber1.connections.count == 1)
+    }
+
+    @Test("Layout, renames and notes follow the source")
+    func layoutAndRenameFollow() throws
+    {
+        guard let context = makeContext() else { return }
+        let pair = try makePair(context: context)
+        let firstCopy = try #require(pair.counterpart(of: pair.member.first))
+
+        pair.member.first.offset = CGSize(width: -120, height: 64)
+        pair.member.first.userName = "Gain"
+        let note = Note(note: "Feed this from the clock", rect: CGRect(x: 1, y: 2, width: 300, height: 100))
+        pair.source.addNote(note)
+
+        pair.sync()
+
+        #expect(firstCopy.offset == pair.member.first.offset)
+        #expect(firstCopy.userName == "Gain")
+        #expect(pair.target.notes.count == 1)
+        #expect(pair.target.notes.first?.note == note.note)
+        #expect(pair.target.notes.first?.rect == note.rect)
+    }
+
+    @Test("A settings change that rebuilds ports replaces the sibling's node, keeping its ids, and rewires it")
+    func settingsChangeReplacesNode() throws
+    {
+        guard let context = makeContext() else { return }
+        let pair = try makePair(context: context)
+
+        let sampler = SampleAndHoldNode(context: context)
+        sampler.strategy = PortType.Float.rawValue
+        pair.source.addNode(sampler)
+        let inlet = try #require(sampler.findPort(named: "inputValue", as: Port.self))
+        _ = try #require(pair.source.connect(pair.member.second.outputNumber, to: inlet))
+        pair.sync()
+
+        let samplerCopy = try #require(pair.counterpart(of: sampler))
+        #expect(samplerCopy.strategy == PortType.Float.rawValue)
+        #expect(pair.target.connections.count == 2)
+        let copyID = samplerCopy.id
+
+        sampler.strategy = PortType.Virtual.rawValue
+        #expect(pair.source.connections.count == 1)
+        let rebuiltInlet = try #require(sampler.findPort(named: "inputValue", as: Port.self))
+        _ = try #require(pair.source.connect(pair.member.second.outputNumber, to: rebuiltInlet))
+        pair.syncExpectingNoUndo()
+
+        let replaced = try #require(pair.counterpart(of: sampler))
+        #expect(replaced !== samplerCopy)
+        #expect(replaced.id == copyID)
+        #expect(replaced.strategy == PortType.Virtual.rawValue)
+        #expect(pair.target.nodes.contains { $0 === samplerCopy } == false)
+        #expect(pair.target.connections.count == 2)
+        let replacedInlet = try #require(replaced.findPort(named: "inputValue", as: Port.self))
+        let secondCopy = try #require(pair.counterpart(of: pair.member.second))
+        #expect(pair.target.connections.contains {
+            $0.outletPort === secondCopy.outputNumber && $0.inletPort === replacedInlet
+        })
+    }
+
+    @Test("Edits inside a nested subgraph reach the sibling's nested subgraph")
+    func nestedEditsFollow() throws
+    {
+        guard let context = makeContext() else { return }
+        let pair = try makePair(context: context)
+
+        let deepAdded = NumberBinaryOperator(context: context)
+        pair.member.nested.subGraph.addNode(deepAdded)
+        _ = try #require(pair.member.nested.subGraph.connect(pair.member.nestedInner.outputNumber, to: deepAdded.inputNumber1))
+        deepAdded.outputNumber.published = true
+        pair.member.nested.subGraph.rebuildPublishedParameterGroup()
+        let nestedProxy = try #require(pair.member.nested.ports.first { $0.id == deepAdded.outputNumber.id })
+        _ = try #require(pair.source.connect(nestedProxy, to: pair.member.second.inputNumber2))
+
+        pair.sync()
+
+        let nestedCopy = try #require(pair.counterpart(of: pair.member.nested))
+        let deepCopy = try #require(pair.counterpart(of: deepAdded))
+        let nestedInnerCopy = try #require(pair.counterpart(of: pair.member.nestedInner))
+        #expect(deepCopy.graph === nestedCopy.subGraph)
+        #expect(nestedCopy.subGraph.nodes.count == 2)
+        #expect(nestedCopy.subGraph.connections.contains {
+            $0.outletPort === nestedInnerCopy.outputNumber && $0.inletPort === deepCopy.inputNumber1
+        })
+        let nestedProxyCopy = try #require(nestedCopy.ports.first { $0.id == deepCopy.outputNumber.id })
+        let secondCopy = try #require(pair.counterpart(of: pair.member.second))
+        #expect(pair.target.connections.contains {
+            $0.outletPort === nestedProxyCopy && $0.inletPort === secondCopy.inputNumber2
+        })
+    }
+
+    @Test("A sync refreshes the template, and a second sync with no edits changes nothing")
+    func syncRefreshesTemplateAndIsIdempotent() throws
+    {
+        guard let context = makeContext() else { return }
+        let pair = try makePair(context: context)
+        let set = try #require(pair.graph.cloneSet(for: pair.member.member.cloneSetID!))
+        let before = set.templateJSON
+
+        pair.source.addNode(NumberBinaryOperator(context: context))
+        pair.sync()
+        #expect(set.templateJSON != before)
+
+        let report = pair.graph.reconcileCloneMember(pair.sibling, from: pair.member.member)
+        #expect(report.isEmpty)
+    }
+
+    @Test("An unlinked member no longer follows")
+    func unlinkedStopsFollowing() throws
+    {
+        guard let context = makeContext() else { return }
+        let pair = try makePair(context: context)
+        pair.graph.unlinkClone(pair.sibling)
+
+        pair.source.addNode(NumberBinaryOperator(context: context))
+        pair.sync()
+
+        #expect(pair.target.nodes.count == 3)
+    }
+
+    @Test("Sync is refused between a member and a member nested inside it")
+    func syncSkipsNestedSelf() throws
+    {
+        guard let context = makeContext() else { return }
+        let pair = try makePair(context: context)
+        pair.graph.delete(node: pair.sibling)
+        pair.source.addNode(pair.sibling)
+
+        pair.source.addNode(NumberBinaryOperator(context: context))
+        pair.sync()
+
+        #expect(pair.target.nodes.count == 3)
+    }
+
+    // MARK: Template as source
+
+    @Test("A member can be made from the template alone, with the set's member class and a full record")
+    func instantiateFromTemplate() throws
+    {
+        guard let context = makeContext() else { return }
+        let graph = Graph(context: context)
+        let iterator = IteratorNode(context: context)
+        graph.addNode(iterator)
+        let inner = NumberBinaryOperator(context: context)
+        iterator.subGraph.addNode(inner)
+        inner.outputNumber.published = true
+        iterator.subGraph.rebuildPublishedParameterGroup()
+        _ = try #require(graph.duplicateAsClone(iterator))
+        let setID = try #require(iterator.cloneSetID)
+
+        let made = try #require(graph.instantiateCloneSetMember(of: setID))
+
+        #expect(made is IteratorNode)
+        #expect(made.graph === graph)
+        #expect(made.cloneSetID == setID)
+        #expect(graph.cloneSetMembers(of: setID).count == 3)
+        let madeInner = try #require(made.subGraph.nodes.first as? NumberBinaryOperator)
+        #expect(madeInner.id != inner.id)
+        #expect(madeInner.outputNumber.published)
+        #expect(made.ports.contains { $0.id == madeInner.outputNumber.id && $0 is any ProxyPortProtocol })
+        let templateID = try #require(iterator.templateID(forLocal: inner.id))
+        #expect(made.localID(forTemplate: templateID) == madeInner.id)
+
+        // It follows edits like any member.
+        iterator.subGraph.addNode(NumberBinaryOperator(context: context))
+        graph.reconcileCloneSiblings(of: iterator)
+        #expect(made.subGraph.nodes.count == 2)
+    }
+
+    @Test("A member with no record is rebuilt from the template, keeping its parent wires by published name")
+    func memberWithoutRecordIsRecovered() throws
+    {
+        guard let context = makeContext() else { return }
+        let pair = try makePair(context: context)
+
+        // Wire the sibling's published inlet from the parent graph.
+        let upstream = NumberBinaryOperator(context: context)
+        pair.graph.addNode(upstream)
+        let proxy = try #require(pair.sibling.ports.first { $0.kind == .Inlet && $0.displayName == "Amount" })
+        _ = try #require(pair.graph.connect(upstream.outputNumber, to: proxy))
+
+        // Lose the record, as a document from before records would.
+        pair.sibling.cloneRecord = [:]
+        pair.source.addNode(NumberBinaryOperator(context: context))
+        pair.sync()
+
+        let rebuilt = try #require(pair.graph.cloneSetMembers(of: pair.member.member.cloneSetID!).first { $0 !== pair.member.member })
+        #expect(rebuilt.subGraph.nodes.count == 4)
+        #expect(!rebuilt.cloneRecord.isEmpty)
+        let rebuiltProxy = try #require(rebuilt.ports.first { $0.kind == .Inlet && $0.displayName == "Amount" })
+        #expect(pair.graph.connections.contains { $0.outletPort === upstream.outputNumber && $0.inletPort === rebuiltProxy })
+        #expect(pair.graph.nodes.contains { $0 === pair.sibling } == false)
+    }
+
+    @Test("A template updated from outside reconciles every member")
+    func externalTemplateUpdateReconcilesMembers() throws
+    {
+        guard let context = makeContext() else { return }
+        let pair = try makePair(context: context)
+        let setID = try #require(pair.member.member.cloneSetID)
+
+        // Produce a newer template from a third, independent member, then feed
+        // its JSON back in as if it had arrived from a sidecar file.
+        let scratch = Graph(context: context)
+        let editor = try #require(pair.graph.instantiateCloneSetMember(of: setID))
+        pair.graph.delete(node: editor)
+        scratch.addNode(editor)
+        editor.subGraph.addNode(NumberBinaryOperator(context: context))
+        let newTemplate = try #require(pair.graph.cloneTemplateJSON(from: editor))
+
+        let reports = pair.graph.applyCloneTemplate(newTemplate, to: setID)
+
+        #expect(reports.count == 2)
+        #expect(reports.allSatisfy { $0.nodesAdded == 1 })
+        #expect(pair.source.nodes.count == 4)
+        #expect(pair.target.nodes.count == 4)
+        #expect(pair.graph.cloneSet(for: setID)?.templateJSON == newTemplate)
+    }
+}

--- a/Tests/MathExpressionNodeTests.swift
+++ b/Tests/MathExpressionNodeTests.swift
@@ -77,16 +77,24 @@ import MathExpressionEngine
     }
 
     /// A transiently invalid edit keeps the last good ports (and their wires)
-    /// rather than tearing them down, and surfaces an error diagnostic.
+    /// rather than tearing them down, and surfaces an error diagnostic: in the
+    /// settings model, and as the node's title icon with the message as tooltip.
     @Test func invalidEditKeepsPortsAndReportsError() throws
     {
         guard let context = makeContext() else { return }
         let node = MathExpressionNode(context: context)
+        #expect(node.titleIcon == nil)
 
         node.stringExpression = "sin("
         #expect(names(node.inputPorts()) == ["x", "y"]) // unchanged
-        #expect(node._settingsModel.diagnostics.contains { $0.severity == .error })
-        #expect(node.subtitle?.hasPrefix("⚠") == true)
+        let diagnostic = try #require(node._settingsModel.diagnostics.first { $0.severity == .error })
+        let icon = try #require(node.titleIcon)
+        #expect(icon.tint == .error)
+        #expect(icon.tooltip.contains(diagnostic.message))
+        #expect(node.subtitle?.contains("⚠") == false)
+
+        node.stringExpression = "sin(x)"
+        #expect(node.titleIcon == nil)
     }
 
     /// Torture-tests for the node-title heuristic, drawn from the language spec:
@@ -167,15 +175,17 @@ import MathExpressionEngine
         #expect(title("in x: float").isEmpty)
     }
 
-    /// An erroring expression whose salient title is empty must not leave the
-    /// node titled a bare "⚠" — the warning is joined to the type name instead.
+    /// An erroring expression whose salient title is empty leaves the node
+    /// titled by its type name alone; the error shows as the title icon.
     @Test func errorWithEmptySalientTitleFallsBackToTypeName() throws
     {
         guard let context = makeContext() else { return }
         let node = MathExpressionNode(context: context)
 
         node.stringExpression = "in x: floot"
-        #expect(node.subtitle == "⚠ \(MathExpressionNode.name)")
+        #expect(node.subtitle == nil)
+        #expect(node.title == MathExpressionNode.name)
+        #expect(node.titleIcon?.tint == .error)
     }
 
     @Test func retypeReplacesPortWithNewType() throws

--- a/Tests/MathExpressionParametricGeometryNodeTests.swift
+++ b/Tests/MathExpressionParametricGeometryNodeTests.swift
@@ -102,4 +102,23 @@ import Satin
         node.expressionX = "out a = u; out b = v"
         #expect(!node._settingsModel.statusX)
     }
+
+    /// An axis that fails to compile is flagged by the title icon, naming the
+    /// axis, and the subtitle stays the plain expressions.
+    @Test func failingAxisShowsTitleIcon() throws
+    {
+        guard let context = makeContext() else { return }
+        let node = MathExpressionParametricGeometryNode(context: context)
+        #expect(node.titleIcon == nil)
+
+        node.expressionY = "sin("
+        let icon = try #require(node.titleIcon)
+        #expect(icon.tint == .error)
+        #expect(icon.tooltip.contains("Y"))
+        #expect(icon.tooltip.contains("X") == false)
+        #expect(node.subtitle?.contains("⚠") == false)
+
+        node.expressionY = "sin(v)"
+        #expect(node.titleIcon == nil)
+    }
 }

--- a/Tests/NodeNamingTests.swift
+++ b/Tests/NodeNamingTests.swift
@@ -14,6 +14,7 @@ private final class NamingTestNode: Node
 
     private var nodeDerivedSubtitle: String?
     private var nodeDerivedTitle: String?
+    private var nodeDerivedTitleIcon: NodeTitleIcon?
 
     override func deriveTitle() -> String
     {
@@ -34,6 +35,17 @@ private final class NamingTestNode: Node
     func setDerivedTitle(_ title: String?)
     {
         nodeDerivedTitle = title
+        subtitleSubject.send()
+    }
+
+    override func deriveTitleIcon() -> NodeTitleIcon?
+    {
+        nodeDerivedTitleIcon
+    }
+
+    func setDerivedTitleIcon(_ icon: NodeTitleIcon?)
+    {
+        nodeDerivedTitleIcon = icon
         subtitleSubject.send()
     }
 }
@@ -231,5 +243,46 @@ private final class NamingTestNode: Node
         }
 
         #expect(nodeViewModel.title == "Updated Instance Title")
+    }
+
+    @Test("Title icon is nil unless the node derives one")
+    func titleIconDefaultsToNil() throws
+    {
+        guard let context = makeContext() else { return }
+        let node = NamingTestNode(context: context)
+        #expect(node.titleIcon == nil)
+
+        let icon = NodeTitleIcon(systemName: "exclamationmark.triangle.fill", tooltip: "Needs attention", tint: .warning)
+        node.setDerivedTitleIcon(icon)
+        #expect(node.titleIcon == icon)
+
+        node.setDerivedTitleIcon(nil)
+        #expect(node.titleIcon == nil)
+    }
+
+    @Test("NodeViewModel mirrors title icon changes")
+    func viewModelMirrorsTitleIcon() async throws
+    {
+        guard let context = makeContext() else { return }
+        let node = NamingTestNode(context: context)
+        let initial = NodeTitleIcon(systemName: "square.on.square", tooltip: "Initial")
+        node.setDerivedTitleIcon(initial)
+        let nodeViewModel = NodeViewModel(node: node)
+        #expect(nodeViewModel.titleIcon == initial)
+
+        let updated = NodeTitleIcon(systemName: "xmark.octagon.fill", tooltip: "Broken", tint: .error)
+        node.setDerivedTitleIcon(updated)
+        for _ in 0..<50 where nodeViewModel.titleIcon != updated
+        {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(nodeViewModel.titleIcon == updated)
+
+        node.setDerivedTitleIcon(nil)
+        for _ in 0..<50 where nodeViewModel.titleIcon != nil
+        {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(nodeViewModel.titleIcon == nil)
     }
 }


### PR DESCRIPTION
An implementation for #199. The premise is that you can duplicate any subgraph type node as a clone, and then any edit within one of that _clone set_ changes them all. Key here is that this is _Fabric_ level functionality, not the introduction of a specialised node. For example, third-party [_SPK Stage Object_](https://tobyz.net/diary/2026/03/spark-stage-scenes/) nodes can be cloned.

This is the current new document spinning cube embedded in a _Sub Graph_ node. Now subgraph type nodes have _Duplicate as clone_ in their context menu –

<img width="800" height="801" alt="Screenshot 2026-09-10 at 09 15 45" src="https://github.com/user-attachments/assets/dda9c92d-43a1-4e62-ba26-50736afe09d3" />

Now cloned, there are two spinning cubes. Note their execution is per-instance, and cloning operations maintain state on a running subgraph, so here we see the two cubes spinning out of sync with each other as the _Number Integrator_ has been running for a different amount of time in each. If this document were saved and opened afresh, those two integrator nodes would start integrating at the same time, and the cubes would be in sync. 

To control a cloned subgraph individually, publish ports. Here, we got the _Spin_ toggle and _Speed_ value from the new document graph for free, and e.g. toggling spin off on one will do what Fabric has taught you to expect: that node’s cube will stop spinning while the other node’s cube continues.

<img width="800" height="801" alt="Screenshot 2026-09-10 at 09 16 52" src="https://github.com/user-attachments/assets/3361f3f2-83fa-4b6c-86ab-0cae4b9010a6" />

This implementation likely can be improved but I think is the right direction. A simpler, more brutal approach of replacing each other members’ subgraph with the updated one fails to be simple in practice, requiring new subgraphs to be minted from the latest so that only shape not execution is cloned, and then any published ports to be remapped. Accepting some kind of change propagation machinery amongst subgraphs of any clone set, you arrive at either a peer-to-peer approach or a template-backed one. This implementation takes the template-backed approach, in practice serialising the desired subgraph shape to JSON. This has the advantage of being amenable to being backed by sidecar files or some kind of repository. This has the disadvantage documents saved with this will not degrade to uncloned duplicates if opened by earlier Fabric Editor, as the peer-to-peer model does. I don’t think that matters, and only having one copy of a cloned subgraph in a document is a filesize win. The clincher for me was it also allows this subgraph-scoped functionality to be contained to the Subgraph base type; the peer-to-peer implementation required clone tracking on the Node base type.

From the genie –

> A clone set is a group of Subgraph nodes kept identical in design while each executes on its own. Edit any member and the others follow. This is the template-backed implementation discussed on the issue: the canonical form of a set lives in the document as data, members carry a record relating them to it, and nothing clone-specific touches Node or Port.
> 
> UX
> 
> - Duplicate as Clone on any Subgraph node (Iterator, Deferred and Environment included) creates a sibling. The first clone starts a set named Set A, Set B, … Sets are renamed from the node menu; clearing the name restores a system one.
> - Members are peers. Enter any member and edit as normal: add, delete, wire, publish, rename, move, tweak a value, change a setting. Siblings update live, coalesced once edits pause for about a tenth of a second. Leaving a canvas and saving also sync.
> - Publishing is the specialisation boundary. Everything a node encodes replicates across the set, layout included. The one exception is the value of a published inlet, which the parent graph sets on each member through its proxy. To make a value differ per clone, publish it.
> - Runtime state is per member. Movie positions, feedback buffers, LFO phase and the like are never touched by a sync. A settings change that rebuilds a node's ports replaces that node in the siblings; everything else is updated in place.
> - Members are marked. A member wears the copies glyph at the trailing edge of its title, on the canvas and in the breadcrumb, shows the set name as its subtitle, and reads "Clone set: Set A, 3 members. Edits here reach every member." on hover.
> - Unlink from Clones turns a member back into an ordinary subgraph with its current contents. Sets nested inside it become sets of their own, so they detach from the former siblings but stay linked among themselves. Select Sibling Clones selects the set's other members on the current canvas.
> - Undo is per edit, on the member where it happened. A sync never appears as an undo step; undoing the edit syncs the siblings back.
> - A plain Duplicate of a member is an ordinary subgraph, not a clone. A set that would contain itself is refused.
> 
> Implementation
> 
> Model. CloneSet is an object on the document's root graph: id, name, the member node class, and the template as canonical JSON, the encoded form of a member's sub graph with every id rewritten to the template's own ids. It is saved with the document and dropped when no member refers to it. SubgraphNode carries cloneSetID and cloneRecord, a dictionary from template ids to the member's local ids for nodes, ports, wires and nested graphs. Node gains nothing.
> 
> Why the record is robust. Duplication rewrites every UUID in a node's JSON. The record's keys are template ids, which a rewrite never touches, and its values are local ids, which a rewrite maps along with the nodes. So Duplicate as Clone yields a correct record from the duplication itself, and a plain Duplicate strips the links. The record also means local ids stay unique per member, so the parent graph's wiring and any host lookup by port id are unaffected.
> 
> Sync. The edited member refreshes the template, then each sibling is reconciled from it through the two records: source local → template → sibling local. Surplus nodes go, missing ones are decoded from the source with ids mapped through the records, and matched nodes take layout, rename, published state and the values of inlets that are neither published nor wired. A node whose class or settings signature differs is replaced under the ids the sibling already recorded, so proxies keep their ids across the replacement. Wires are diffed by the sibling's own port ids; nested sub graphs reconcile first so the proxies the parent's wires land on exist. Nothing registers undo. The settings signature is the node's encoded form minus ideand clone links, with UUIDs normalised.
> 
> Template as source. One primitive makes a member from the template alone, in the set's member class, with every id fresh and recorded. It serves new members, recovery of a member with no record, which is rebuilt in place with the parent's wires re-bound to its published    ports by name, and a template updated from outside the a transient member. This is the path a sidecar or shared template would take.
> 
> Change detection. Graph gains a content revision, bumped by its own mutation API. While a node is a member it owns a CloneMemberObserverthat watches its node tree through the signals nodes, py publish: the offset and ports-changed subjects, thesubtitle subject read for the rename alone, observation tracking on a port's publish state, and each parameter's value publisher, counted only for an unwired, unpublished inlet. Every sink drops anything not on the main thread, since some subjects fire per frame from the render thread. A CloneSetCoordinator on the root graph debounces syncs and is main-thread state; calls from elsewhere are handed to the main actor.
> 
> Editor. Node menu items, a rename alert, breadcrumb entries showing a node's title icon, sync on leaving a canvas and a flush before    save. The glyph itself comes through Node.deriveTitleIcR.
> 
> One fix on the way. JSON parsed with JSONSerialization carries NSNumbers that the AnyCodable bridge re-encodes zeros as booleans, which would have corrupted saved templates. Clone paths parsead. A SuperShape parameter whose default sat below itsslider minimum, found by the fidelity test, is fixed as well.                                                                           
> Tests
> 
> 36 tests in CloneSetTests: records through duplication, save and unlink; every kind of edit reaching a sibling, including nested graphs and proxies; per-member published values; node replacemtion from the template, recovery and external templateapplication; live sync scheduling, debounce and undo; the badge and its view model mirror; and a fidelity pass that clones every core node type and expects a reconcile to change nothing.
> 
> Not in this PR
> 
> Named sets in the node library, per-node clone immunity, and sidecar or shared templates. The model is shaped for all three. 